### PR TITLE
build(codeql): fix GitHub Action warning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2 # https://github.com/actions/checkout
-        with:
-          fetch-depth: 2
-
-      - if: ${{ github.event_name == 'pull_request' }} # https://github.com/github/codeql-action#usage
-        run: git checkout HEAD^2
 
       - name: Initialize
         uses: github/codeql-action/init@v1


### PR DESCRIPTION
### Resolves #342 

Fix CodeQL GitHub Action warning per https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/troubleshooting-the-codeql-workflow#warning-git-checkout-head2-is-no-longer-necessary