### PR TITLE
fix: use tilde for node_module imports

### DIFF
--- a/packages/cdai/src/components/IdeAPIKeyGeneration/_IdeAPIKeyGeneration.scss
+++ b/packages/cdai/src/components/IdeAPIKeyGeneration/_IdeAPIKeyGeneration.scss
@@ -8,10 +8,10 @@
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
 
-@import 'carbon-components/scss/components/inline-loading/inline-loading';
-@import 'carbon-components/scss/components/link/link';
-@import 'carbon-components/scss/components/modal/modal';
-@import 'carbon-components/scss/components/text-input/text-input';
+@import '~carbon-components/scss/components/inline-loading/inline-loading';
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/modal/modal';
+@import '~carbon-components/scss/components/text-input/text-input';
 
 .#{$ide-prefix}-api-key-generation .#{$prefix}--modal-content {
   @include carbon--breakpoint-down('lg') {

--- a/packages/cdai/src/components/IdeCard/_IdeCard.scss
+++ b/packages/cdai/src/components/IdeCard/_IdeCard.scss
@@ -7,9 +7,10 @@
 
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/link/link';
-@import 'carbon-components/scss/components/tile/tile';
-@import 'carbon-components/scss/components/tooltip/tooltip';
+
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/tile/tile';
+@import '~carbon-components/scss/components/tooltip/tooltip';
 
 $ide-card-size: carbon--mini-units(30);
 

--- a/packages/cdai/src/components/IdeCreate/_ide-create.scss
+++ b/packages/cdai/src/components/IdeCreate/_ide-create.scss
@@ -8,9 +8,9 @@
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
 
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/link/link';
-@import 'carbon-components/scss/components/progress-indicator/progress-indicator';
+@import '~carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/progress-indicator/progress-indicator';
 
 .#{$ide-prefix}-create-header {
   padding-bottom: $spacing-05;

--- a/packages/cdai/src/components/IdeDataTable/_IdeDataTable.scss
+++ b/packages/cdai/src/components/IdeDataTable/_IdeDataTable.scss
@@ -6,6 +6,7 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/toolbar/toolbar';
-@import 'carbon-components/scss/components/data-table/data-table';
-@import 'carbon-components/scss/components/button/button';
+
+@import '~carbon-components/scss/components/toolbar/toolbar';
+@import '~carbon-components/scss/components/data-table/data-table';
+@import '~carbon-components/scss/components/button/button';

--- a/packages/cdai/src/components/IdeEmptyState/_IdeEmptyState.scss
+++ b/packages/cdai/src/components/IdeEmptyState/_IdeEmptyState.scss
@@ -6,8 +6,9 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/link/link';
-@import 'carbon-components/scss/components/button/button';
+
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/button/button';
 
 .#{$ide-prefix}-empty-state {
   display: flex;

--- a/packages/cdai/src/components/IdeFilter/_IdeFilter.scss
+++ b/packages/cdai/src/components/IdeFilter/_IdeFilter.scss
@@ -7,7 +7,8 @@
 
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/tag/tag';
+
+@import '~carbon-components/scss/components/tag/tag';
 
 .#{$ide-prefix}-filter {
   position: relative;

--- a/packages/cdai/src/components/IdeHTTPErrors/_IdeHTTPErrors.scss
+++ b/packages/cdai/src/components/IdeHTTPErrors/_IdeHTTPErrors.scss
@@ -7,7 +7,8 @@
 
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/link/link';
+
+@import '~carbon-components/scss/components/link/link';
 
 $sm: 320px;
 $md: 672px;

--- a/packages/cdai/src/components/IdeHome/_IdeHome.scss
+++ b/packages/cdai/src/components/IdeHome/_IdeHome.scss
@@ -6,8 +6,9 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/tabs/tabs';
-@import 'carbon-components/scss/components/button/button';
+
+@import '~carbon-components/scss/components/tabs/tabs';
+@import '~carbon-components/scss/components/button/button';
 
 $ide-home-header-height: 25rem;
 $ide-home-header-collapsed-height: 3rem;

--- a/packages/cdai/src/components/IdeNavigation/_IdeNavigation.scss
+++ b/packages/cdai/src/components/IdeNavigation/_IdeNavigation.scss
@@ -6,14 +6,15 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/ui-shell/content';
-@import 'carbon-components/scss/components/ui-shell/side-nav';
-@import 'carbon-components/scss/components/ui-shell/header';
-@import 'carbon-components/scss/components/ui-shell/header-panel';
-@import 'carbon-components/scss/components/link/link';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/tabs/tabs';
-@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+
+@import '~carbon-components/scss/components/ui-shell/content';
+@import '~carbon-components/scss/components/ui-shell/side-nav';
+@import '~carbon-components/scss/components/ui-shell/header';
+@import '~carbon-components/scss/components/ui-shell/header-panel';
+@import '~carbon-components/scss/components/link/link';
+@import '~carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/tabs/tabs';
+@import '~carbon-components/scss/components/breadcrumb/breadcrumb';
 
 @import './PageHeader/IdePageHeader';
 @import './PageContent/IdePageContent';

--- a/packages/cdai/src/components/IdeRemove/_IdeRemove.scss
+++ b/packages/cdai/src/components/IdeRemove/_IdeRemove.scss
@@ -8,8 +8,8 @@
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
 
-@import 'carbon-components/scss/components/modal/modal';
-@import 'carbon-components/scss/components/text-input/text-input';
+@import '~carbon-components/scss/components/modal/modal';
+@import '~carbon-components/scss/components/text-input/text-input';
 
 .#{$ide-prefix}-remove--modal-body-textfield-container {
   margin-top: $spacing-04;

--- a/packages/cdai/src/components/IdeSaving/_IdeManualSave.scss
+++ b/packages/cdai/src/components/IdeSaving/_IdeManualSave.scss
@@ -8,7 +8,7 @@
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
 
-@import 'carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/button/button';
 
 .#{$ide-prefix}-manual-save--button {
   width: carbon--mini-units(20);

--- a/packages/cdai/src/components/IdeSlideOverPanel/_IdeSlideOverPanel.scss
+++ b/packages/cdai/src/components/IdeSlideOverPanel/_IdeSlideOverPanel.scss
@@ -8,9 +8,10 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/text-input/text-input';
-@import 'carbon-components/scss/components/text-area/text-area';
+
+@import '~carbon-components/scss/components/button/button';
+@import '~carbon-components/scss/components/text-input/text-input';
+@import '~carbon-components/scss/components/text-area/text-area';
 
 .#{$ide-prefix}-slide-over-overlay {
   position: fixed;

--- a/packages/cdai/src/components/IdeTableToolbarSearch/_IdeTableToolbarSearch.scss
+++ b/packages/cdai/src/components/IdeTableToolbarSearch/_IdeTableToolbarSearch.scss
@@ -6,8 +6,9 @@
 //
 @import '../../globals/scss/carbon-settings';
 @import '../../globals/scss/variables';
-@import 'carbon-components/scss/components/toolbar/toolbar';
-@import 'carbon-components/scss/components/data-table/data-table';
+
+@import '~carbon-components/scss/components/toolbar/toolbar';
+@import '~carbon-components/scss/components/data-table/data-table';
 
 .#{$ide-prefix}-table-toolbar-search {
   transition: flex $duration--moderate-02 $carbon--standard-easing,

--- a/packages/cdai/src/globals/scss/_carbon-settings.scss
+++ b/packages/cdai/src/globals/scss/_carbon-settings.scss
@@ -13,4 +13,4 @@
 @import '~@carbon/themes/scss/themes';
 @import '~@carbon/motion/scss/motion';
 @import '~@carbon/colors/scss/colors';
-@import 'carbon-components/scss/globals/scss/_motion.scss';
+@import '~carbon-components/scss/globals/scss/_motion.scss';


### PR DESCRIPTION
dont force consumers to have to update their webpack configuration so that the SCSS import can be resolved