### PR TITLE
feat: export modal

### DIFF
--- a/packages/experimental/src/components/ExportModal/ExportModal-test.js
+++ b/packages/experimental/src/components/ExportModal/ExportModal-test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+
+import { ExportModal } from '.';
+
+const { name } = ExportModal;
+const defaultProps = {
+  filename: '',
+  inputLabel: 'File name',
+  modalHeading: 'Export',
+  onRequestClose: () => {},
+  onRequestSubmit: () => {},
+  open: true,
+  primaryButtonText: 'Export',
+  secondaryButtonText: 'Cancel',
+  validExtensions: ['pdf'],
+  invalidInputText: 'File must have valid extension .pdf',
+};
+
+describe(name, () => {
+  test('should render', async () => {
+    const { click, change } = fireEvent;
+    const { fn } = jest;
+    const onRequestSubmit = fn();
+
+    const { container } = render(
+      <ExportModal {...defaultProps} onRequestSubmit={onRequestSubmit} />
+    );
+
+    const submitBtn = container.querySelector('.bx--btn--primary');
+    const textInput = container.querySelector('.bx--text-input');
+
+    click(submitBtn);
+    expect(onRequestSubmit).not.toBeCalled();
+
+    change(textInput, { target: { value: 'test.pdf' } });
+    click(submitBtn);
+    expect(onRequestSubmit).toBeCalled();
+  });
+});

--- a/packages/experimental/src/components/ExportModal/ExportModal.js
+++ b/packages/experimental/src/components/ExportModal/ExportModal.js
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Modal, TextInput } from 'carbon-components-react';
+import PropTypes from 'prop-types';
+import { expPrefix } from '../../global/js/settings';
+
+export const ExportModal = ({
+  filename,
+  inputLabel,
+  invalidInputText,
+  modalHeading,
+  onRequestClose,
+  onRequestSubmit,
+  open,
+  primaryButtonText,
+  secondaryButtonText,
+  validExtensions,
+}) => {
+  const [name, setName] = useState(filename);
+
+  const onChangeHandler = (evt) => {
+    setName(evt.target.value);
+  };
+
+  const hasInvalidExtension = () => {
+    if (!validExtensions || !validExtensions.length) return false;
+    if (!name.includes('.')) return true;
+    const ext = name.split('.').pop();
+    if (!validExtensions.includes(ext)) return true;
+    return false;
+  };
+
+  const primaryButtonDisabled = !name || hasInvalidExtension();
+
+  return (
+    <Modal
+      open={open}
+      primaryButtonText={primaryButtonText}
+      secondaryButtonText={secondaryButtonText}
+      modalHeading={modalHeading}
+      onRequestSubmit={onRequestSubmit}
+      onRequestClose={onRequestClose}
+      className={`${expPrefix}--export-modal`}
+      primaryButtonDisabled={primaryButtonDisabled}>
+      <div className={`${expPrefix}--export-modal-inner`}>
+        <TextInput
+          value={name}
+          onChange={onChangeHandler}
+          labelText={inputLabel}
+          invalid={hasInvalidExtension()}
+          invalidText={invalidInputText}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+ExportModal.propTypes = {
+  /**
+   * name of the file being exported
+   */
+  filename: PropTypes.string,
+  /**
+   * label for the text input
+   */
+  inputLabel: PropTypes.string,
+  /**
+   * text for an invalid input
+   */
+  invalidInputText: PropTypes.string,
+  /**
+   * Header that displays at the top of the modal
+   */
+  modalHeading: PropTypes.string,
+  /**
+   * Specify a handler for closing modal
+   */
+  onRequestClose: PropTypes.func,
+  /**
+   * Specify a handler for "submitting" modal. Access the imported file via `file => {}`
+   */
+  onRequestSubmit: PropTypes.func,
+  /**
+   * Specify whether the Modal is currently open
+   */
+  open: PropTypes.bool,
+  /**
+   * Specify the text for the primary button
+   */
+  primaryButtonText: PropTypes.string,
+  /**
+   * Specify the text for the secondary button
+   */
+  secondaryButtonText: PropTypes.string,
+  /**
+   * array of valid extensions the file can have
+   */
+  validExtensions: PropTypes.array,
+};
+
+ExportModal.defaultProps = {
+  filename: '',
+  inputLabel: '',
+  invalidInputText: '',
+  modalHeading: '',
+  onRequestClose: () => {},
+  onRequestSubmit: () => {},
+  open: false,
+  primaryButtonText: '',
+  secondaryButtonText: '',
+  validExtensions: [],
+};

--- a/packages/experimental/src/components/ExportModal/ExportModal.js
+++ b/packages/experimental/src/components/ExportModal/ExportModal.js
@@ -21,6 +21,10 @@ export const ExportModal = ({
     setName(evt.target.value);
   };
 
+  const onSubmitHandler = () => {
+    onRequestSubmit(name);
+  };
+
   const hasInvalidExtension = () => {
     if (!validExtensions || !validExtensions.length) return false;
     if (!name.includes('.')) return true;
@@ -37,7 +41,7 @@ export const ExportModal = ({
       primaryButtonText={primaryButtonText}
       secondaryButtonText={secondaryButtonText}
       modalHeading={modalHeading}
-      onRequestSubmit={onRequestSubmit}
+      onRequestSubmit={onSubmitHandler}
       onRequestClose={onRequestClose}
       className={`${expPrefix}--export-modal`}
       primaryButtonDisabled={primaryButtonDisabled}>

--- a/packages/experimental/src/components/ExportModal/ExportModal.mdx
+++ b/packages/experimental/src/components/ExportModal/ExportModal.mdx
@@ -1,0 +1,20 @@
+import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { ExportModal } from './ExportModal';
+
+# ExportModal
+
+[Usage guidelines](https://www.carbondesignsystem.com/community/patterns/export-pattern/)
+&nbsp;|&nbsp;
+[Carbon Modal usage guidelines](https://www.carbondesignsystem.com/components/modal/usage)
+&nbsp;|&nbsp;
+[Carbon Modal documentation](https://react.carbondesignsystem.com/?path=/docs/modal--default)
+
+## Overview
+
+<Preview>
+  <Story id="experimental-exportmodal--with-state-manager" />
+</Preview>
+
+## Component API
+
+<Props />

--- a/packages/experimental/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/experimental/src/components/ExportModal/ExportModal.stories.js
@@ -1,0 +1,70 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+import React, { useState } from 'react';
+import { Button } from 'carbon-components-react';
+import { ExportModal } from '.';
+import styles from './_storybook-styles.scss'; // import index in case more files are added later.
+import mdx from './ExportModal.mdx';
+
+export default {
+  title: 'Experimental/ExportModal',
+  component: ExportModal,
+  parameters: {
+    styles,
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const defaultProps = {
+  filename: 'Sample02.pdf',
+  inputLabel: 'File name',
+  modalHeading: 'Export',
+  onRequestClose: () => {},
+  onRequestSubmit: () => {},
+  open: true,
+  primaryButtonText: 'Export',
+  secondaryButtonText: 'Cancel',
+};
+
+const Template = (args) => {
+  return <ExportModal {...args} />;
+};
+
+const TemplateWithState = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <ExportModal
+        {...args}
+        open={open}
+        onRequestClose={() => setOpen(false)}
+      />
+      <Button onClick={() => setOpen(true)}>Launch modal</Button>
+    </>
+  );
+};
+
+export const WithStateManager = TemplateWithState.bind({});
+WithStateManager.args = {
+  ...defaultProps,
+};
+
+export const Standard = Template.bind({});
+Standard.args = {
+  ...defaultProps,
+};
+
+export const WithExtensionValidation = Template.bind({});
+WithExtensionValidation.args = {
+  ...defaultProps,
+  validExtensions: ['pdf'],
+  filename: 'name',
+  invalidInputText: 'File must have valid extension .pdf',
+};

--- a/packages/experimental/src/components/ExportModal/_export-modal.scss
+++ b/packages/experimental/src/components/ExportModal/_export-modal.scss
@@ -1,0 +1,5 @@
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
+
+@import 'carbon-components/scss/components/modal/modal';
+@import 'carbon-components/scss/components/text-input/text-input';

--- a/packages/experimental/src/components/ExportModal/_index.scss
+++ b/packages/experimental/src/components/ExportModal/_index.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// An index file is most useful when you have multiple components
+
+@import './export-modal';

--- a/packages/experimental/src/components/ExportModal/_storybook-styles.scss
+++ b/packages/experimental/src/components/ExportModal/_storybook-styles.scss
@@ -1,0 +1,1 @@
+@import './index';

--- a/packages/experimental/src/components/ExportModal/index.js
+++ b/packages/experimental/src/components/ExportModal/index.js
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+export { ExportModal } from './ExportModal';


### PR DESCRIPTION
Contributes to #31 

Adds the export modal

#### Changelog

A       packages/experimental/src/components/ExportModal/ExportModal-test.js
A       packages/experimental/src/components/ExportModal/ExportModal.js
A       packages/experimental/src/components/ExportModal/ExportModal.mdx
A       packages/experimental/src/components/ExportModal/ExportModal.stories.js
A       packages/experimental/src/components/ExportModal/_export-modal.scss
A       packages/experimental/src/components/ExportModal/_index.scss
A       packages/experimental/src/components/ExportModal/_storybook-styles.scss
A       packages/experimental/src/components/ExportModal/index.js

**New**

Export modal