### PR TITLE
Remove undeclared dependency

### DIFF
--- a/packages/experimental/src/global/styles/_carbon-settings.scss
+++ b/packages/experimental/src/global/styles/_carbon-settings.scss
@@ -11,7 +11,7 @@
 @import 'carbon-components/scss/globals/scss/vars';
 @import '@carbon/type/scss/type';
 @import '@carbon/layout/scss/layout';
-@import '@carbon/grid/scss/grid';
+@import 'carbon-components/scss/globals/grid/grid';
 @import '@carbon/themes/scss/themes';
 @import '@carbon/motion/scss/motion';
 


### PR DESCRIPTION
There is an undeclared dependency on the Carbon grid package . This will move it to use the scss which is shipped in the core carbon-components project