### PR TITLE
Fixed AboutModal accessibility test failure and re-enable test

### DIFF
--- a/packages/experimental/src/components/AboutModal/AboutModal.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.js
@@ -69,8 +69,8 @@ export let AboutModal = React.forwardRef(
       <div className={`${blockClass}__logo`}>{logo}</div>
       <ModalHeader
         className={`${blockClass}__header`}
-        title={title}
-        titleClassName={`${blockClass}__title`}
+        label={title}
+        labelClassName={`${blockClass}__title`}
       />
       <ModalBody className={`${blockClass}__body`}>
         <div className={`${blockClass}__body-content`}>

--- a/packages/experimental/src/components/AboutModal/AboutModal.test.js
+++ b/packages/experimental/src/components/AboutModal/AboutModal.test.js
@@ -89,13 +89,13 @@ describe(componentName, () => {
     expect(container.querySelector(`.${blockClass}`)).not.toBeNull();
   });
 
-  /*it('has no accessibility violations', async () => {
+  it('has no accessibility violations', async () => {
     const { container } = render(
       <AboutModal open {...{ content, logo, title }} />
     );
     await expect(container).toBeAccessible(componentName);
     await expect(container).toHaveNoAxeViolations();
-  });*/
+  });
 
   it('renders title and content', () => {
     render(<AboutModal open {...{ content, logo, title }} />);

--- a/packages/experimental/src/components/AboutModal/_about-modal.scss
+++ b/packages/experimental/src/components/AboutModal/_about-modal.scss
@@ -43,6 +43,8 @@
 
   .#{$block-class} .#{$block-class}__title {
     @include carbon--type-style('productive-heading-04');
+
+    color: $text-01;
   }
 
   .#{$block-class} .#{$block-class}__body {


### PR DESCRIPTION
Contributes to #393

AboutModal failed an accessibility check for not labelling the dialog, which is actually behaviour inherited from ComposedModal. It turns out ComposedModal will label the dialog automatically from a `label` but not from a `title`. I don't understand the logic of that, but switching to use `label` is a simple way to resolve that accessibility issue.

#### What did you change?

AboutModal.js and .scss and .test.js

#### How did you test and verify your work?

Ran all tests.