### PR TITLE
Recreate experimental as a passthrough

### DIFF
--- a/packages/cloud-cognitive/src/settings.js
+++ b/packages/cloud-cognitive/src/settings.js
@@ -16,16 +16,12 @@ export const carbon = {
   },
 };
 
-export const pkg = {
-  // If the component is enabled, return it for use. Otherwise
-  // return a Canary placeholder, setting the name of the
-  // replaced component and transferring any properties set.
-  checkComponentEnabled: (component, name) =>
-    pkgSettings.isComponentEnabled(name)
-      ? component
-      : Object.assign(
-          Canary.bind(undefined, { componentName: name }),
-          component
-        ),
-  ...pkgSettings,
-};
+// If the component is enabled, return it for use. Otherwise
+// return a Canary placeholder, setting the name of the
+// replaced component and transferring any properties set.
+pkgSettings.checkComponentEnabled = (component, name) =>
+  pkgSettings.isComponentEnabled(name)
+    ? component
+    : Object.assign(Canary.bind(undefined, { componentName: name }), component);
+
+export const pkg = pkgSettings;

--- a/packages/experimental/.babelrc.js
+++ b/packages/experimental/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require('babel-preset-ibm-cloud-cognitive')();

--- a/packages/experimental/index.js
+++ b/packages/experimental/index.js
@@ -5,4 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from '@carbon/ibm-cloud-cognitive/index-all-enabled.js';
+import { pkg } from '@carbon/ibm-cloud-cognitive';
+pkg.prefix = 'expcanary';
+pkg.setAllComponents(true);
+
+// import the commonJS export from ibm-cloud-cognitive, so this will work
+// when build both as ESM and CJS by Babel
+export * from '@carbon/ibm-cloud-cognitive';

--- a/packages/experimental/index.js
+++ b/packages/experimental/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from '@carbon/ibm-cloud-cognitive/index-all-enabled.js';

--- a/packages/experimental/index.scss
+++ b/packages/experimental/index.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+$pkg-prefix: 'expcanary';
 @import '@carbon/ibm-cloud-cognitive/scss/index';

--- a/packages/experimental/index.scss
+++ b/packages/experimental/index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '@carbon/ibm-cloud-cognitive/scss/index';

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@carbon/ibm-cloud-cognitive",
+  "name": "@carbon/ibm-cloud-cognitive-experimental",
   "description": "Carbon for Cloud & Cognitive UI components",
-  "version": "0.30.6",
+  "version": "0.30.6-canary.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/carbon-design-system/ibm-cloud-cognitive.git",
-    "directory": "packages/cloud-cognitive"
+    "directory": "packages/experimental"
   },
   "bugs": "https://github.com/carbon-design-system/ibm-cloud-cognitive/issues",
   "files": [
@@ -31,33 +31,22 @@
     "build:js": "yarn build:js-esm && yarn build:js-cjs",
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js-modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js-modules -d lib",
-    "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js','**/enable-all.js','**/disable-all.js'",
-    "build:scss": "bundler bundle:scss src/index.scss && copyfiles 'src/**/*.scss' scss -u 1",
+    "build:js-modules": "babel index.js",
+    "build:scss": "bundler bundle:scss index.scss && copyfiles '**/*.scss' scss",
     "ci-check": "node scripts/import",
     "clean": "rimraf es lib css scss",
-    "generate": "cross-env FORCE_COLOR=1 node scripts/generate",
     "postinstall": "carbon-telemetry collect --install",
-    "test": "bundler check 'src/**/*.scss'"
+    "test": "bundler check '**/*.scss'"
   },
   "peerDependencies": {
     "react": "^16.13.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@carbon/ibm-cloud-cognitive-security": "^0.4.12",
-    "@carbon/icons-react": "^10.24.0",
-    "@carbon/import-once": "^10.5.0",
-    "@carbon/telemetry": "^0.0.0-alpha.6",
-    "carbon-components": "^10.30.0",
-    "carbon-components-react": "^7.30.0",
-    "carbon-icons": "^7.0.7",
-    "react-resize-detector": "^5.2.0"
+    "@carbon/ibm-cloud-cognitive": "^0.30.6",
+    "@carbon/telemetry": "^0.0.0-alpha.6"
   },
   "devDependencies": {
-    "chalk": "^4.1.0",
-    "change-case": "^4.1.2",
-    "cross-env": "^7.0.3",
-    "fs-extra": "^9.1.0",
-    "yargs": "^16.2.0"
+    "cross-env": "^7.0.3"
   }
 }

--- a/packages/experimental/scripts/import.js
+++ b/packages/experimental/scripts/import.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = require('@carbon/ibm-cloud-cognitive-core/import')(
+  require('path').resolve(__dirname, '..', 'lib')
+);


### PR DESCRIPTION
Contributes to #363

Add an experimental package as a simple passthrough to ibm-cloud-cognitive

#### What did you change?

added experimental package and files within in

#### How did you test and verify your work?

We're doing that right now.
