### PR TITLE
fix(WebTerminal): move from experimental to canary in storybook

### DIFF
--- a/packages/experimental/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/experimental/src/components/WebTerminal/WebTerminal.stories.js
@@ -9,6 +9,9 @@ import React, { useState, useCallback } from 'react';
 import WebTerminal from './WebTerminal';
 import { Navigation } from './preview-components';
 import mdx from './WebTerminal.mdx';
+import {
+  storybookPrefixCanary as storybookPrefix /* , storybookPrefixReleased */,
+} from '../../../config';
 
 import styles from './_storybook-styles.scss';
 
@@ -77,7 +80,7 @@ export const WithDocumentationLinks = Template.bind({});
 WithDocumentationLinks.args = { documentationLinks };
 
 export default {
-  title: `Experimental/WebTerminal`,
+  title: `${storybookPrefix}/WebTerminal`,
   parameters: {
     styles,
     docs: {


### PR DESCRIPTION
Contributes to #405 

I moved `<WebTerminal />` from `Experimental` to `Canary`.

#### What did you change?
Moved this story from `experimental` to `canary` in our storybook

#### How did you test and verify your work?
Verified that this component is now inside of `canary` and there are no additional components inside `experimental` within storybook.
