### PR TITLE
fix: remove spurious scrollbar when available height is very small

### DIFF
--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -23,8 +23,7 @@
   .bx--modal-container
   .#{$pkg-prefix}-modal-content {
   display: grid;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .#{$pkg-prefix}-modal-content


### PR DESCRIPTION
Contributes to #390

On the containing div there was an `overflow-y: auto` that was causing a spurious and unusable scrollbar to appear when the height was very small.

#### What did you change?

Removed this.

#### How did you test and verify your work?

In storybook, verified that the remaining scroll and scrollbar behaviours are still good.
