### PR TITLE
fix(EmptyState): fix error logs by not having defaults for shared props

### DIFF
--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
@@ -120,9 +120,7 @@ export const EmptyStateProps = {
 export const EmptyStateDefaultProps = {
   heading: 'Start by adding data assets',
   subtext: 'Click Upload assets to upload your data',
-  illustrationTheme: 'light',
   illustrationSize: 'lg',
-  customIllustrationAltText: 'Empty state illustration',
 };
 
 EmptyState.propTypes = EmptyStateProps;


### PR DESCRIPTION
Contributes to #507 

Since the empty states are sharing some default props, there were some components that used them but they are not necessary. 

#### What did you change?
Removed default props not shared by all components, because they end up getting spread onto the outer most element as an html attribute.

#### How did you test and verify your work?
Ran `jest /EmptyStates/` and `jest /Notifications/`, no longer any console errors.