### PR TITLE
chore: core is no longer a dependency of experimental

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -48,7 +48,6 @@
     "react-resize-detector": "^5.2.0"
   },
   "devDependencies": {
-    "@carbon/ibm-cloud-cognitive-core": "^0.6.5",
     "chalk": "^4.1.0",
     "fs-extra": "^9.1.0",
     "param-case": "^3.0.4",


### PR DESCRIPTION
core is not a dependency, and flagging it made a loop in the dependency tree causing it to build twice.

#### What did you change?

package.json in experimental

#### How did you test and verify your work?

built experimental
