### PR TITLE
fix: unwrap if fragment

### DIFF
--- a/packages/experimental/src/global/js/utils/__tests__/unwrap-if-fragment.test.js
+++ b/packages/experimental/src/global/js/utils/__tests__/unwrap-if-fragment.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import unwrapIfFragment from '../unwrap-if-fragment.js';
+
+describe('unwrap-if-fragment', () => {
+  it('Should handle a fragment with one child', () => {
+    const child = 'a child';
+    const children = [child];
+    const result = unwrapIfFragment(<>{children.map((item) => item)}</>);
+
+    expect(result).toEqual(children);
+  });
+
+  it('Should handle a fragment with multiple children', () => {
+    const child = 'a child';
+    const children = [child, child, child];
+    const result = unwrapIfFragment(<>{children.map((item) => item)}</>);
+
+    expect(result).toEqual(children);
+  });
+
+  it('Should handle a multiple fragments and children', () => {
+    const child = 'a child';
+    const children = [child, child, child];
+    children.push([...children]);
+    const result = unwrapIfFragment(<>{children.map((item) => item)}</>);
+
+    expect(result).toEqual(children.flatMap((child) => child));
+  });
+
+  it('Should handle a nested fragments and children', () => {
+    const child = 'a child';
+    const children = [child, child, child];
+    children.push([...children]);
+    const result = unwrapIfFragment(
+      <>
+        <>{children.map((item) => item)}</>
+        {child}
+      </>
+    );
+
+    const expectedResult = children.flatMap((child) => child);
+    expectedResult.push(child);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('Should handle an array with a lone one child', () => {
+    const child = 'a child';
+    const result = unwrapIfFragment(child);
+
+    expect(result).toEqual([child]);
+  });
+
+  it('Should handle an array with one child', () => {
+    const child = 'a child';
+    const children = [child];
+    const result = unwrapIfFragment(child);
+
+    expect(result).toEqual(children);
+  });
+
+  it('Should handle an array with multiple children', () => {
+    const child = 'a child';
+    const children = [child, child, child];
+    const result = unwrapIfFragment(children);
+
+    expect(result).toEqual(children);
+  });
+
+  it('Should handle an array with multiple children and levels', () => {
+    const child = 'a child';
+    const children = [child, child, child];
+    children.push(...children);
+    const result = unwrapIfFragment(children);
+
+    expect(result).toEqual(children.flatMap((child) => child));
+  });
+});

--- a/packages/experimental/src/global/js/utils/unwrap-if-fragment.js
+++ b/packages/experimental/src/global/js/utils/unwrap-if-fragment.js
@@ -10,21 +10,28 @@ const unwrapIfFragment = (children) => {
   const isFragment = (item) => item && item.type === React.Fragment;
 
   const addChildren = (children) => {
-    for (let child of children) {
-      if (isFragment(child)) {
-        addChildren(child.props.children);
+    const loopOver = (children) => {
+      for (let child of children) {
+        addChildren(child);
+      }
+    };
+
+    // children is nothing, one fragment, array with one or more children, or a single item
+    if (!children) return;
+
+    if (isFragment(children)) {
+      loopOver(children.props.children);
+    } else {
+      if (Array.isArray(children)) {
+        loopOver(children);
       } else {
-        newChildArray.push(child);
+        newChildArray.push(children);
       }
     }
   };
 
-  // nothing, one fragment, one or more children
-  if (isFragment(children)) {
-    addChildren(children.props.children);
-  } else {
-    addChildren(children);
-  }
+  // nothing, one fragment, array with one or more children, or a single item
+  addChildren(children);
 
   return newChildArray;
 };


### PR DESCRIPTION
Contributes to #356

Fixed - unwrapIfFragment failed for a single, non-fragment item.
Also added tests for unwrapIfFragment.

#### Changelog

packages/experimental/src/global/js/utils/__tests__/unwrap-if-fragment.test.js
packages/experimental/src/global/js/utils/unwrap-if-fragment.js