### PR TITLE
fix: add Tearsheet and PageHeader to index.js

### DIFF
--- a/packages/experimental/src/components/AboutModal/index.js
+++ b/packages/experimental/src/components/AboutModal/index.js
@@ -5,6 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-export { PageHeader } from './PageHeader';
-export { ActionBarItem } from './ActionBarItem';
-export { PageActionItem } from './PageActionItem';
+// NOTE: An index file is most useful when you have multiple components
+
+export { AboutModal } from './AboutModal';

--- a/packages/experimental/src/components/Tearsheet/_index.scss
+++ b/packages/experimental/src/components/Tearsheet/_index.scss
@@ -7,4 +7,4 @@
 
 // An index file is most useful when you have multiple components
 
-@import './tearsheet.scss';
+@import './tearsheet';

--- a/packages/experimental/src/components/Tearsheet/index.js
+++ b/packages/experimental/src/components/Tearsheet/index.js
@@ -5,6 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-export { PageHeader } from './PageHeader';
-export { ActionBarItem } from './ActionBarItem';
-export { PageActionItem } from './PageActionItem';
+export { Tearsheet } from './Tearsheet';

--- a/packages/experimental/src/components/_index.scss
+++ b/packages/experimental/src/components/_index.scss
@@ -10,6 +10,8 @@
 @import './AboutModal/index';
 @import './EmptyState/index';
 @import './ExampleComponent/index';
+@import './ImportModal/index';
 @import './ModifiedTabs/index';
 @import './PageHeader/index';
+@import './RemovalModal/index';
 @import './Tearsheet/index';

--- a/packages/experimental/src/components/index.js
+++ b/packages/experimental/src/components/index.js
@@ -7,3 +7,5 @@
 
 export { ExampleComponent } from './ExampleComponent';
 export { ModifiedTabs } from './ModifiedTabs';
+export { PageHeader, ActionBarItem, PageActionItem } from './PageHeader';
+export { Tearsheet } from './Tearsheet';

--- a/packages/experimental/src/components/index.js
+++ b/packages/experimental/src/components/index.js
@@ -5,7 +5,11 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+export { AboutModal } from './AboutModal';
+export { EmptyState } from './EmptyState';
 export { ExampleComponent } from './ExampleComponent';
+export { ImportModal } from './ImportModal';
 export { ModifiedTabs } from './ModifiedTabs';
 export { PageHeader, ActionBarItem, PageActionItem } from './PageHeader';
+export { RemovalModal } from './RemovalModal';
 export { Tearsheet } from './Tearsheet';

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { ExampleComponent, ModifiedTabs } from './components';
+export * from './components';


### PR DESCRIPTION
Contributes to #59 

Publicly export PageHeader and Tearsheet components.
#### Changelog

M       packages/experimental/src/components/index.js