### PR TITLE
Fixed AboutModal accessibility test failure and re-enable test

### DIFF
--- a/packages/experimental/scripts/generate/templates/DISPLAY_NAME.stories.js
+++ b/packages/experimental/scripts/generate/templates/DISPLAY_NAME.stories.js
@@ -29,9 +29,9 @@ export default {
   // },
   parameters: {
     styles,
-  },
-  docs: {
-    page: mdx,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/experimental/scripts/generate/templates/_STYLE_NAME.scss
+++ b/packages/experimental/scripts/generate/templates/_STYLE_NAME.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';

--- a/packages/experimental/src/components/AboutModal/AboutModal.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.js
@@ -69,8 +69,8 @@ export let AboutModal = React.forwardRef(
       <div className={`${blockClass}__logo`}>{logo}</div>
       <ModalHeader
         className={`${blockClass}__header`}
-        title={title}
-        titleClassName={`${blockClass}__title`}
+        label={title}
+        labelClassName={`${blockClass}__title`}
       />
       <ModalBody className={`${blockClass}__body`}>
         <div className={`${blockClass}__body-content`}>

--- a/packages/experimental/src/components/AboutModal/AboutModal.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.js
@@ -90,8 +90,7 @@ export let AboutModal = React.forwardRef(
           )}
         </div>
       </ModalBody>
-      <ModalFooter>
-        className={`${blockClass}__footer`}
+      <ModalFooter className={`${blockClass}__footer`}>
         {additionalInfo &&
           additionalInfo.length > 0 &&
           (additionalInfo.length === 1 ? (

--- a/packages/experimental/src/components/AboutModal/AboutModal.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.js
@@ -1,13 +1,19 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+// Import portions of React that are needed.
 import React from 'react';
+
+// Other standard imports.
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import cx from 'classnames';
+import { pkg } from '../../settings';
+
+// Carbon and package components we use.
 import {
   ComposedModal,
   ModalHeader,
@@ -17,39 +23,59 @@ import {
   Tab,
 } from 'carbon-components-react';
 
-import { pkg } from '../../settings';
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--about-modal`;
 const componentName = 'AboutModal';
 
-export let AboutModal = ({
-  additionalInfo,
-  className,
-  content,
-  copyrightText,
-  legalText,
-  links,
-  logo,
-  onClose,
-  open,
-  title,
-}) => {
-  return (
+// NOTE: the component SCSS is not imported here: it is rolled up separately.
+
+/**
+ * The AboutModal component provides a way to communicate product information
+ * to users. It is triggered by a user’s action, appears on top of the main
+ * page content, and is persistent until dismissed. The purpose of this modal
+ * should be immediately apparent to the user, with a clear and obvious path
+ * to completion.
+ */
+export let AboutModal = React.forwardRef(
+  (
+    {
+      additionalInfo,
+      className,
+      content,
+      copyrightText,
+      legalText,
+      links,
+      logo,
+      onClose,
+      open,
+      title,
+      // Collect any other property values passed in.
+      ...rest
+    },
+    ref
+  ) => (
     <ComposedModal
-      className={classNames(`${pkg.prefix}-about-modal`, {
-        [`${pkg.prefix}-about-modal-with-tabs`]:
+      {
+        // Pass through any other property values as HTML attributes.
+        ...rest
+      }
+      className={cx(blockClass, {
+        [`${blockClass}--with-tabs`]:
           additionalInfo && additionalInfo.length > 1,
-        [className]: className,
+        // Apply any supplied class names to the main HTML element.
+        [className]: className, // this handles className omitted/falsy
       })}
-      onClose={onClose}
-      open={open}>
-      <div className={`${pkg.prefix}-about-modal-product-logo`}>{logo}</div>
+      {...{ onClose, open, ref }}>
+      <div className={`${blockClass}__logo`}>{logo}</div>
       <ModalHeader
+        className={`${blockClass}__header`}
         title={title}
-        titleClassName={`${pkg.prefix}-about-modal-title`}
+        titleClassName={`${blockClass}__title`}
       />
-      <ModalBody className={`${pkg.prefix}-about-modal-content`}>
-        <div className={`${pkg.prefix}-about-modal-body-content`}>
+      <ModalBody className={`${blockClass}__body`}>
+        <div className={`${blockClass}__body-content`}>
           {content}
-          <div className={`${pkg.prefix}-about-modal-links-container`}>
+          <div className={`${blockClass}__links-container`}>
             {links &&
               links.length > 0 &&
               links.map((link, i) => (
@@ -57,31 +83,28 @@ export let AboutModal = ({
               ))}
           </div>
           {legalText && (
-            <p className={`${pkg.prefix}-about-modal-legal-text`}>
-              {legalText}
-            </p>
+            <p className={`${blockClass}__legal-text`}>{legalText}</p>
           )}
           {copyrightText && (
-            <p className={`${pkg.prefix}-about-modal-copyright-text`}>
-              {copyrightText}
-            </p>
+            <p className={`${blockClass}__copyright-text`}>{copyrightText}</p>
           )}
         </div>
       </ModalBody>
       <ModalFooter>
+        className={`${blockClass}__footer`}
         {additionalInfo &&
           additionalInfo.length > 0 &&
           (additionalInfo.length === 1 ? (
             <>
-              <p className={`${pkg.prefix}-about-modal-version-label`}>
+              <p className={`${blockClass}__version-label`}>
                 {additionalInfo[0].label}
               </p>
-              <p className={`${pkg.prefix}-about-modal-version-number`}>
+              <p className={`${blockClass}__version-number`}>
                 {additionalInfo[0].content}
               </p>
             </>
           ) : (
-            <Tabs className={`${pkg.prefix}-about-modal-tab-container`}>
+            <Tabs className={`${blockClass}__tab-container`}>
               {additionalInfo.map((tab, i) => (
                 <Tab
                   id={'about-modal-tab-' + tab.label}
@@ -94,12 +117,18 @@ export let AboutModal = ({
           ))}
       </ModalFooter>
     </ComposedModal>
-  );
-};
+  )
+);
 
 // Return a placeholder if not released and not enabled by feature flag
 AboutModal = pkg.checkComponentEnabled(AboutModal, componentName);
 
+// The display name of the component, used by React.
+AboutModal.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
 AboutModal.propTypes = {
   /**
    * Additional information to be displayed in the footer. Can be used for
@@ -114,47 +143,54 @@ AboutModal.propTypes = {
       content: PropTypes.node,
     })
   ),
+
   /**
-   * Specify an optional className to be applied to the modal root node
+   * Provide an optional class to be applied to the modal root node.
    */
   className: PropTypes.string,
+
   /**
    * A summary that appears immediately beneath the title, and might
    * include information such as: version name, server name,
    * user name, user role, browser version, browser OS etc.
    */
   content: PropTypes.node.isRequired,
+
   /**
    * Trademark and copyright information. Suggested format for copyright -
    * "Copyright © 2018 Company".
    */
   copyrightText: PropTypes.node,
+
   /**
    * Text providing legal information.
    */
   legalText: PropTypes.node,
+
   /**
    * An array of Carbon `Link` components that contain links to additional
    * information.
    */
   links: PropTypes.arrayOf(PropTypes.element),
+
   /**
    * A visual symbol used to represent the product.
    */
   logo: PropTypes.node.isRequired,
+
   /**
    * Specifies an optional handler which is called when the AboutModal
    * is closed. Returning `false` prevents the AboutModal from closing.
    */
   onClose: PropTypes.func,
+
   /**
    * Specifies whether the AboutModal is open or not.
    */
-  open: PropTypes.bool.isRequired,
+  open: PropTypes.bool,
+
   /**
    * The title of the AboutModal is usually the product or service name.
    */
   title: PropTypes.node.isRequired,
 };
-
-AboutModal.displayName = componentName;

--- a/packages/experimental/src/components/AboutModal/AboutModal.mdx
+++ b/packages/experimental/src/components/AboutModal/AboutModal.mdx
@@ -3,9 +3,15 @@ import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { AboutModal } from '.';
 
-# About modal
+# AboutModal
 
 [About modal usage guidelines](https://pages.github.ibm.com/cdai-design/pal/patterns/about-modal/usage)
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Component API](#component-api)
 
 ## Overview
 
@@ -14,7 +20,7 @@ users. It is triggered by a user’s action, appears on top of the main page
 content, and is persistent until dismissed. The purpose of this modal should be
 immediately apparent to the user, with a clear and obvious path to completion.
 
-## Usage
+## Example usage
 
 <Preview>
   <Story

--- a/packages/experimental/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -7,14 +7,16 @@
 
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Link } from 'carbon-components-react';
 
 import { pkg } from '../../settings';
 import '../../enable-all'; // must come before component is imported (directly or indirectly)
 import { getStorybookPrefix } from '../../../config';
+
 import { AboutModal } from '.';
+
+import { Button, Link } from 'carbon-components-react';
+
 import mdx from './AboutModal.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, AboutModal.displayName);
 
 import ExampleLogo from './_story-assets/example-logo.svg';
 import ansibleLogo from './_story-assets/ansible-logo.png';
@@ -23,14 +25,16 @@ import jsLogo from './_story-assets/js-logo.png';
 
 import styles from './_storybook-styles.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, AboutModal.displayName);
+
 export default {
   title: `${storybookPrefix}/${AboutModal.displayName}`,
   component: AboutModal,
   parameters: {
     styles,
-    docs: {
-      page: mdx,
-    },
+  },
+  docs: {
+    page: mdx,
   },
 };
 
@@ -76,10 +80,9 @@ Template.propTypes = {
   ...AboutModal.propTypes,
 };
 
-export const Basic = Template.bind({});
-Basic.storyName = 'About Modal';
-Basic.args = {
-  story: Basic,
+export const aboutModal = Template.bind({});
+aboutModal.args = {
+  story: aboutModal,
 };
 
 export const withLinksAndLegalAndCopyrightText = Template.bind({});

--- a/packages/experimental/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.stories.js
@@ -32,9 +32,9 @@ export default {
   component: AboutModal,
   parameters: {
     styles,
-  },
-  docs: {
-    page: mdx,
+    docs: {
+      page: mdx,
+    },
   },
 };
 

--- a/packages/experimental/src/components/AboutModal/AboutModal.test.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.test.js
@@ -89,13 +89,13 @@ describe(componentName, () => {
     expect(container.querySelector(`.${blockClass}`)).not.toBeNull();
   });
 
-  /*it('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = render(
       <AboutModal open {...{ content, logo, title }} />
     );
     await expect(container).toBeAccessible(componentName);
     await expect(container).toHaveNoAxeViolations();
-  });*/
+  });
 
   it('renders title and content', () => {
     render(<AboutModal open {...{ content, logo, title }} />);

--- a/packages/experimental/src/components/AboutModal/AboutModal.test.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.test.js
@@ -5,22 +5,56 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { Link } from 'carbon-components-react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
+import { pkg, carbon } from '../../settings';
 import '../../enable-all'; // must come before component is imported (directly or indirectly)
 
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { Link } from 'carbon-components-react';
 import { AboutModal } from '.';
+
 import ExampleLogo from './_story-assets/example-logo.svg';
 import ansibleLogo from './_story-assets/ansible-logo.png';
 import grafanaLogo from './_story-assets/grafana-logo.png';
 import jsLogo from './_story-assets/js-logo.png';
 
-const onCloseReturnsTrue = jest.fn(() => true);
-const onCloseReturnsFalse = jest.fn(() => false);
+const blockClass = `${pkg.prefix}--about-modal`;
+const componentName = AboutModal.displayName;
 
-const content = 'This is example content';
+const { click } = fireEvent;
+
+const additionalInfo = [
+  { label: 'Version number', content: '1.3.41' },
+  {
+    label: 'Technologies used',
+    content: (
+      <>
+        <img
+          src={grafanaLogo}
+          alt="Grafana"
+          className="about-modal-stories--tech-logo"
+        />
+        <img
+          src={ansibleLogo}
+          alt="Ansible"
+          className="about-modal-stories--tech-logo"
+        />
+        <img
+          src={jsLogo}
+          alt="JavaScript"
+          className="about-modal-stories--tech-logo"
+        />
+      </>
+    ),
+  },
+];
+const className = `class-${uuidv4()}`;
+const content = `This is example content: ${uuidv4()}`;
+const copyrightText = `Copyright test text ${uuidv4()}`;
+const dataTestId = uuidv4();
 const logo = (
   <img
     src={ExampleLogo}
@@ -28,184 +62,139 @@ const logo = (
     style={{ maxWidth: '6rem' }}
   />
 );
+const legalText = `Legal test text ${uuidv4()}`;
+const links = [
+  <Link href="https://www.carbondesignsystem.com" key="link1">
+    Carbon Design System
+  </Link>,
+  <Link href="https://www.ibm.com/design/language" key="link2">
+    IBM Design Language
+  </Link>,
+];
+const onCloseReturnsTrue = jest.fn(() => true);
+const onCloseReturnsFalse = jest.fn(() => false);
+const titleText = `Watson ${uuidv4()} Ops`;
 const title = (
   <>
-    IBM <span style={{ fontWeight: '600' }}>Watson AI Ops</span>
+    IBM <span>{titleText}</span>
   </>
 );
+const versionNumber = `1.3.${uuidv4()}`;
 
-describe('AboutModal', () => {
-  test('renders title and content', () => {
-    render(<AboutModal open logo={logo} content={content} title={title} />);
+describe(componentName, () => {
+  it('renders a component AboutModal', () => {
+    const { container } = render(
+      <AboutModal open {...{ content, logo, title }} />
+    );
+    expect(container.querySelector(`.${blockClass}`)).not.toBeNull();
+  });
+
+  /*it('has no accessibility violations', async () => {
+    const { container } = render(
+      <AboutModal open {...{ content, logo, title }} />
+    );
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
+  });*/
+
+  it('renders title and content', () => {
+    render(<AboutModal open {...{ content, logo, title }} />);
     expect(
-      screen.getByText(/Watson AI Ops/i) && screen.getByText(content)
+      screen.getByText(titleText) && screen.getByText(content)
     ).toBeTruthy();
   });
 
-  test('renders product logo', () => {
+  it('renders product logo', () => {
     const { container } = render(
-      <AboutModal open logo={logo} content={content} title={title} />
+      <AboutModal open {...{ content, logo, title }} />
     );
     const renderedProductLogo = container.querySelector('img');
     expect(renderedProductLogo).toBeTruthy();
   });
 
-  test('renders with links', () => {
+  it('renders with links', () => {
     const { getByText, container } = render(
-      <AboutModal
-        content={content}
-        open
-        logo={logo}
-        title={title}
-        links={[
-          <Link href="https://www.carbondesignsystem.com" key="link1">
-            Carbon Design System
-          </Link>,
-          <Link href="https://www.ibm.com/design/language" key="link2">
-            IBM Design Language
-          </Link>,
-        ]}
-      />
+      <AboutModal open {...{ content, links, logo, title }} />
     );
 
-    const { click } = fireEvent;
     const link = container.querySelector('a').href;
     click(getByText('Carbon Design System'));
     expect(link.length && link).toEqual('https://www.carbondesignsystem.com/');
   });
 
-  test('renders legal text', () => {
-    render(
-      <AboutModal
-        open
-        logo={logo}
-        content={content}
-        title={
-          <>
-            IBM <span style={{ fontWeight: '600' }}>Watson AI Ops</span>
-          </>
-        }
-        legalText="Legal test text"
-      />
-    );
-    expect(screen.getByText(/Legal test text/i)).toBeTruthy();
+  it('renders legal text', () => {
+    render(<AboutModal open {...{ content, legalText, logo, title }} />);
+    expect(screen.getByText(legalText)).toBeTruthy();
   });
 
-  test('renders copyright text', () => {
-    render(
-      <AboutModal
-        open
-        logo={logo}
-        content={content}
-        title={title}
-        copyrightText="Copyright test text"
-      />
-    );
-    expect(screen.getByText(/Copyright test text/i)).toBeTruthy();
+  it('renders copyright text', () => {
+    render(<AboutModal open {...{ content, copyrightText, logo, title }} />);
+    expect(screen.getByText(copyrightText)).toBeTruthy();
   });
 
-  test('renders a clickable carbon tab for additional info', () => {
+  it('renders a clickable carbon tab for additional info', () => {
     render(
       <AboutModal
-        content={content}
         open
-        logo={logo}
-        title={title}
-        legalText="This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information."
-        copyrightText="Copyright IBM corporation 2020"
-        additionalInfo={[
-          { label: 'Version number', content: '1.3.41' },
-          {
-            label: 'Technologies used',
-            content: (
-              <>
-                <img
-                  src={grafanaLogo}
-                  alt="Grafana"
-                  className="about-modal-stories--tech-logo"
-                />
-                <img
-                  src={ansibleLogo}
-                  alt="Ansible"
-                  className="about-modal-stories--tech-logo"
-                />
-                <img
-                  src={jsLogo}
-                  alt="JavaScript"
-                  className="about-modal-stories--tech-logo"
-                />
-              </>
-            ),
-          },
-        ]}
+        {...{ additionalInfo, content, copyrightText, legalText, logo, title }}
       />
     );
-    const { click } = fireEvent;
     const tabToSelect = screen.getByRole('tab', { name: /Version number/i });
     click(tabToSelect);
     expect(
       tabToSelect.parentElement.classList.contains(
-        'bx--tabs__nav-item--selected'
+        `${carbon.prefix}--tabs__nav-item--selected`
       )
     ).toBeTruthy();
   });
 
-  test('renders a version number', () => {
+  it('renders a version number', () => {
     const { getByText } = render(
       <AboutModal
         open
-        logo={logo}
-        content={content}
-        title={title}
-        additionalInfo={[{ label: 'Version number', content: '1.3.41' }]}
+        {...{ content, logo, title }}
+        additionalInfo={[{ label: 'Version number', content: versionNumber }]}
       />
     );
-    expect(getByText(/1.3.41/i)).toBeTruthy();
+    expect(getByText(versionNumber)).toBeTruthy();
   });
 
-  test('is visible when open is true', () => {
+  it('is visible when open is true', () => {
     const { container } = render(
       <AboutModal open logo={logo} content={content} title={title} />
     );
-    const aboutModal = container.querySelector('.bx--modal');
+    const aboutModal = container.querySelector(`.${carbon.prefix}--modal`);
     expect(aboutModal.classList.contains('is-visible')).toBeTruthy();
   });
 
-  test('is not visible when open is not true', () => {
+  it('is not visible when open is not true', () => {
     const { container } = render(
-      <AboutModal open={false} logo={logo} content={content} title={title} />
+      <AboutModal open={false} {...{ content, logo, title }} />
     );
-    const aboutModal = container.querySelector('.bx--modal');
+    const aboutModal = container.querySelector(`.${carbon.prefix}--modal`);
     expect(aboutModal.classList.contains('is-visible')).toBeFalsy();
   });
 
-  test('applies className to the root node', () => {
+  it('applies className to the root node', () => {
     const { container } = render(
-      <AboutModal
-        open
-        logo={logo}
-        content={content}
-        title={title}
-        className="test-class"
-      />
+      <AboutModal open {...{ className, content, logo, title }} />
     );
-    const aboutModal = container.querySelector('.bx--modal');
-    expect(aboutModal.classList.contains('test-class')).toBeTruthy();
+    const aboutModal = container.querySelector(`.${carbon.prefix}--modal`);
+    expect(aboutModal.classList.contains(className)).toBeTruthy();
   });
 
-  test('calls onClose() when modal is closed', () => {
+  it('calls onClose() when modal is closed', () => {
     const { container } = render(
       <AboutModal
         open
-        logo={logo}
-        content={content}
-        title={title}
+        {...{ content, logo, title }}
         onClose={onCloseReturnsTrue}
       />
     );
-    const { click } = fireEvent;
-    const aboutModal = container.querySelector('.bx--modal');
-    const closeButton = aboutModal.querySelector('.bx--modal-close');
+    const aboutModal = container.querySelector(`.${carbon.prefix}--modal`);
+    const closeButton = aboutModal.querySelector(
+      `.${carbon.prefix}--modal-close`
+    );
 
     expect(aboutModal.classList.contains('is-visible')).toBeTruthy();
     expect(onCloseReturnsTrue).toHaveBeenCalledTimes(0);
@@ -214,24 +203,40 @@ describe('AboutModal', () => {
     expect(onCloseReturnsTrue).toHaveBeenCalledTimes(1);
   });
 
-  test('calls onClose() when modal is closed and allows veto of close', () => {
+  it('calls onClose() when modal is closed and allows veto of close', () => {
     const { container } = render(
       <AboutModal
         open
-        logo={logo}
-        content={content}
-        title={title}
+        {...{ content, logo, title }}
         onClose={onCloseReturnsFalse}
       />
     );
-    const { click } = fireEvent;
-    const aboutModal = container.querySelector('.bx--modal');
-    const closeButton = aboutModal.querySelector('.bx--modal-close');
+    const aboutModal = container.querySelector(`.${carbon.prefix}--modal`);
+    const closeButton = aboutModal.querySelector(
+      `.${carbon.prefix}--modal-close`
+    );
 
     expect(aboutModal.classList.contains('is-visible')).toBeTruthy();
     expect(onCloseReturnsFalse).toHaveBeenCalledTimes(0);
     click(closeButton);
     expect(aboutModal.classList.contains('is-visible')).toBeTruthy();
     expect(onCloseReturnsFalse).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds additional properties to the containing node', () => {
+    const { container } = render(
+      <AboutModal open {...{ content, logo, title }} data-testid={dataTestId} />
+    );
+    expect(
+      container.querySelector(`.${blockClass}[data-testid="${dataTestId}"]`)
+    ).toBeInTheDocument();
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    render(<AboutModal open {...{ content, logo, ref, title }} />);
+    expect(
+      ref.current.outerModal.current.classList.contains(blockClass)
+    ).toBeTruthy();
   });
 });

--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -43,6 +43,8 @@
 
   .#{$block-class} .#{$block-class}__title {
     @include carbon--type-style('productive-heading-04');
+
+    color: $text-01;
   }
 
   .#{$block-class} .#{$block-class}__body {

--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -35,7 +35,7 @@
     margin: $spacing-05;
   }
 
-  .#{$block-class}.#{$block-class}__header {
+  .#{$block-class} .#{$block-class}__header {
     grid-row: auto;
     margin-bottom: 0;
     padding: 0 20% $spacing-03 $spacing-05;
@@ -60,7 +60,7 @@
     min-height: calc(#{$layout-05} + #{$spacing-08});
   }
 
-  .#{$block-class}.#{$block-class}__body-content {
+  .#{$block-class} .#{$block-class}__body-content {
     margin-bottom: $spacing-09;
   }
 
@@ -69,7 +69,7 @@
     margin-bottom: calc(#{$spacing-09} + #{$spacing-08});
   }
 
-  .#{$block-class}.#{$block-class}__links-container {
+  .#{$block-class} .#{$block-class}__links-container {
     margin-top: $spacing-05;
   }
 

--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -1,123 +1,137 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Imports of Carbon settings and component styles and other
+// related component styles used by ExampleComponent.
 @import '@carbon/themes/scss/themes';
 @import 'carbon-components/scss/globals/scss/_vars.scss';
 @import 'carbon-components/scss/components/link/link';
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/tabs/tabs';
 
-.#{$pkg-prefix}-about-modal {
-  background-color: $ui-background;
+// Define all component styles in a mixin which is then exported using
+// the Carbon import-once mechanism.
+@mixin about-modal {
+  $block-class: #{$pkg-prefix}--about-modal;
+
+  .#{$block-class} {
+    background-color: $ui-background;
+  }
+
+  .#{$block-class} .bx--modal-container {
+    grid-template-rows: auto auto 1fr auto;
+  }
+
+  .#{$block-class}__logo {
+    margin: $spacing-05;
+  }
+
+  .#{$block-class}.#{$block-class}__header {
+    grid-row: auto;
+    margin-bottom: 0;
+    padding: 0 20% $spacing-03 $spacing-05;
+  }
+
+  .#{$block-class} .#{$block-class}__title {
+    @include carbon--type-style('productive-heading-04');
+  }
+
+  .#{$block-class} .#{$block-class}__body {
+    @include carbon--type-style('body-short-02');
+
+    grid-row: auto;
+    min-height: $layout-05;
+    margin-bottom: 0;
+    padding: 0 20% 0 $spacing-05;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  .#{$block-class}.#{$block-class}--with-tabs .#{$block-class}__body {
+    min-height: calc(#{$layout-05} + #{$spacing-08});
+  }
+
+  .#{$block-class}.#{$block-class}__body-content {
+    margin-bottom: $spacing-09;
+  }
+
+  .#{$block-class}.#{$block-class}--with-tabs .#{$block-class}__body-content {
+    // stylelint-disable-next-line carbon/layout-token-use
+    margin-bottom: calc(#{$spacing-09} + #{$spacing-08});
+  }
+
+  .#{$block-class}.#{$block-class}__links-container {
+    margin-top: $spacing-05;
+  }
+
+  .#{$block-class} .#{$block-class}__links-container a + a {
+    margin-left: $spacing-03;
+    padding-left: $spacing-03;
+    border-left: 1px solid $text-01;
+  }
+
+  .#{$block-class} .#{$block-class}__legal-text,
+  .#{$block-class} .#{$block-class}__copyright-text {
+    margin-top: $spacing-07;
+    color: $text-03;
+  }
+
+  .#{$block-class} .#{$block-class}__copyright-text {
+    margin-top: $spacing-05;
+  }
+
+  .#{$block-class} .#{$block-class}__footer {
+    position: relative;
+    flex-direction: column;
+    justify-content: center;
+    height: rem(72px);
+    color: $inverse-01;
+    background-color: $inverse-02;
+  }
+
+  .#{$block-class} .#{$block-class}__footer::before {
+    position: absolute;
+    top: calc(-1 * #{$spacing-09});
+    width: 80%;
+    height: $spacing-09;
+    background: linear-gradient(to bottom, transparent, $ui-01 45%);
+    content: '';
+  }
+
+  .#{$block-class}.#{$block-class}--with-tabs .bx--modal-footer::before {
+    // stylelint-disable-next-line carbon/layout-token-use
+    top: calc(-1 * (#{$spacing-09} + #{$spacing-08}));
+    height: calc(#{$spacing-09} + #{$spacing-08});
+    background: linear-gradient(to bottom, transparent, $ui-01 25%);
+  }
+
+  .#{$block-class} .#{$block-class}__tab-container {
+    position: absolute;
+    bottom: 100%;
+  }
+
+  .#{$block-class} .#{$block-class}__version-label,
+  .#{$block-class} .#{$block-class}__version-number {
+    @include carbon--type-style('body-short-01');
+
+    padding-left: $spacing-05;
+    color: $inverse-01;
+  }
+
+  .#{$block-class} .#{$block-class}__version-label {
+    @include carbon--font-weight('semibold');
+  }
 }
 
-.#{$pkg-prefix}-about-modal .bx--modal-container {
-  grid-template-rows: auto auto 1fr auto;
-}
-
-.#{$pkg-prefix}-about-modal-product-logo {
-  margin: $spacing-05;
-}
-
-.#{$pkg-prefix}-about-modal .bx--modal-header {
-  grid-row: auto;
-  margin-bottom: 0;
-  padding: 0 20% $spacing-03 $spacing-05;
-}
-
-.#{$pkg-prefix}-about-modal-title {
-  @include carbon--type-style('productive-heading-04');
-}
-
-.#{$pkg-prefix}-about-modal-content {
-  @include carbon--type-style('body-short-02');
-
-  grid-row: auto;
-  min-height: $layout-05;
-  margin-bottom: 0;
-  padding: 0 20% 0 $spacing-05;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
-.#{$pkg-prefix}-about-modal-with-tabs .#{$pkg-prefix}-about-modal-content {
-  min-height: calc(#{$layout-05} + #{$spacing-08});
-}
-
-.#{$pkg-prefix}-about-modal-body-content {
-  margin-bottom: $spacing-09;
-}
-
-.#{$pkg-prefix}-about-modal-with-tabs .#{$pkg-prefix}-about-modal-body-content {
-  // stylelint-disable-next-line carbon/layout-token-use
-  margin-bottom: calc(#{$spacing-09} + #{$spacing-08});
-}
-
-.#{$pkg-prefix}-about-modal-links-container {
-  margin-top: $spacing-05;
-}
-
-.#{$pkg-prefix}-about-modal-links-container a + a {
-  margin-left: $spacing-03;
-  padding-left: $spacing-03;
-  border-left: 1px solid $text-01;
-}
-
-.#{$pkg-prefix}-about-modal-legal-text,
-.#{$pkg-prefix}-about-modal-copyright-text {
-  margin-top: $spacing-07;
-  color: $text-03;
-}
-
-.#{$pkg-prefix}-about-modal-copyright-text {
-  margin-top: $spacing-05;
-}
-
-.#{$pkg-prefix}-about-modal .bx--modal-footer {
-  position: relative;
-  flex-direction: column;
-  justify-content: center;
-  height: rem(72px);
-  color: $inverse-01;
-  background-color: $inverse-02;
-}
-
-.#{$pkg-prefix}-about-modal .bx--modal-footer::before {
-  position: absolute;
-  top: calc(-1 * #{$spacing-09});
-  width: 80%;
-  height: $spacing-09;
-  background: linear-gradient(to bottom, transparent, $ui-01 45%);
-  content: '';
-}
-
-.#{$pkg-prefix}-about-modal.#{$pkg-prefix}-about-modal-with-tabs
-  .bx--modal-footer::before {
-  // stylelint-disable-next-line carbon/layout-token-use
-  top: calc(-1 * (#{$spacing-09} + #{$spacing-08}));
-  height: calc(#{$spacing-09} + #{$spacing-08});
-  background: linear-gradient(to bottom, transparent, $ui-01 25%);
-}
-
-.#{$pkg-prefix}-about-modal-tab-container {
-  position: absolute;
-  bottom: 100%;
-}
-
-.#{$pkg-prefix}-about-modal-version-label,
-.#{$pkg-prefix}-about-modal-version-number {
-  @include carbon--type-style('body-short-01');
-
-  padding-left: $spacing-05;
-  color: $inverse-01;
-}
-
-.#{$pkg-prefix}-about-modal-version-label {
-  @include carbon--font-weight('semibold');
+@include exports('about-modal') {
+  @include about-modal;
 }

--- a/packages/experimental/src/components/AboutModal/_index.scss
+++ b/packages/experimental/src/components/AboutModal/_index.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/experimental/src/components/AboutModal/_storybook-styles.scss
+++ b/packages/experimental/src/components/AboutModal/_storybook-styles.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,3 +12,8 @@
   margin-right: $spacing-05;
   object-fit: contain;
 }
+
+// Uncomment next line (which must appear last) to test in storybook
+// that the SCSS styles for this component are sufficently specific
+// to override Carbon whichever order the styles get loaded in.
+//@import 'carbon-components/css/carbon-components.min';

--- a/packages/experimental/src/components/ExampleComponent/ExampleComponent.stories.js
+++ b/packages/experimental/src/components/ExampleComponent/ExampleComponent.stories.js
@@ -26,9 +26,9 @@ export default {
   },
   parameters: {
     styles,
-  },
-  docs: {
-    page: mdx,
+    docs: {
+      page: mdx,
+    },
   },
 };
 


### PR DESCRIPTION
Contributes to #393

AboutModal failed an accessibility check for not labelling the dialog, which is actually behaviour inherited from ComposedModal. It turns out ComposedModal will label the dialog automatically from a `label` but not from a `title`. I don't understand the logic of that, but switching to use `label` is a simple way to resolve that accessibility issue.

#### What did you change?

AboutModal.js and .scss and .test.js

#### How did you test and verify your work?

Ran all tests.