### PR TITLE
Remove AboutModal theme prop and respond to Carbon theme

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -17,29 +17,37 @@ $css--reset: false;
 @import '../generated/feature-flags/feature-flags';
 @import '@carbon/themes/scss/themes';
 
+// Setting attribute storybook-carbon-theme="XXX" on the html element
+// will set the carbon theme used for the storybook pane.
+// Adding class sb--use-carbon-theme-XXX on any element
+// will set the carbon theme used within that element.
 @if map-get($feature-flags, 'enable-css-custom-properties') {
-  :root {
+  :root,
+  .sb--use-carbon-theme-white {
     @include carbon--theme(
       $theme: $carbon--theme--white,
       $emit-custom-properties: true
     );
   }
 
-  :root[storybook-carbon-theme='g10'] {
+  :root[storybook-carbon-theme='g10'],
+  .sb--use-carbon-theme-g10 {
     @include carbon--theme(
       $theme: $carbon--theme--g10,
       $emit-custom-properties: true
     );
   }
 
-  :root[storybook-carbon-theme='g90'] {
+  :root[storybook-carbon-theme='g90'],
+  .sb--use-carbon-theme-g90 {
     @include carbon--theme(
       $theme: $carbon--theme--g90,
       $emit-custom-properties: true
     );
   }
 
-  :root[storybook-carbon-theme='g100'] {
+  :root[storybook-carbon-theme='g100'],
+  .sb--use-carbon-theme-g100 {
     @include carbon--theme(
       $theme: $carbon--theme--g100,
       $emit-custom-properties: true

--- a/packages/experimental/src/components/AboutModal/AboutModal.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.js
@@ -8,6 +8,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import ReactResizeDetector from 'react-resize-detector';
+import classNames from 'classnames';
 import {
   ComposedModal,
   Link,
@@ -21,6 +22,7 @@ import {
 import { pkgPrefix } from '../../global/js/settings';
 
 export const AboutModal = ({
+  className,
   copyrightText,
   legalText,
   links,
@@ -31,7 +33,6 @@ export const AboutModal = ({
   body,
   open,
   technologiesUsed,
-  theme,
 }) => {
   const [hasScrollableContent, setHasScrollableContent] = useState();
   const modalRef = useRef();
@@ -54,18 +55,12 @@ export const AboutModal = ({
       */}
       <div>
         <ComposedModal
-          className={[
-            `${pkgPrefix}-about-modal`,
-            theme === 'dark'
-              ? `${pkgPrefix}-about-modal-dark-theme`
-              : `${pkgPrefix}-about-modal-light-theme`,
-            hasScrollableContent
-              ? `${pkgPrefix}-about-modal-scroll-enabled`
-              : '',
-            technologiesUsed && technologiesUsed.length > 0
-              ? `${pkgPrefix}-about-modal-with-tabs`
-              : '',
-          ].join(' ')}
+          className={classNames(`${pkgPrefix}-about-modal`, {
+            [`${pkgPrefix}-about-modal-scroll-enabled`]: hasScrollableContent,
+            [`${pkgPrefix}-about-modal-with-tabs`]:
+              technologiesUsed && technologiesUsed.length > 0,
+            [className]: className,
+          })}
           open={open}
           ref={modalRef}>
           <div className={`${pkgPrefix}-modal-content`}>
@@ -109,14 +104,10 @@ export const AboutModal = ({
             </ModalBody>
             <ModalFooter>
               {technologiesUsed && technologiesUsed.length ? (
-                <Tabs
-                  className={`${pkgPrefix}-about-modal-tab-container`}
-                  light={theme === 'light'}
-                  aria-label="About modal technology used and version number tabs">
+                <Tabs className={`${pkgPrefix}-about-modal-tab-container`}>
                   <Tab
                     id="about-modal-technologies-used-tab"
-                    label="Technologies used"
-                    aria-label="Technologies used tab">
+                    label="Technologies used">
                     <div
                       className={`${pkgPrefix}-about-modal-tab-content-flex`}>
                       {technologiesUsed &&
@@ -133,8 +124,7 @@ export const AboutModal = ({
                   </Tab>
                   <Tab
                     id="about-modal-version-number-tab"
-                    label="Version number"
-                    aria-label="Version number tab">
+                    label="Version number">
                     <div
                       className={`${pkgPrefix}-about-modal-tab-content-flex ${pkgPrefix}-about-modal-tab-content-version-flex`}>
                       <p className={`${pkgPrefix}-about-modal-version-label`}>
@@ -172,6 +162,12 @@ AboutModal.propTypes = {
    * About modal body content
    */
   body: PropTypes.string.isRequired,
+
+  /**
+   * Specify an optional className to be applied to the modal root node
+   */
+  className: PropTypes.string,
+
   /**
    * About modal product copyright text
    */
@@ -216,10 +212,6 @@ AboutModal.propTypes = {
     })
   ),
   /**
-   * About modal product name
-   */
-  theme: PropTypes.oneOf(['light', 'dark']),
-  /**
    * About modal product version number
    */
   versionNumber: PropTypes.string.isRequired,
@@ -231,5 +223,4 @@ AboutModal.defaultProps = {
   links: [],
   onRequestClose: () => {},
   technologiesUsed: [],
-  theme: 'dark',
 };

--- a/packages/experimental/src/components/AboutModal/AboutModal.mdx
+++ b/packages/experimental/src/components/AboutModal/AboutModal.mdx
@@ -9,7 +9,7 @@ import { AboutModal } from './AboutModal';
 ## Overview
 
 The `AboutModal` modal component provides a way to communicate product
-information to users and sits on top of an applications’ main window.
+information to users and sits on top of an application’s main window.
 
 The `AboutModal` is triggered by a user’s action which appears on top of the
 main page content, and is persistent until dismissed. The purpose of this modal
@@ -19,43 +19,43 @@ completion.
 ### Default About screen modal
 
 <Preview>
-  <Story id="experimental-aboutmodal--default" />
+  <Story id="cloud-cognitive-canary-aboutmodal--default" />
 </Preview>
 
 ### About screen modal with links
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-links" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-links" />
 </Preview>
 
 ### About screen modal with links and legal text
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-links-and-legal-text" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-links-and-legal-text" />
 </Preview>
 
 ### About screen modal with links, legal, and copyright text
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-links-and-legal-and-copyright-text" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-links-and-legal-and-copyright-text" />
 </Preview>
 
 ### About screen modal with technology used tab
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-technology-used-tab" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-technology-used-tab" />
 </Preview>
 
 ### About screen modal with light theme
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-light-theme" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-light-theme" />
 </Preview>
 
 ### About screen modal with scrollable content
 
 <Preview>
-  <Story id="experimental-aboutmodal--with-scroll" />
+  <Story id="xcloud-cognitive-canary-aboutmodal--with-scroll" />
 </Preview>
 
 ## Component API

--- a/packages/experimental/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.stories.js
@@ -43,6 +43,7 @@ const Template = (args) => (
       </>
     }
     versionNumber="0.0.1"
+    className="sb--use-carbon-theme-g90"
     {...args}
   />
 );
@@ -87,6 +88,7 @@ export const Default = () => {
             </>
           }
           versionNumber="0.0.1"
+          className="sb--use-carbon-theme-g90"
         />
       )}
     </ModalStateManager>
@@ -160,7 +162,7 @@ withTechnologyUsedTab.args = {
 
 export const withLightTheme = Template.bind({});
 withLightTheme.args = {
-  theme: 'light',
+  className: 'sb--use-carbon-theme-g10',
 };
 
 export const withScroll = Template.bind({});

--- a/packages/experimental/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.stories.js
@@ -43,7 +43,6 @@ const Template = (args) => (
       </>
     }
     versionNumber="0.0.1"
-    className="sb--use-carbon-theme-g90"
     {...args}
   />
 );
@@ -88,7 +87,6 @@ export const Default = () => {
             </>
           }
           versionNumber="0.0.1"
-          className="sb--use-carbon-theme-g90"
         />
       )}
     </ModalStateManager>
@@ -158,6 +156,11 @@ withTechnologyUsedTab.args = {
       alt: 'Logo for javascript',
     },
   ],
+};
+
+export const withDarkTheme = Template.bind({});
+withDarkTheme.args = {
+  className: 'sb--use-carbon-theme-g90',
 };
 
 export const withLightTheme = Template.bind({});

--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -39,41 +39,13 @@
   width: 100%;
 }
 
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-light-theme {
-  @include carbon--theme($carbon--theme--white, true);
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-light-theme
-  .bx--modal-footer {
-  @include carbon--theme($carbon--theme--g100, true);
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-light-theme
-  .#{$pkg-prefix}-about-modal-tab-container {
-  @include carbon--theme($carbon--theme--white, true);
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-dark-theme {
-  @include carbon--theme($carbon--theme--g100, true);
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-dark-theme
-  .bx--modal-footer {
-  @include carbon--theme($carbon--theme--white, true);
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-dark-theme
-  .#{$pkg-prefix}-about-modal-tab-container {
-  @include carbon--theme($carbon--theme--g100, true);
-}
-
 .#{$pkg-prefix}-about-modal .bx--modal-footer {
   position: relative;
   flex-direction: column;
   grid-row: auto;
   justify-content: center;
   padding-left: $spacing-05;
-  background-color: $ui-background;
+  background-color: $inverse-02;
 }
 
 .#{$pkg-prefix}-about-modal {
@@ -91,6 +63,8 @@
   .#{$pkg-prefix}-about-modal-version-label,
   .#{$pkg-prefix}-about-modal-version-number {
     @include carbon--type-style('body-short-01');
+
+    color: $inverse-01;
   }
   .#{$pkg-prefix}-about-modal-version-label {
     @include carbon--font-weight('semibold');
@@ -148,9 +122,7 @@
 
 .#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-content,
 .#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-legal-text,
-.#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-copyright-text,
-.#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-version-label,
-.#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-version-number {
+.#{$pkg-prefix}-about-modal .#{$pkg-prefix}-about-modal-copyright-text {
   color: $text-01;
 }
 


### PR DESCRIPTION
Contributes to #384

Remove the theme property and respond to Carbon theme instead

#### What did you change?

Removed theme prop, and added className prop to AboutModal. Removed scss related to theme prop. Updated stories to use classes instead to control theme.

#### How did you test and verify your work?

Built, linted, examined result with Storybook.
