### PR TITLE
fix: canary component warnings

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -32,7 +32,7 @@
     "build:js": "yarn build:js-esm && yarn build:js-cjs",
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js-modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js-modules -d lib",
-    "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js', 'enable-all.js', 'disable-all.js'",
+    "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js','**/enable-all.js','**/disable-all.js'",
     "build:scss": "bundler bundle:scss src/index.scss && copyfiles 'src/**/*.scss' scss -u 1",
     "ci-check": "node scripts/import",
     "clean": "rimraf es lib scss",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -32,7 +32,7 @@
     "build:js": "yarn build:js-esm && yarn build:js-cjs",
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js-modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js-modules -d lib",
-    "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js'",
+    "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js', 'enable-all.js', 'disable-all.js'",
     "build:scss": "bundler bundle:scss src/index.scss && copyfiles 'src/**/*.scss' scss -u 1",
     "ci-check": "node scripts/import",
     "clean": "rimraf es lib scss",

--- a/packages/experimental/src/__tests__/settings.test.js
+++ b/packages/experimental/src/__tests__/settings.test.js
@@ -15,11 +15,13 @@ describe('settings', () => {
     //   pkg.prefix: 'my-prefix',
     // }));
     pkg.prefix = 'my-prefix';
+    pkg._silenceWarnings = true;
     pkg.component.ExampleComponent = true;
 
     // dynamic import so we can modify the import on the component before using it
     const { ExampleComponent } = await import('../components/ExampleComponent');
     const wrapper = shallow(<ExampleComponent />);
+
     expect(wrapper.find('.my-prefix--example-component')).toHaveLength(1);
   });
 });

--- a/packages/experimental/src/enable-all.js
+++ b/packages/experimental/src/enable-all.js
@@ -8,4 +8,5 @@
 // NOTE: This file has a side effect of enabling all component flags
 
 import { pkg } from './settings';
+pkg._silenceWarnings = true;
 pkg.setAllComponents(true);

--- a/packages/experimental/src/global/js/package-settings.js
+++ b/packages/experimental/src/global/js/package-settings.js
@@ -62,21 +62,23 @@ const warningMessageAllComponents =
 const warningMessageAllFeatures =
   'IBM Cloud Cognitive (WARNING): All features enabled through use of setAllFeatures';
 
+let allComponents = false;
+let allFeatures = false;
+let silent = false;
+
 const settings = {
-  _allComponents: false,
-  _allFeatures: false,
   // flags
   prefix: defaults.prefix,
   component: new Proxy(component, {
     set(target, property, value) {
-      if (value) {
+      if (value && !silent) {
         console.warn(warningMessageComponent(property));
       }
       target[property] = value;
       return true; // value set
     },
     get(target, property) {
-      if (settings._allComponents) {
+      if (allComponents) {
         return true;
       }
 
@@ -90,14 +92,14 @@ const settings = {
   }),
   feature: new Proxy(feature, {
     set(target, property, value) {
-      if (value) {
+      if (value && !silent) {
         console.warn(warningMessageFeature(property));
       }
       target[property] = value;
       return true; // value set
     },
     get(target, property) {
-      if (settings._allFeatures) {
+      if (allFeatures) {
         return true;
       }
 
@@ -120,33 +122,30 @@ const settings = {
     return flags.feature[feature];
   },
   setAllComponents: (enabled) => {
-    if (enabled) {
+    if (enabled && !silent) {
       console.warn(warningMessageAllComponents);
     }
-    settings._allComponents = enabled;
+    allComponents = enabled;
   },
   setAllFeatures: (enabled) => {
-    if (enabled) {
+    if (enabled && !silent) {
       console.warn(warningMessageAllFeatures);
     }
-    settings._allFeatures = enabled;
+    allFeatures = enabled;
   },
 };
 
 const settingsProxy = new Proxy(settings, {
   set(target, property, value) {
     switch (property) {
-      case '_allComponentsEnabled':
-        target.setAllComponents(!!value);
-        return true; // value set
-
-      case '_allFeaturesEnabled':
-        target.setAllFeatures(!!value);
+      case '_silenceWarnings':
+        // change secret field
+        silent = value;
         return true; // value set
 
       default:
-        // do nothing
-        return false; // did not set anything
+        target[property] = value;
+        return true; // value set
     }
   },
 });

--- a/packages/experimental/src/settings.js
+++ b/packages/experimental/src/settings.js
@@ -14,8 +14,4 @@ export const carbon = {
   },
 };
 
-export const pkg = {
-  ...pkgSettings,
-};
-
-export default { carbon, pkg };
+export const pkg = pkgSettings;


### PR DESCRIPTION
Contributes to #462 

Experimental was outputting canary warnings during test, these have now been suppressed.

#### What did you change?

- babel config to ignore enable-all and disable-all
- settings.test to disable warnings
- enable-all to disable warnings
- package-settings to facilitate warning suppression and fix prefix update
- settings to correctly export package-settings

#### How did you test and verify your work?
