### PR TITLE
fix: script to generate component shell using correct prefix now

### DIFF
--- a/packages/experimental/scripts/generate/templates/DISPLAY_NAME.js
+++ b/packages/experimental/scripts/generate/templates/DISPLAY_NAME.js
@@ -16,7 +16,7 @@ import React from 'react';
 /**
  * TODO: Add use of Carbon prefix if needed
  */
-import { expPrefix /*, carbonPrefix */ } from '../../global/js/settings';
+import { pkgPrefix /*, carbonPrefix */ } from '../../global/js/settings';
 
 const blockClass = `${pkgPrefix}--STYLE_NAME`;
 


### PR DESCRIPTION
Contributes to #349

@AlexanderMelox noticed that the build was breaking it and appears to be caused by 

#### Changelog

**Changed**

`packages/experimental/scripts/generate/templates/DISPLAY_NAME.js`
