### PR TITLE
fix spacing in IdePageHeader

### DIFF
--- a/packages/cdai/src/components/IdeNavigation/PageHeader/_IdePageHeader.scss
+++ b/packages/cdai/src/components/IdeNavigation/PageHeader/_IdePageHeader.scss
@@ -11,7 +11,6 @@
 }
 
 .#{$ide-prefix}-page-header {
-  margin-top: carbon--mini-units(6);
   box-shadow: inset 0 -1px $ui-01;
 }
 


### PR DESCRIPTION
an extra "margin-top" rule has appeared in the move over from CDAI, this break compatibility

