### PR TITLE
fix: import continer disabled after file added in import modal

### DIFF
--- a/packages/experimental/src/components/ImportModal/ImportModal.js
+++ b/packages/experimental/src/components/ImportModal/ImportModal.js
@@ -148,6 +148,7 @@ export const ImportModal = ({
         accept={validFileTypes}
         labelText={fileDropLabel}
         onAddFiles={onAddFile}
+        disabled={files.length}
       />
       <p className={`${expPrefix}--import-modal-label`}>{inputHeader}</p>
       <div className={`${expPrefix}--input-group`}>


### PR DESCRIPTION
Contributes to #30 

When a file is added to the import modal the upload container will now be disabled since only one file is allowed at a time.

#### Changelog

M       packages/experimental/src/components/ImportModal/ImportModal.js
