### PR TITLE
build(Prettier): ignore CHANGELOGs from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ es
 lib
 umd
 dist
+
+# Managed by Lerna - https://github.com/lerna/lerna/tree/main/commands/version#--conventional-commits
+CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "lerna run clean && lerna clean --yes && rimraf node_modules",
     "copy-common-files": "sh ./scripts/copy-common-files.sh;",
     "format": "prettier --write '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**'",
-    "format:diff": "prettier --list-different '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**' '!**/CHANGELOG.md' '!README.md'",
+    "format:diff": "prettier --list-different '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**' '!README.md'",
     "monorepo:npm-upgrade": "sh ./scripts/monorepo-npm-upgrade.sh",
     "lint": "yarn lint:es && yarn lint:style",
     "lint:es": "eslint 'packages/*/src/**/*.js'",


### PR DESCRIPTION
Resolves #225 

#### Changelog

**New**

Added `CHANGELOG.md` to `.prettierignore` - Because this is generated and updated by Lerna, I couldn't see the value in formatting with Prettier as these files should never need to be touched by anyone working on the project