### PR TITLE
fix: reiew updates

### DIFF
--- a/packages/experimental/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/experimental/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -84,12 +84,19 @@ export const BreadcrumbWithOverflow = ({
         // adding just 1 to childArray.length - displayCount
         child = childArray[index + 1];
       }
-      newOverflowBreadcrumbItems.push(React.cloneElement(child));
+      newOverflowBreadcrumbItems.push(
+        React.cloneElement(child, {
+          key: `displayed-breadcrumb-${internalId}-overflow-item-${index}`,
+        })
+      );
     }
 
     if (displayCount === 0) {
       newDisplayedBreadcrumbItems.push(
-        <BreadcrumbOverflowMenu overflowItems={newOverflowBreadcrumbItems} />
+        <BreadcrumbOverflowMenu
+          overflowItems={newOverflowBreadcrumbItems}
+          key={`$displayed-breadcrumb-${internalId}-overflow`}
+        />
       );
     } else {
       let displayed = 0;
@@ -120,6 +127,7 @@ export const BreadcrumbWithOverflow = ({
           newDisplayedBreadcrumbItems.push(
             <BreadcrumbOverflowMenu
               overflowItems={newOverflowBreadcrumbItems}
+              key={`$displayed-breadcrumb-${internalId}-overflow`}
             />
           );
         }

--- a/packages/experimental/src/components/PageHeader/ButtonSetWithOverflow.js
+++ b/packages/experimental/src/components/PageHeader/ButtonSetWithOverflow.js
@@ -81,12 +81,12 @@ export const ButtonSetWithOverflow = ({
     <ReactResizeDetector handleWidth={true} onResize={handleResize}>
       <div className={cx([blockClass, className])} ref={spaceAvailableRef}>
         <ReactResizeDetector onResize={handleButtonResize}>
-          <ButtonSet
-            className={`${blockClass}--button-container ${blockClass}--button-container--hidden`}
-            aria-hidden={true}
-            ref={sizingContainerRefSet}>
-            {children}
-          </ButtonSet>
+          <div
+            className={`${blockClass}--button-container ${blockClass}--button-container--hidden`}>
+            <ButtonSet aria-hidden={true} ref={sizingContainerRefSet}>
+              {children}
+            </ButtonSet>
+          </div>
         </ReactResizeDetector>
         <ReactResizeDetector onResize={handleButtonResize}>
           <div

--- a/packages/experimental/src/components/PageHeader/PageHeader.js
+++ b/packages/experimental/src/components/PageHeader/PageHeader.js
@@ -40,6 +40,7 @@ export const PageHeader = ({
   keepBreadcrumbAndTabs,
   navigation,
   pageActions,
+  pageHeaderOffset,
   preCollapseTitleRow,
   subtitle,
   tags,
@@ -202,7 +203,6 @@ export const PageHeader = ({
         update.breadcrumbRowSpaceBelow = isNaN(val) ? 0 : val;
       }
       if (titleRowEl) {
-        // debugger;
         val = parseFloat(
           window.getComputedStyle(titleRowEl).getPropertyValue('margin-top'),
           10
@@ -215,6 +215,8 @@ export const PageHeader = ({
   };
 
   useEffect(() => {
+    // NOTE: The buffer is used to add space between the bottom of the header and the last content
+
     // No navigation and title row not pre-collapsed
     // and only one of tags or (subtitle or available space)
     setLastRowBufferActive(
@@ -256,7 +258,9 @@ export const PageHeader = ({
         ...prevCSSProps,
         [`--${blockClass}--height-px`]: `${metrics.headerHeight}px`,
         [`--${blockClass}--width-px`]: `${metrics.headerWidth}px`,
-        [`--${blockClass}--header-top`]: `${metrics.headerTopValue}px`,
+        [`--${blockClass}--header-top`]: `${
+          metrics.headerTopValue + pageHeaderOffset
+        }px`,
         [`--${blockClass}--breadcrumb-title-visibility`]:
           scrollYValue > 0 ? 'visible' : 'hidden',
         [`--${blockClass}--scroll`]: `${scrollYValue}`,
@@ -276,14 +280,15 @@ export const PageHeader = ({
         )}`,
         [`--${blockClass}--breadcrumb-row-width-px`]: `${metrics.breadcrumbRowWidth}px`,
         [`--${blockClass}--breadcrumb-top`]: `${Math.min(
-          0,
+          pageHeaderOffset,
           !keepBreadcrumbAndTabs && navigation
             ? metrics.headerHeight -
                 metrics.titleRowSpaceAbove -
                 metrics.navigationRowHeight -
                 metrics.breadcrumbRowHeight -
-                scrollYValue
-            : 0
+                scrollYValue +
+                pageHeaderOffset
+            : pageHeaderOffset
         )}px`,
       };
     });
@@ -299,6 +304,7 @@ export const PageHeader = ({
     metrics.headerTopValue,
     metrics.navigationRowHeight,
     navigation,
+    pageHeaderOffset,
     scrollYValue,
     tags,
   ]);
@@ -669,6 +675,11 @@ PageHeader.propTypes = {
    */
   pageActions: PropTypes.element,
   /**
+   * Number of pixels the page header sits from the top of the screen.
+   * The nature of the pageHeader makes this hard to measure
+   */
+  pageHeaderOffset: PropTypes.number,
+  /**
    * The title row typically starts below the breadcrumb row. This option
    * preCollapses it into the breadcrumb row.
    */
@@ -699,5 +710,6 @@ PageHeader.defaultProps = {
   background: false,
   className: '',
   keepBreadcrumbAndTabs: false,
+  pageHeaderOffset: 0,
   preCollapseTitleRow: false,
 };

--- a/packages/experimental/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/experimental/src/components/PageHeader/PageHeader.stories.js
@@ -11,7 +11,10 @@ import React from 'react';
 import {
   BreadcrumbItem,
   Column,
+  Content,
   Grid,
+  Header,
+  HeaderName,
   Row,
   Tab,
   Tabs,
@@ -443,6 +446,55 @@ const TemplateWithSwitchedArgs = (args) => {
 
 export const AllAttributesWithSwitches = TemplateWithSwitchedArgs.bind({});
 AllAttributesWithSwitches.args = {
+  actionBarItems,
+  actionBarItemsSwitchedArg: true,
+  availableSpace: summaryDetails,
+  availableSpaceSwitchedArg: true,
+  background: true,
+  breadcrumbItems,
+  breadcrumbItemsSwitchedArg: true,
+  keepBreadcrumbAndTabs: false,
+  navigation: tabBar,
+  navigationSwitchedArg: true,
+  pageActions,
+  pageActionsSwitchedArg: true,
+  preCollapseTitleRow: false,
+  subtitle,
+  subtitleSwitchedArg: true,
+  tags,
+  tagsSwitchedArg: true,
+  title,
+  titleSwitchedArg: true,
+  titleIcon: Bee24,
+  titleIconSwitchedArg: true,
+};
+
+const TemplatePageHeaderWithCarbonHeader = (args) => {
+  return (
+    <div className="page-header-stories__app">
+      <Header aria-label="IBM Platform Name">
+        <HeaderName href="#" prefix="IBM">
+          [Platform]
+        </HeaderName>
+      </Header>
+      <Content className="page-header-stories__content-container">
+        <PageHeader
+          className="example-class-name"
+          {...includeTheseArgs(args)}
+          pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
+        />
+        <div className="page-header-stories__inner-content">
+          {dummyPageContent}
+        </div>
+      </Content>
+    </div>
+  );
+};
+
+export const PageHeaderWithCarbonHeader = TemplatePageHeaderWithCarbonHeader.bind(
+  {}
+);
+PageHeaderWithCarbonHeader.args = {
   actionBarItems,
   actionBarItemsSwitchedArg: true,
   availableSpace: summaryDetails,

--- a/packages/experimental/src/components/PageHeader/_page-header.scss
+++ b/packages/experimental/src/components/PageHeader/_page-header.scss
@@ -125,7 +125,7 @@ $raised-z-index: 99;
 
 .#{$block-class}--action-bar-column-content {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   overflow: hidden;
   white-space: nowrap;
 

--- a/packages/experimental/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/experimental/src/components/PageHeader/_storybook-styles.scss
@@ -6,6 +6,8 @@
 //
 @import './index';
 
+@import 'carbon-components/scss/components/ui-shell/ui-shell';
+
 .sbdocs .page-header-stories__viewport {
   max-height: 500px;
   overflow-y: auto;
@@ -39,4 +41,16 @@
 .page-header-stories__status-icon {
   vertical-align: middle;
   fill: $support-02;
+}
+
+.page-header-stories__app {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.page-header-stories__content-container {
+  height: 100%;
+  padding: 0;
 }


### PR DESCRIPTION
Contributes to #59 

- Removed a number of runtime key/ref errors where ReactResizeDetector could not place a ref on a functional component.
- Moved pageActions in breadcrumb next to actionBarItems as per review
- Added a pageHeaderOffset property to allow use with a Global Header. A more elegant solution that passing an offset could be raised as a new issue.
- Added story TemplatePageHeaderWithCarbonHeader

#### Changelog

Use the following command to list changes or manually list out new, changed and
removed files.

M       packages/experimental/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
M       packages/experimental/src/components/PageHeader/ButtonSetWithOverflow.js
M       packages/experimental/src/components/PageHeader/PageHeader.js
M       packages/experimental/src/components/PageHeader/PageHeader.stories.js
M       packages/experimental/src/components/PageHeader/_page-header.scss
M       packages/experimental/src/components/PageHeader/_storybook-styles.scss
