### PR TITLE
chore: allow scss comments

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   extends: ['stylelint-config-carbon'],
   plugins: ['stylelint-plugin-carbon-tokens'],
   rules: {
+    'scss/double-slash-comment-inline': null,
     // ADDED TO TEST CARBON USE
     'carbon/layout-token-use': [true, { severity: 'error' }],
     'carbon/motion-token-use': [true, { severity: 'error' }],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@carbon/bundler": "^10.9.0",
-    "@carbon/rollup-config": "^0.0.1",
+    "@carbon/rollup-config": "^0.1.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@testing-library/react": "^11.0.4",


### PR DESCRIPTION
Allow SCSS comments so that we can generate SCSS that does not publish comments


Currently this
```scss
// stylelint-disable xxx
content: ''; /* disabled stylelint because */
```
generates
```css
content: ''; /* disabled stylelint because */
```
Where as the following does not
```scss
// stylelint-disable xxx
content: ''; // disabled stylelint because
```