### PR TITLE
chore: update ide snapshot to fix build

### DIFF
--- a/packages/cdai/src/components/IdeNavigation/PageHeader/__snapshots__/IdePageHeader.spec.js.snap
+++ b/packages/cdai/src/components/IdeNavigation/PageHeader/__snapshots__/IdePageHeader.spec.js.snap
@@ -60,6 +60,7 @@ Array [
             data-ui-id="IdePageHeader--tabs-container"
           >
             <Tabs
+              scrollIntoView={true}
               selected={0}
               selectionMode="automatic"
               type="default"
@@ -177,6 +178,7 @@ Array [
             data-ui-id="IdePageHeader--tabs-container"
           >
             <Tabs
+              scrollIntoView={true}
               selected={0}
               selectionMode="automatic"
               type="default"


### PR DESCRIPTION
The IdePageHeader snapshot is out of date since Carbon 10.26 updated to reflect the change.

#### Changelog

M       packages/cdai/src/components/IdeNavigation/PageHeader/__snapshots__/IdePageHeader.spec.js.snap