### PR TITLE
build(rollup-config): move reference to dependents

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@carbon/bundler": "^10.9.0",
-    "@carbon/rollup-config": "^0.1.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@testing-library/react": "^11.0.4",

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -37,5 +37,8 @@
   "dependencies": {
     "@carbon/ibm-cloud-cognitive-experimental": "^0.2.0",
     "@carbon/ibm-cloud-cognitive-security": "^0.1.0"
+  },
+  "devDependencies": {
+    "@carbon/rollup-config": "^0.1.0"
   }
 }

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -39,5 +39,8 @@
     "carbon-components-react": "^7.23.0",
     "carbon-icons": "^7.0.7",
     "react-resize-detector": "^5.2.0"
+  },
+  "devDependencies": {
+    "@carbon/rollup-config": "^0.1.0"
   }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -32,5 +32,8 @@
   },
   "dependencies": {
     "@carbon/ibm-security": "^1.26.0"
+  },
+  "devDependencies": {
+    "@carbon/rollup-config": "^0.1.0"
   }
 }


### PR DESCRIPTION
#### Changelog

**Changed**

Move `@carbon/rollup-plugin` private dependency to dependent packages, similarly to https://github.com/carbon-design-system/carbon/search?l=JSON&q=test-utils