### PR TITLE
feat: add feature flags

### DIFF
--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -11,6 +11,10 @@ import { withCarbonTheme } from '@carbon/storybook-addon-theme/react';
 
 import index from './index.scss';
 
+// Only impacts on experimental stories
+import { getPackageFlags } from '../../experimental/src/global/js/settings';
+getPackageFlags({ component: { enableAll: false } }); // {ExampleComponent: true}});
+
 const Style = ({ children, styles }) => {
   const { unuse, use } = styles;
 

--- a/packages/experimental/src/__tests__/index-test.js
+++ b/packages/experimental/src/__tests__/index-test.js
@@ -5,8 +5,44 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-describe('example-component', () => {
-  it('should work', () => {
-    expect(true).toBe(true);
-  });
+// import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+// import React from 'react';
+
+import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+import React from 'react';
+// import { ExampleComponent } from '../';
+import { pkgPrefix, getPackageFlags } from '../global/js/settings';
+const canaryClass = `${pkgPrefix}--canary`;
+import * as components from '../';
+const name = 'export checks';
+
+describe(name, () => {
+  const testComponents = {};
+  for (const key in components) {
+    if (key.charAt(0) === key.charAt(0).toUpperCase()) {
+      // assume component
+      // TODO: remove this test and check all components
+      if (key === 'ExampleComponent') {
+        testComponents[key] = components[key];
+      }
+    }
+  }
+
+  for (const key in testComponents) {
+    const TestComponent = testComponents[key];
+
+    test('Renders a canary if no package flags set', () => {
+      getPackageFlags({ component: { [key]: false } }, { initAgain: true });
+      const { container } = render(<TestComponent />);
+
+      expect(container.querySelector(`.${canaryClass}`)).not.toBeNull();
+    });
+
+    test('Does not render a canary if package flags set', () => {
+      getPackageFlags({ component: { [key]: true } }, { initAgain: true });
+      const { container } = render(<TestComponent />);
+
+      expect(container.querySelector(`.${canaryClass}`)).toBeNull();
+    });
+  }
 });

--- a/packages/experimental/src/components/ExampleComponent/ExampleComponent-test.js
+++ b/packages/experimental/src/components/ExampleComponent/ExampleComponent-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+import React from 'react';
+import { ExampleComponent } from '.';
+
+import { pkgPrefix, getPackageFlags } from '../../global/js/settings';
+
+const { name } = ExampleComponent;
+const canaryClass = `${pkgPrefix}--canary`;
+const blockClass = `${pkgPrefix}-example-component`;
+
+describe(name, () => {
+  test('has no accessibility violations', async () => {
+    getPackageFlags(
+      { component: { ExampleComponent: true } },
+      { initAgain: true }
+    );
+    const { container } = render(<ExampleComponent />);
+
+    await expect(container).toBeAccessible(name);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  test('Renders a canary if no package flags set', () => {
+    getPackageFlags(undefined, { initAgain: true });
+    const { container } = render(<ExampleComponent />);
+
+    expect(container.querySelector(`.${canaryClass}`)).not.toBeNull();
+  });
+
+  test('Renders an experimental-component flag is enabled', () => {
+    getPackageFlags(
+      { component: { ExampleComponent: true } },
+      { initAgain: true }
+    );
+    const { container } = render(<ExampleComponent />);
+
+    expect(container.querySelector(`.${blockClass}`)).not.toBeNull();
+  });
+});

--- a/packages/experimental/src/components/ExampleComponent/ExampleComponent.js
+++ b/packages/experimental/src/components/ExampleComponent/ExampleComponent.js
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Canary } from '../_Canary';
 import { Button, ButtonSet } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { pkgPrefix } from '../../global/js/settings';
+import { getPackageFlags, pkgPrefix } from '../../global/js/settings';
 import cx from 'classnames';
 
 const blockClass = `${pkgPrefix}-example-component`;
@@ -28,6 +29,10 @@ export const ExampleComponent = ({
   size,
   ...props
 }) => {
+  if (!getPackageFlags().component.ExampleComponent) {
+    return <Canary component="ExampleComponent" />;
+  }
+
   const mode = boxedBorder
     ? `${blockClass}--boxed-set`
     : `${blockClass}--shadow-set`;

--- a/packages/experimental/src/components/_Canary/Canary-test.js
+++ b/packages/experimental/src/components/_Canary/Canary-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+import React from 'react';
+
+import { Canary } from '.';
+
+const { name } = Canary;
+
+describe(name, () => {
+  test('has no accessibility violations', async () => {
+    const { container } = render(<Canary>{name}</Canary>);
+
+    await expect(container).toBeAccessible(name);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  it(`adds content for the ${name}`, () => {
+    expect(render(<Canary>{name}</Canary>).getByText(name)).toBeInTheDocument();
+  });
+
+  test('adds a class to the containing node', () => {
+    const className = 'className';
+
+    expect(
+      render(
+        <Canary className={className}>{name}</Canary>
+      ).container.querySelector(`.${className}`)
+    ).toBeInTheDocument();
+  });
+
+  test('adds additional props to the containing node', () => {
+    const dataTestId = 'dataTestId';
+
+    expect(
+      render(<Canary data-testid={dataTestId}>{name}</Canary>).getByTestId(
+        dataTestId
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/experimental/src/components/_Canary/Canary.js
+++ b/packages/experimental/src/components/_Canary/Canary.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import cx from 'classnames';
+import { string } from 'prop-types';
+import React from 'react';
+
+import { pkgPrefix } from '../../global/js/settings';
+
+const blockClass = `${pkgPrefix}--canary`;
+
+import './_canary.scss';
+
+/**
+ *  Canary component used when the component requested is not yet production
+ */
+export const Canary = ({ component, className, ...rest }) => {
+  const instructions = `import { getPackageFlags } from '../../experimental/src/global/js/settings';
+getPackageFlags({component: {ExampleComponent: true}});`;
+  return (
+    <div className={cx(blockClass, className)} {...rest}>
+      <h2>
+        This component <strong>{component}</strong> is not ready yet.
+      </h2>
+      <p>
+        To enable this initialize package flags before any components are
+        loaded, passing an override object.
+      </p>
+      <br />
+      <p>e.g. in main.js</p>
+      <pre className={`${blockClass}--code`}>{instructions}</pre>
+    </div>
+  );
+};
+
+Canary.propTypes = {
+  /** Provide an optional class to be applied to the containing node */
+  className: string,
+
+  /** Name of the component that is not ready yet */
+  component: string.isRequired,
+};
+
+Canary.defaultProps = {
+  className: null,
+};

--- a/packages/experimental/src/components/_Canary/_canary.scss
+++ b/packages/experimental/src/components/_Canary/_canary.scss
@@ -1,0 +1,16 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../global/styles/carbon-settings'; // goes before carbon imports as it affects how carbon is used.
+@import '../../global/styles/project-settings';
+
+$block-class: #{$pkg-prefix}-canary;
+
+.#{$block-class}--code {
+  padding: $spacing-05;
+  background-color: $ui-01;
+}

--- a/packages/experimental/src/components/_Canary/index.js
+++ b/packages/experimental/src/components/_Canary/index.js
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { getPackageFlags } from './global/js/settings';
-
-export * from './components';
+export { Canary } from './Canary';

--- a/packages/experimental/src/global/js/package-flags.cmn.js
+++ b/packages/experimental/src/global/js/package-flags.cmn.js
@@ -1,0 +1,81 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+const defaultFlags = {
+  // by default only released components are set to true
+  component: {
+    AboutModal: false,
+    ActionBar: false,
+    APIKeyDownlaoder: false,
+    APIKeyModal: false,
+    BreadcrumbWithOverflow: false,
+    Card: false,
+    ContextHeader: false,
+    EmptyState: false,
+    ExampleComponent: false,
+    ExportModal: false,
+    ImportModal: false,
+    ModifiedTabs: false,
+    Notifications: false,
+    PageHeader: false,
+    RemoveDeleteModal: false,
+    SidePanel: false,
+    TagSet: false,
+    TearSheet: false,
+  },
+
+  // feature level flags
+  feature: {
+    'a-new-feature': false,
+  },
+};
+
+const enableAll = (section) => {
+  const result = {};
+  for (const key in section) {
+    result[key] = true;
+  }
+  return result;
+};
+
+const checkEnabled = (flags, overrides = {}) => {
+  const result = {};
+  for (const key in flags) {
+    if (overrides[key]?.enableAll) {
+      // enable all for this section
+      delete overrides[key].enableAll;
+      result[key] = enableAll(flags[key]);
+    } else {
+      result[key] = { ...flags[key], ...(overrides[key] || {}) };
+    }
+  }
+  return result;
+};
+
+const packageFlags = () => {
+  let initialized = false;
+  let flags;
+
+  // doNotUse parameter is intended for dev flags
+  // doNotUse.initAgain causes flags to be refreshed which is handy in tests
+  // an override section containing enableAll=true turns on everything in that section - handy for storybook
+  return (overrides, doNotUse) => {
+    const defaults = { ...defaultFlags };
+
+    if (!initialized || doNotUse?.initAgain === true) {
+      initialized = true;
+
+      flags = checkEnabled(defaults, overrides);
+    }
+
+    return flags;
+  };
+};
+
+const getPackageFlags = packageFlags();
+
+module.exports = getPackageFlags;

--- a/packages/experimental/src/global/js/package-flags.js
+++ b/packages/experimental/src/global/js/package-flags.js
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+import cmn from './package-flags.cmn.js';
+export default cmn;

--- a/packages/experimental/src/global/js/settings.js
+++ b/packages/experimental/src/global/js/settings.js
@@ -1,7 +1,8 @@
 import featureFlags from '../../generated/feature-flags/feature-flags';
+import getPackageFlags from './package-flags';
 import { settings } from 'carbon-components';
 
 const pkgPrefix = 'exp';
 const carbonPrefix = settings.prefix;
 
-export { pkgPrefix, carbonPrefix, featureFlags };
+export { pkgPrefix, carbonPrefix, featureFlags, getPackageFlags };


### PR DESCRIPTION
Contributes to #272

Adds a feature flags strategy for the experimental package.

- Added package-flags with the ability to override
- Turns on all components for storybook
- Added Canary component to use in all exported components
- Adds an index test for experimental/components to check for canary and non-canary 
- Adds canary and non-canary tests to ExampleComponenet
- Export getPackageFlags() from index

NOTE: 
- Use of common js form for package-flags.cmn.js is due to common js files not being able to require ESM. In a separate PR a reorg of flags and common files will generate SCSS flags from JS flags using Carbon technology. WIP on my machine at this point.

TODO:
- Add Canary to all components
- Investigate why storybook/preview cannot import package from @carbon/ibm-cloud-cognitive-experimental

#### Changelog

Use the following command to list changes or manually list out new, changed and
removed files.

M       packages/core/.storybook/preview.js
M       packages/experimental/src/__tests__/index-test.js
A       packages/experimental/src/components/ExampleComponent/ExampleComponent-test.js
M       packages/experimental/src/components/ExampleComponent/ExampleComponent.js
A       packages/experimental/src/components/_Canary/Canary-test.js
A       packages/experimental/src/components/_Canary/Canary.js
A       packages/experimental/src/components/_Canary/_canary.scss
A       packages/experimental/src/components/_Canary/index.js
A       packages/experimental/src/global/js/package-flags.cmn.js
A       packages/experimental/src/global/js/package-flags.js
M       packages/experimental/src/global/js/settings.js
M       packages/experimental/src/index.js