### PR TITLE
fix: card updates

### DIFF
--- a/packages/experimental/src/components/Card/Card.js
+++ b/packages/experimental/src/components/Card/Card.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { pkgPrefix } from '../../global/js/settings';
 
 export const Card = ({
-  actionOnclick,
   actionButtonText,
   actionIcon: ActionIcon,
   pictogram: Pictogram,
@@ -15,6 +14,7 @@ export const Card = ({
   label,
   media,
   mediaPosition,
+  onActionClick,
   onClick,
   title,
 }) => {
@@ -42,7 +42,7 @@ export const Card = ({
         <div className={`${pkgPrefix}-card-actions`}>
           {actionButtonText && (
             <div className={`${pkgPrefix}-card-action-button`}>
-              <Button kind="primary" onClick={actionOnclick}>
+              <Button kind="primary" onClick={onActionClick}>
                 {actionButtonText}
               </Button>
             </div>
@@ -50,7 +50,7 @@ export const Card = ({
           {ActionIcon && (
             <ActionIcon
               className={`${pkgPrefix}-card-action-icon`}
-              onClick={actionOnclick}
+              onClick={onActionClick}
             />
           )}
         </div>
@@ -70,20 +70,19 @@ export const Card = ({
 Card.propTypes = {
   actionButtonText: PropTypes.string,
   actionIcon: PropTypes.object,
-  actionOnclick: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
   href: PropTypes.string,
   label: PropTypes.string,
   media: PropTypes.node,
   mediaPosition: PropTypes.oneOf(['top', 'left']),
+  onActionClick: PropTypes.func,
   onClick: PropTypes.func,
   pictogram: PropTypes.object,
   title: PropTypes.string,
 };
 
 Card.defaultProps = {
-  actionOnclick: null,
   actionButtonText: '',
   actionIcon: null,
   children: '',
@@ -92,6 +91,7 @@ Card.defaultProps = {
   label: '',
   media: null,
   mediaPosition: 'top',
+  onActionClick: null,
   onClick: null,
   pictogram: null,
   title: '',

--- a/packages/experimental/src/components/Card/Card.js
+++ b/packages/experimental/src/components/Card/Card.js
@@ -5,53 +5,55 @@ import PropTypes from 'prop-types';
 import { pkgPrefix } from '../../global/js/settings';
 
 export const Card = ({
-  actionButtonFn,
+  actionOnclick,
   actionButtonText,
   actionIcon: ActionIcon,
-  actionIconFn,
+  pictogram: Pictogram,
   children,
   className,
   href,
   label,
-  mediaAltText,
-  mediaUrl,
+  media,
+  mediaPosition,
   onClick,
   title,
 }) => {
   const cardClasses = cx({
     [`${pkgPrefix}-card`]: true,
     [`${pkgPrefix}-card--clickable`]: onClick,
+    [`${pkgPrefix}-card--media-left`]: mediaPosition === 'left',
     className,
   });
 
   const CardContent = (
     <div className={cardClasses}>
-      {mediaUrl && (
-        <img
-          className={`${pkgPrefix}-card-media`}
-          src={mediaUrl}
-          alt={mediaAltText}
-        />
+      {media && <div className={`${pkgPrefix}-card-media`}>{media}</div>}
+      {Pictogram && (
+        <div className={`${pkgPrefix}-card-pictogram`}>
+          <Pictogram />
+        </div>
       )}
-      <div className={`${pkgPrefix}-card-header`}>
-        <p className={`${pkgPrefix}-card-label`}>{label}</p>
-        <p className={`${pkgPrefix}-card-title`}>{title}</p>
-      </div>
-      <div className={`${pkgPrefix}-card-body`}>{children}</div>
-      <div className={`${pkgPrefix}-card-actions`}>
-        {actionButtonText && (
-          <div className={`${pkgPrefix}-card-action-button`}>
-            <Button kind="primary" onClick={actionButtonFn}>
-              {actionButtonText}
-            </Button>
-          </div>
-        )}
-        {ActionIcon && (
-          <ActionIcon
-            className={`${pkgPrefix}-card-action-icon`}
-            onClick={actionIconFn}
-          />
-        )}
+      <div className={`${pkgPrefix}-card-content-container`}>
+        <div className={`${pkgPrefix}-card-header`}>
+          <p className={`${pkgPrefix}-card-label`}>{label}</p>
+          <p className={`${pkgPrefix}-card-title`}>{title}</p>
+        </div>
+        <div className={`${pkgPrefix}-card-body`}>{children}</div>
+        <div className={`${pkgPrefix}-card-actions`}>
+          {actionButtonText && (
+            <div className={`${pkgPrefix}-card-action-button`}>
+              <Button kind="primary" onClick={actionOnclick}>
+                {actionButtonText}
+              </Button>
+            </div>
+          )}
+          {ActionIcon && (
+            <ActionIcon
+              className={`${pkgPrefix}-card-action-icon`}
+              onClick={actionOnclick}
+            />
+          )}
+        </div>
       </div>
     </div>
   );
@@ -66,31 +68,31 @@ export const Card = ({
 };
 
 Card.propTypes = {
-  actionButtonFn: PropTypes.func,
   actionButtonText: PropTypes.string,
   actionIcon: PropTypes.object,
-  actionIconFn: PropTypes.func,
+  actionOnclick: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
   href: PropTypes.string,
   label: PropTypes.string,
-  mediaAltText: PropTypes.string,
-  mediaUrl: PropTypes.string,
+  media: PropTypes.node,
+  mediaPosition: PropTypes.oneOf(['top', 'left']),
   onClick: PropTypes.func,
+  pictogram: PropTypes.object,
   title: PropTypes.string,
 };
 
 Card.defaultProps = {
-  actionButtonFn: null,
+  actionOnclick: null,
   actionButtonText: '',
   actionIcon: null,
-  actionIconFn: null,
   children: '',
   className: '',
   href: '',
   label: '',
-  mediaAltText: '',
-  mediaUrl: '',
+  media: null,
+  mediaPosition: 'top',
   onClick: null,
+  pictogram: null,
   title: '',
 };

--- a/packages/experimental/src/components/Card/Card.stories.js
+++ b/packages/experimental/src/components/Card/Card.stories.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { Card } from '.';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import mdx from './Card.mdx';
-import { ArrowRight24 } from '@carbon/icons-react';
+import { ArrowRight24, Cloud32 } from '@carbon/icons-react';
 
 export default {
   title: 'Experimental/Card',
@@ -25,15 +25,14 @@ export default {
 const defaultProps = {
   label: 'Label',
   title: 'Title',
-  onActionSubmit: () => {},
+  onActionClick: () => {},
   children: (
     <p>
       expressive card body content block. description inviting the user to take
       action on the card.
     </p>
   ),
-  mediaUrl: 'https://via.placeholder.com/400x300/000/fff',
-  mediaAltText: 'alt text',
+  actionButtonText: 'Primary button',
 };
 
 const Template = (opts) => {
@@ -45,26 +44,51 @@ const Template = (opts) => {
   );
 };
 
-export const ActionButton = Template.bind({});
-ActionButton.args = {
-  ...defaultProps,
-  actionButtonText: 'Primary button',
+const TemplateWide = (opts) => {
+  const { children, ...args } = opts;
+  return (
+    <div className="card-demo-container--wide">
+      <Card {...args}>{children}</Card>
+    </div>
+  );
 };
 
-export const ActionIcon = Template.bind({});
-ActionIcon.args = {
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultProps,
+  media: <img src="https://via.placeholder.com/300x200/000/fff" alt="img" />,
+};
+
+export const MediaLeft = TemplateWide.bind({});
+MediaLeft.args = {
+  ...defaultProps,
+  mediaPosition: 'left',
+  media: <img src="https://via.placeholder.com/300x225/000/fff" alt="img" />,
+};
+
+export const WithActionIcon = Template.bind({});
+WithActionIcon.args = {
   ...defaultProps,
   actionIcon: ArrowRight24,
+  actionButtonText: '',
 };
 
-export const ClickableWithFunction = Template.bind({});
-ClickableWithFunction.args = {
+export const WithPictogram = Template.bind({});
+WithPictogram.args = {
+  ...defaultProps,
+  pictogram: Cloud32,
+};
+
+export const ClickableCardWithOnclick = Template.bind({});
+ClickableCardWithOnclick.args = {
   ...defaultProps,
   onClick: () => {},
+  actionButtonText: '',
 };
 
-export const ClickableWithLink = Template.bind({});
-ClickableWithLink.args = {
+export const ClickableCardWithLink = Template.bind({});
+ClickableCardWithLink.args = {
   ...defaultProps,
   href: '/',
+  actionButtonText: '',
 };

--- a/packages/experimental/src/components/Card/_card.scss
+++ b/packages/experimental/src/components/Card/_card.scss
@@ -4,11 +4,26 @@
 @import 'carbon-components/scss/components/button/button';
 
 .#{$pkg-prefix}-card {
-  background: $ui-03;
+  background: $ui-01;
 }
 
 .#{$pkg-prefix}-card--clickable {
   cursor: pointer;
+}
+
+.#{$pkg-prefix}-card--media-left {
+  display: flex;
+  flex-direction: row;
+}
+
+.#{$pkg-prefix}-card--media-left .#{$pkg-prefix}-card-content-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.#{$pkg-prefix}-card--media-left .#{$pkg-prefix}-card-actions {
+  align-self: flex-end;
+  margin-top: auto;
 }
 
 .#{$pkg-prefix}-card-media {
@@ -49,4 +64,9 @@
 .#{$pkg-prefix}-card-link {
   color: inherit;
   text-decoration: inherit;
+}
+
+.#{$pkg-prefix}-card-pictogram {
+  padding-top: $spacing-05;
+  padding-left: $spacing-05;
 }

--- a/packages/experimental/src/components/Card/_storybook-styles.scss
+++ b/packages/experimental/src/components/Card/_storybook-styles.scss
@@ -1,5 +1,11 @@
 @import './index';
 
 .card-demo-container {
-  width: 300px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.card-demo-container--wide {
+  width: 100%;
+  max-width: 900px;
 }


### PR DESCRIPTION
Contributes to #301

* updates to allow different media positioning (https://pages.github.ibm.com/cdai-design/pal/components/card/expressive/style#3.-media-(optional))
* adds `pictogram` option
* changes how `media` in consumed. previously assumed a url and provided an `<img />` tag for that url, but now the consumer will provide the media in component form.

#### Changelog

M       packages/experimental/src/components/Card/Card.js
M       packages/experimental/src/components/Card/Card.stories.js
M       packages/experimental/src/components/Card/_card.scss
M       packages/experimental/src/components/Card/_storybook-styles.scss
