### PR TITLE
fix: suppress console errors from required props during index tests

### DIFF
--- a/packages/experimental/src/__tests__/index-all-disabled.test.js
+++ b/packages/experimental/src/__tests__/index-all-disabled.test.js
@@ -17,6 +17,12 @@ import * as components from '../index-all-disabled';
 const name = 'export checks';
 
 describe(name, () => {
+  beforeAll(() => {
+    // The component instantiations that follow will generate a stack of
+    // console errors about required props not provided, and we don't care.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   for (const key in components) {
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       // TODO: remove this test and check all components
@@ -24,9 +30,8 @@ describe(name, () => {
 
       const TestComponent = components[key];
 
-      test(`Renders a canary, for "${key}", if no package flags set`, () => {
+      it(`Renders a canary, for "${key}", if no package flags set`, () => {
         const { container } = render(<TestComponent />);
-
         expect(container.querySelector(`.${canaryClass}`)).not.toBeNull();
       });
     }

--- a/packages/experimental/src/__tests__/index-all-enabled.test.js
+++ b/packages/experimental/src/__tests__/index-all-enabled.test.js
@@ -17,6 +17,12 @@ import * as components from '../index-all-enabled';
 const name = 'export checks';
 
 describe(name, () => {
+  beforeAll(() => {
+    // The component instantiations that follow will generate a stack of
+    // console errors about required props not provided, and we don't care.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   for (const key in components) {
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       // TODO: remove this test and check all components
@@ -24,9 +30,8 @@ describe(name, () => {
 
       const TestComponent = components[key];
 
-      test(`Does not render a canary, for "${key}", if package flags set`, () => {
+      it(`Does not render a canary, for "${key}", if package flags set`, () => {
         const { container } = render(<TestComponent />);
-
         expect(container.querySelector(`.${canaryClass}`)).toBeNull();
       });
     }

--- a/packages/experimental/src/__tests__/index.test.js
+++ b/packages/experimental/src/__tests__/index.test.js
@@ -17,6 +17,12 @@ const name = 'export checks';
 const canaryClass = `${pkg.prefix}-canary`;
 
 describe(name, () => {
+  beforeAll(() => {
+    // The component instantiations that follow will generate a stack of
+    // console errors about required props not provided, and we don't care.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   for (const key in components) {
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       const TestComponent = components[key];

--- a/packages/experimental/src/__tests__/settings.test.js
+++ b/packages/experimental/src/__tests__/settings.test.js
@@ -3,24 +3,23 @@ import { pkg } from '../settings';
 import { shallow } from 'enzyme';
 
 describe('settings', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
   it('uses the default css prefix', () => {
     expect(pkg.prefix).toEqual('exp');
   });
 
   it('can use custom prefix with a react component', async () => {
-    // jest.mock('./settings', () => ({
-    //   pkg.prefix: 'my-prefix',
-    // }));
     pkg.prefix = 'my-prefix';
     pkg._silenceWarnings = true;
     pkg.component.ExampleComponent = true;
 
     // dynamic import so we can modify the import on the component before using it
     const { ExampleComponent } = await import('../components/ExampleComponent');
-    const wrapper = shallow(<ExampleComponent />);
+    const wrapper = shallow(
+      <ExampleComponent
+        primaryButtonLabel="primary"
+        secondaryButtonLabel="secondary"
+      />
+    );
 
     expect(wrapper.find('.my-prefix--example-component')).toHaveLength(1);
   });


### PR DESCRIPTION
Contributes to #462

The index tests instantiate a stack of components (well, at the moment, only ExampleComponent, but even that has two required props) with no props to test the Canary behaviour. Missing off required props causes console errors, expected but not relevant to the tests. Suppressing these cleans up the test output a bit more.

#### What did you change?

index-all-disabled.test.js, index-all-enabled.test.js, index.test.js and settings.test.js

#### How did you test and verify your work?

Ran all the tests.