### PR TITLE
fix(HTTPErrors): fix centering issue with HTTPError content

### DIFF
--- a/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
@@ -20,6 +20,8 @@
     &.#{$block-class}-content {
       @include carbon--breakpoint(sm) {
         position: fixed;
+        top: 50%;
+        left: 50%;
         z-index: 2;
         transform: translate(-50%, -150%);
       }


### PR DESCRIPTION
Contributes to #542 

When putting together the code sandbox for the HTTPErrors component I noticed that the content was not properly centered, this will fix that issue.

#### What did you change?
Add missing css properties needed to center the HTTPError content.
