### PR TITLE
chore: skip CI after publish step pushes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "command": {
     "version": {
       "conventionalCommits": true,
-      "message": "chore(release): publish"
+      "message": "chore(release): publish [skip ci]"
     }
   },
   "useWorkspaces": true,


### PR DESCRIPTION
#### Changelog

**Changed**

Skip CI when the release step commits and pushes to the default branch