### PR TITLE
fix(SidePanel): should fix focus trap which is breaking the side panel

### DIFF
--- a/packages/cloud-cognitive/src/global/js/utils/__tests__/wrap-focus.test.js
+++ b/packages/cloud-cognitive/src/global/js/utils/__tests__/wrap-focus.test.js
@@ -1,0 +1,150 @@
+import wrapFocus from '../wrapFocus';
+
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('wrapFocus', () => {
+  let node;
+  let spyInnerModal;
+  let spyButton0;
+  let spyButton2;
+
+  beforeEach(() => {
+    node = document.createElement('div');
+    node.tabIndex = '-1';
+    node.innerHTML = `
+      <button id="outer-preceding"></button>
+      <span
+        id="start-sentinel"
+        tabIndex="0"
+        role="link"
+        class="bx--visually-hidden">
+      </span>
+      <div id="inner-modal" tabindex="-1">
+        <button id="button-0">Button 0</button>
+        <button id="button-1">Button 1</button>
+        <button id="button-2">Button 2</button>
+      </div>
+      <span
+        id="end-sentinel"
+        tabIndex="0"
+        role="link"
+        class="bx--visually-hidden">
+      </span>
+      <button id="outer-following"></button>
+      <div class="bx--tooltip" tabindex="0"></div>
+    `;
+    document.body.appendChild(node);
+    spyInnerModal = jest.spyOn(node.querySelector('#inner-modal'), 'focus');
+    spyButton0 = jest.spyOn(node.querySelector('#button-0'), 'focus');
+    spyButton2 = jest.spyOn(node.querySelector('#button-2'), 'focus');
+  });
+
+  it('runs forward focus-wrap when following outer node is focused on', () => {
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#outer-following'),
+      oldActiveNode: node.querySelector('#button-2'),
+    });
+    expect(spyButton0).toHaveBeenCalled();
+  });
+
+  it('runs forward focus-wrap when following focus sentinel is focused on', () => {
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#end-sentinel'),
+      oldActiveNode: node.querySelector('#button-2'),
+    });
+    expect(spyButton0).toHaveBeenCalled();
+  });
+
+  it('runs reverse focus-wrap when preceding outer node is focused on', () => {
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#outer-preceding'),
+      oldActiveNode: node.querySelector('#button-0'),
+    });
+    expect(spyButton2).toHaveBeenCalled();
+  });
+
+  it('runs reverse focus-wrap when preceding focus sentinel is focused on', () => {
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#start-sentinel'),
+      oldActiveNode: node.querySelector('#button-0'),
+    });
+    expect(spyButton2).toHaveBeenCalled();
+  });
+
+  it('does not run focus-wrap when a floating menu is focused on', () => {
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('.bx--tooltip'),
+      oldActiveNode: node.querySelector('#button-2'),
+    });
+    expect(spyInnerModal).not.toHaveBeenCalled();
+    expect(spyButton0).not.toHaveBeenCalled();
+    expect(spyButton2).not.toHaveBeenCalled();
+  });
+
+  it('uses inner modal node as a escape hatch for focusing for forward focus-wrap', () => {
+    node.querySelector(
+      '#inner-modal'
+    ).innerHTML = `<div id="dummy-old-active-node"></div>`;
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#outer-following'),
+      oldActiveNode: node.querySelector('#dummy-old-active-node'),
+    });
+    expect(spyInnerModal).toHaveBeenCalled();
+  });
+
+  it('uses inner modal node as a escape hatch for focusing for reverse focus-wrap', () => {
+    node.querySelector(
+      '#inner-modal'
+    ).innerHTML = `<div id="dummy-old-active-node"></div>`;
+    wrapFocus({
+      bodyNode: node.querySelector('#inner-modal'),
+      startSentinelNode: node.querySelector('#start-sentinel'),
+      endSentinelNode: node.querySelector('#end-sentinel'),
+      currentActiveNode: node.querySelector('#outer-preceding'),
+      oldActiveNode: node.querySelector('#dummy-old-active-node'),
+    });
+    expect(spyInnerModal).toHaveBeenCalled();
+  });
+
+  afterEach(() => {
+    if (spyButton2) {
+      spyButton2.mockRestore();
+      spyButton2 = null;
+    }
+    if (spyButton0) {
+      spyButton0.mockRestore();
+      spyButton0 = null;
+    }
+    if (spyInnerModal) {
+      spyInnerModal.mockRestore();
+      spyInnerModal = null;
+    }
+    if (node) {
+      node.parentNode.removeChild(node);
+      node = null;
+    }
+  });
+});

--- a/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
+++ b/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
@@ -60,10 +60,7 @@ function wrapFocus({
       currentActiveNode === startTrapNode ||
       comparisonResult & DOCUMENT_POSITION_BROAD_PRECEDING
     ) {
-      let arrayNodes = Array.slice.call(
-        bodyNode.querySelectorAll(selectorTabbable),
-        0
-      );
+      let arrayNodes = Array.from(bodyNode.querySelectorAll(selectorTabbable));
       arrayNodes.reverse();
       const tabbable = arrayNodes.find((elem) => Boolean(elem.offsetParent));
       if (tabbable) {

--- a/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
+++ b/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
@@ -39,6 +39,7 @@ function elementOrParentIsFloatingMenu(
  * @param {Node} options.endTrapNode The DOM node of the focus sentinel the is placed next to `modalNode`.
  * @param {Node} options.currentActiveNode The DOM node that has focus.
  * @param {Node} options.oldActiveNode The DOM node that previously had focus.
+ * @param {Node} [options.selectorsFloatingMenus] The CSS selectors that matches floating menus
  */
 function wrapFocus({
   bodyNode,
@@ -46,12 +47,14 @@ function wrapFocus({
   endTrapNode,
   currentActiveNode,
   oldActiveNode,
+  selectorsFloatingMenus,
 }) {
   if (
     bodyNode &&
     currentActiveNode &&
     oldActiveNode &&
-    !bodyNode.contains(currentActiveNode)
+    !bodyNode.contains(currentActiveNode) &&
+    !elementOrParentIsFloatingMenu(currentActiveNode, selectorsFloatingMenus)
   ) {
     const comparisonResult = oldActiveNode.compareDocumentPosition(
       currentActiveNode


### PR DESCRIPTION
Contributes to #434 

This will _hopefully_ fix the side panel focus trap bug that @AlexanderMelox found. Thanks @joshblack for the help 🙏 

#### What did you change?
Line [63-66 from wrapFocus](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js#L63-L66) is trying to convert an array like node list to an array using `Array.slice.call`, but it should have been `Array.prototype.slice.call`, which can also be achieved by using the static method `Array.from`.

#### How did you test and verify your work?
- Everything still functions as expected in the storybook for the side panel, however this bug has only been able to be reproduced when using the packaged version of the component.
- New tests for `wrapFocus.js` pass, `jest /utils/`