### PR TITLE
PR for #54: Add additional tests and mdx examples

### DIFF
--- a/packages/experimental/src/components/EmptyState/EmptyState-test.js
+++ b/packages/experimental/src/components/EmptyState/EmptyState-test.js
@@ -9,6 +9,7 @@ import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { EmptyState } from '.';
+import CustomIllustration from './EmptyStateIllustrations/light/error.svg';
 
 const { name } = EmptyState;
 
@@ -30,5 +31,74 @@ describe(name, () => {
 
     click(getByText('Create new'));
     expect(onActionHandler).toBeCalled();
+  });
+
+  test('should render a clickable link and match rendered url to linkUrl prop', () => {
+    const { getByText, container } = render(
+      <EmptyState
+        heading="Empty state heading"
+        subtext="Empty state subtext"
+        linkText="View documentation"
+        linkUrl="https://www.carbondesignsystem.com/"
+      />
+    );
+    const { click } = fireEvent;
+    const link = container.querySelector('a').href;
+    click(getByText('View documentation'));
+    expect(link.length && link).toEqual('https://www.carbondesignsystem.com/');
+  });
+
+  test('should render heading by passing string', () => {
+    const { getByText } = render(
+      <EmptyState heading="Empty state heading" subtext="Empty state subtext" />
+    );
+    expect(getByText('Empty state heading')).toBeTruthy();
+  });
+
+  test('should render heading by passing node', () => {
+    const { getByText } = render(
+      <EmptyState
+        heading={<h3>Custom heading</h3>}
+        subtext="Empty state subtext"
+      />
+    );
+    expect(getByText('Custom heading')).toBeTruthy();
+  });
+
+  test('should render subtext by passing string', () => {
+    const { getByText } = render(
+      <EmptyState heading="Empty state header" subtext="Empty state subtext" />
+    );
+    expect(getByText('Empty state subtext')).toBeTruthy();
+  });
+
+  test('should render subtext by passing node', () => {
+    const { getByText } = render(
+      <EmptyState
+        heading="Empty state header"
+        subtext={<p>This is the subtext of the empty state</p>}
+      />
+    );
+    expect(getByText('This is the subtext of the empty state')).toBeTruthy();
+  });
+
+  test('should render empty state with illustration', () => {
+    const { container } = render(<EmptyState illustration="nodata" />);
+    const renderedSvg = container.querySelector('img');
+    expect(renderedSvg).toBeTruthy();
+  });
+
+  test('should render svg as default illustration', () => {
+    const { container } = render(<EmptyState illustration="nodata" />);
+    const renderedSvgSrc = container.querySelector('img').src;
+    expect(renderedSvgSrc.substr(renderedSvgSrc.length - 4)).toEqual('.svg');
+  });
+
+  test('should render a custom illustration', () => {
+    const { container } = render(
+      <EmptyState illustration={CustomIllustration} />
+    );
+    const customIllustrationElement = container.querySelector('img');
+    expect(customIllustrationElement).toBeTruthy();
   });
 });

--- a/packages/experimental/src/components/EmptyState/EmptyState.js
+++ b/packages/experimental/src/components/EmptyState/EmptyState.js
@@ -49,7 +49,11 @@ export const EmptyState = ({
           ].join(' ')}
         />
       )}
-      <h3 className={`${expPrefix}-header`}>{heading}</h3>
+      {typeof heading !== 'string' ? (
+        heading
+      ) : (
+        <h3 className={`${expPrefix}-header`}>{heading}</h3>
+      )}
       {typeof subtext !== 'string' ? (
         subtext
       ) : (

--- a/packages/experimental/src/components/EmptyState/EmptyState.mdx
+++ b/packages/experimental/src/components/EmptyState/EmptyState.mdx
@@ -14,8 +14,52 @@ The `EmptyState` component follows the Carbon guidelines for empty states with
 some added specifications around illustration usage. For additional usage
 guidelines and documentation please refer to the links above.
 
+### Default Empty state
+
+<Preview>
+  <Story id="experimental-emptystate--default" />
+</Preview>
+
+### Empty state with illustration
+
 <Preview>
   <Story id="experimental-emptystate--with-illustration" />
+</Preview>
+
+### Empty state with dark themed illustration
+
+<Preview>
+  <Story id="experimental-emptystate--with-dark-mode-illustration" />
+</Preview>
+
+### Empty state with custom illustration
+
+<Preview>
+  <Story id="experimental-emptystate--with-custom-illustration" />
+</Preview>
+
+### Empty state with action
+
+<Preview>
+  <Story id="experimental-emptystate--with-action" />
+</Preview>
+
+### Empty state with action (Button with icon)
+
+<Preview>
+  <Story id="experimental-emptystate--with-action-icon-button" />
+</Preview>
+
+### Empty state with link
+
+<Preview>
+  <Story id="experimental-emptystate--with-link" />
+</Preview>
+
+### Empty state with action and link
+
+<Preview>
+  <Story id="experimental-emptystate--with-action-and-link" />
 </Preview>
 
 ## Component API


### PR DESCRIPTION
Contributes to #54 

This is a follow up PR to #159 and adds more test coverage as @davidmenendez had suggested. As well as adding the other component variations to the `.mdx` file as suggested by @lee-chase.

#### Changelog

**Changed**

`/packages/experimental/src/components/EmptyState/EmptyState.mdx`
`/packages/experimental/src/components/EmptyState/EmptyState-test.js`
`/packages/experimental/src/components/EmptyState/EmptyState.js`

#### Testing / Reviewing

Run `yarn test` to see tests.
And visit storybook doc page for `<EmptyState />` component to see the different previews/variations of this component.
