### PR TITLE
chore(release): correct repository information in package.jsons

### DIFF
--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "version": "0.0.2",
   "license": "Apache-2.0",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/automation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/automation"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/babel-preset-ibm-cloud-cognitive/package.json
+++ b/packages/babel-preset-ibm-cloud-cognitive/package.json
@@ -4,7 +4,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/babel-preset-ibm-cloud-cognitive",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/babel-preset-ibm-cloud-cognitive"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cdai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/cdai"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "files": [
     "es",
@@ -26,25 +30,6 @@
     "storybook": "start-storybook -p 6006",
     "build": "node scripts/build.js"
   },
-  "devDependencies": {
-    "@babel/cli": "^7.11.6",
-    "@babel/core": "^7.11.6",
-    "@babel/plugin-proposal-class-properties": "^7.10.4",
-    "@babel/plugin-transform-regenerator": "^7.10.4",
-    "@babel/plugin-transform-runtime": "^7.11.5",
-    "@babel/preset-env": "^7.11.5",
-    "@babel/preset-react": "^7.10.4",
-    "rimraf": "^3.0.2",
-    "sinon": "^7.4.2"
-  },
-  "dependencies": {
-    "@babel/runtime": "^7.11.2",
-    "focus-trap-react": "^6.0.0",
-    "pluralize": "^8.0.0",
-    "react-highlighter": "^0.4.3",
-    "react-select": "^3.1.0",
-    "uuid": "^3.4.0"
-  },
   "peerDependencies": {
     "@carbon/elements": "^10.11.1",
     "carbon-addons-cloud": "^3.5.4",
@@ -57,6 +42,25 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "yarn": "^1.16.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.11.2",
+    "focus-trap-react": "^6.0.0",
+    "pluralize": "^8.0.0",
+    "react-highlighter": "^0.4.3",
+    "react-select": "^3.1.0",
+    "uuid": "^3.4.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.11.6",
+    "@babel/core": "^7.11.6",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-transform-regenerator": "^7.10.4",
+    "@babel/plugin-transform-runtime": "^7.11.5",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/preset-react": "^7.10.4",
+    "rimraf": "^3.0.2",
+    "sinon": "^7.4.2"
   },
   "babel": {
     "presets": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,11 @@
   "bin": {
     "carbon-cli": "./bin/carbon-cli.js"
   },
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/cli"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/cli/src/commands/sync/packageJson.js
+++ b/packages/cli/src/commands/sync/packageJson.js
@@ -73,10 +73,11 @@ function run(workspace) {
   const { directory, packages } = workspace;
   return Promise.all(
     packages.map(async ({ packageJsonPath, packageJson, packageFolder }) => {
-      let repository = `${REPO_URL_BASE}/tree/master/`;
-      repository += path.relative(directory, packageFolder);
-
-      packageJson.repository = repository;
+      packageJson.repository = {
+        type: 'git',
+        url: `${REPO_URL_BASE}.git`,
+        directory: path.relative(directory, packageFolder),
+      };
       packageJson.bugs = `${REPO_URL_BASE}/issues`;
       packageJson.license = 'Apache-2.0';
 

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/cloud-cognitive",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/cloud-cognitive"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "files": [
     "css",

--- a/packages/common-services/package.json
+++ b/packages/common-services/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "version": "0.0.2",
   "license": "Apache-2.0",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/common-services",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/common-services"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@carbon/ibm-cloud-cognitive-core",
   "private": true,
-  "main": "scripts/build.js",
   "version": "0.4.1",
   "license": "Apache-2.0",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/core",
+  "main": "scripts/build.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/core"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/experimental",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/experimental"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "files": [
     "css",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -4,7 +4,11 @@
   "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/jest-config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/jest-config"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/rollup-config/package.json
+++ b/packages/rollup-config/package.json
@@ -4,7 +4,11 @@
   "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/rollup-config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/rollup-config"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "keywords": [
     "carbon",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "repository": "https://github.com/carbon-design-system/ibm-cloud-cognitive/tree/master/packages/security",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/security"
+  },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "files": [
     "css",

--- a/packages/storybook-addon-carbon-theme/package.json
+++ b/packages/storybook-addon-carbon-theme/package.json
@@ -1,31 +1,41 @@
 {
   "name": "@carbon/storybook-addon-theme",
-  "version": "0.2.1",
   "description": "Carbon theme switcher for Storybook",
-  "keywords": [
-    "addon",
-    "carbon",
-    "theme",
-    "storybook"
-  ],
-  "homepage": "https://github.com/storybookjs/storybook#readme",
-  "bugs": "https://github.com/carbon-design-system/carbon/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/carbon-design-system/carbon.git",
-    "directory": "packages/scss-generator"
-  },
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "main": "dist/react.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
+    "directory": "packages/storybook-addon-carbon-theme"
+  },
+  "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
+  "homepage": "https://github.com/storybookjs/storybook#readme",
   "files": [
     "dist/**/*",
     "README.md",
     "*.js"
   ],
+  "keywords": [
+    "addon",
+    "carbon",
+    "theme",
+    "storybook",
+    "carbon design system",
+    "carbon community",
+    "carbon for cloud & cognitive"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && babel src --out-dir dist -s",
     "prepare": "npm run build"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "vue": "*"
   },
   "dependencies": {
     "@storybook/addons": "5.3.19",
@@ -38,16 +48,9 @@
     "core-js": "^3.0.1",
     "global": "^4.3.2"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "@babel/cli": "^7.10.0",
     "@babel/core": "^7.10.0",
     "@babel/preset-react": "^7.10.4"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "vue": "*"
   }
 }


### PR DESCRIPTION
Contributes to #

Some repository links are computed wrongly and e.g. include the package subdirectory when pointing to issues or PRs.

#### Changelog

**Changed**

- `packages/cli/src/commands/sync/packageJson.js`: use extended repository information that includes the directory instead of a concatenated string (see https://docs.npmjs.com/cli/v6/configuring-npm/package-json)
- ran `yarn sync`
