### PR TITLE
chore: core is no longer a dependency of security

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -49,7 +49,6 @@
     "classnames": "^2.2.6"
   },
   "devDependencies": {
-    "@carbon/ibm-cloud-cognitive-core": "^0.6.6",
     "jest-config": "^0.3.2",
     "npm-run-all": "^4.1.5"
   }


### PR DESCRIPTION
core is not a dependency, and flagging it made a loop in the dependency tree causing it to build twice.

#### What did you change?

package.json in core

#### How did you test and verify your work?

built security