### PR TITLE
fix: shallow copies of settings were losing proxy behaviour

### DIFF
--- a/packages/experimental/src/__tests__/settings.test.js
+++ b/packages/experimental/src/__tests__/settings.test.js
@@ -15,7 +15,7 @@ describe('settings', () => {
     //   pkg.prefix: 'my-prefix',
     // }));
     pkg.prefix = 'my-prefix';
-    pkg._silenceWarnings = true;
+    pkg._silenceWarnings(true);
     pkg.component.ExampleComponent = true;
 
     // dynamic import so we can modify the import on the component before using it

--- a/packages/experimental/src/enable-all.js
+++ b/packages/experimental/src/enable-all.js
@@ -8,5 +8,5 @@
 // NOTE: This file has a side effect of enabling all component flags
 
 import { pkg } from './settings';
-pkg._silenceWarnings = true;
+pkg._silenceWarnings(true);
 pkg.setAllComponents(true);


### PR DESCRIPTION
Contributes to #462 

Experimental was still outputting canary warnings during test, these have now been suppressed even more. Shallow copies of package-settings, such as that made by settings.js, did not inherit the proxy behaviour. I've made the silencer into a method instead, and optimised the structures a bit since it's now (hopefully) in a final form.

#### What did you change?

package-settings.js

#### How did you test and verify your work?

Ran the tests.
