### PR TITLE
chore(Notifications): rework some of the notificaitons tests

### DIFF
--- a/packages/cloud-cognitive/src/components/Notifications/Notifications.test.js
+++ b/packages/cloud-cognitive/src/components/Notifications/Notifications.test.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import React from 'react';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
@@ -23,10 +24,9 @@ describe('Notifications', () => {
   });
 
   it('should toggle do not disturb switch', () => {
-    const { click } = fireEvent;
     const { fn } = jest;
     const onToggle = fn();
-    const { container } = render(
+    render(
       <Notifications
         data={[]}
         open
@@ -35,18 +35,13 @@ describe('Notifications', () => {
       />
     );
 
-    click(
-      container.querySelector(`#${blockClass}__do-not-disturb-toggle-component`)
-    );
+    userEvent.click(screen.getByRole('checkbox', /Do not disturb/i));
     expect(onToggle).toBeCalled();
   });
 
-  it('should render empty state illustration', () => {
-    const { container } = render(
-      <Notifications data={[]} open setOpen={() => {}} />
-    );
-    const renderedEmptyStateSvg = container.querySelector('svg');
-    expect(renderedEmptyStateSvg).toBeTruthy();
+  it('should render notifications empty state', () => {
+    render(<Notifications data={[]} open setOpen={() => {}} />);
+    expect(screen.getByText(/you do not have any notifications/i));
   });
 
   it('should render notification with error state svg', () => {
@@ -134,7 +129,7 @@ describe('Notifications', () => {
   });
 
   it('should render link in notification', () => {
-    const { getByText, container } = render(
+    render(
       <Notifications
         data={[
           {
@@ -153,10 +148,9 @@ describe('Notifications', () => {
         setOpen={() => {}}
       />
     );
-    const { click } = fireEvent;
-    const link = container.querySelectorAll('a')[0].href;
-    click(getByText('View logs'));
-    expect(link.length && link).toEqual('https://www.carbondesignsystem.com/');
+    const logLink = screen.getByText(/view logs/i);
+    userEvent.click(logLink);
+    expect(logLink);
   });
 
   it('should render Read more button', () => {
@@ -176,7 +170,7 @@ describe('Notifications', () => {
         setOpen={() => {}}
       />
     );
-    expect(getByText(/Read more/i)).toBeTruthy();
+    expect(getByText(/read more/i)).toBeTruthy();
   });
 
   it('adds additional properties to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/Notifications/Notifications.test.js
+++ b/packages/cloud-cognitive/src/components/Notifications/Notifications.test.js
@@ -17,48 +17,55 @@ import { Notifications } from '.';
 const blockClass = `${pkg.prefix}--notifications-panel`;
 const dataTestId = uuidv4();
 
+const renderNotifications = ({ ...rest }) =>
+  render(
+    <Notifications
+      {...{
+        open: true,
+        setOpen: () => {},
+        ...rest,
+      }}
+    />
+  );
+
 describe('Notifications', () => {
   it('renders the notification panel', () => {
-    render(<Notifications data={[]} open setOpen={() => {}} />);
+    renderNotifications({
+      data: [],
+    });
     expect(screen.queryAllByText(/Notifications/i)).toBeTruthy();
   });
 
   it('should toggle do not disturb switch', () => {
     const { fn } = jest;
     const onToggle = fn();
-    render(
-      <Notifications
-        data={[]}
-        open
-        onDoNotDisturbChange={onToggle}
-        setOpen={() => {}}
-      />
-    );
+    renderNotifications({
+      onDoNotDisturbChange: onToggle,
+      data: [],
+    });
 
     userEvent.click(screen.getByRole('checkbox', /Do not disturb/i));
     expect(onToggle).toBeCalled();
   });
 
   it('should render notifications empty state', () => {
-    render(<Notifications data={[]} open setOpen={() => {}} />);
+    renderNotifications({
+      data: [],
+    });
     expect(screen.getByText(/you do not have any notifications/i));
   });
 
   it('should render notification with error state svg', () => {
-    const { container } = render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'error',
-            title: 'LogRhythm connection failure',
-            timestamp: new Date(),
-          },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
+    const { container } = renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'error',
+          title: 'LogRhythm connection failure',
+          timestamp: new Date(),
+        },
+      ],
+    });
     const renderedEmptyStateSvg = container.querySelectorAll(
       `svg.${blockClass}__notification-status-icon-error`
     );
@@ -66,20 +73,16 @@ describe('Notifications', () => {
   });
 
   it('should render notification with warning state svg', () => {
-    const { container } = render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'warning',
-            title: 'LogRhythm connection failure',
-            timestamp: new Date(),
-          },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
+    const { container } = renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'warning',
+          title: 'LogRhythm connection failure',
+          timestamp: new Date(),
+        },
+      ],
+    });
     const renderedEmptyStateSvg = container.querySelectorAll(
       `svg.${blockClass}__notification-status-icon-warning`
     );
@@ -87,20 +90,16 @@ describe('Notifications', () => {
   });
 
   it('should render notification with success state svg', () => {
-    const { container } = render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'success',
-            title: 'LogRhythm connection failure',
-            timestamp: new Date(),
-          },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
+    const { container } = renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'success',
+          title: 'LogRhythm connection failure',
+          timestamp: new Date(),
+        },
+      ],
+    });
     const renderedEmptyStateSvg = container.querySelectorAll(
       `svg.${blockClass}__notification-status-icon-success`
     );
@@ -108,20 +107,16 @@ describe('Notifications', () => {
   });
 
   it('should render notification with informational state svg', () => {
-    const { container } = render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'informational',
-            title: 'LogRhythm connection failure',
-            timestamp: new Date(),
-          },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
+    const { container } = renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'informational',
+          title: 'LogRhythm connection failure',
+          timestamp: new Date(),
+        },
+      ],
+    });
     const renderedEmptyStateSvg = container.querySelectorAll(
       `svg.${blockClass}__notification-status-icon-informational`
     );
@@ -129,59 +124,47 @@ describe('Notifications', () => {
   });
 
   it('should render link in notification', () => {
-    render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'informational',
-            title: 'LogRhythm connection failure',
-            timestamp: new Date(),
-            link: {
-              text: 'View logs',
-              url: 'https://www.carbondesignsystem.com/',
-            },
-            onNotificationClick: () => {},
+    renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'informational',
+          title: 'LogRhythm connection failure',
+          timestamp: new Date(),
+          link: {
+            text: 'View logs',
+            url: 'https://www.carbondesignsystem.com/',
           },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
+          onNotificationClick: () => {},
+        },
+      ],
+    });
     const logLink = screen.getByText(/view logs/i);
     userEvent.click(logLink);
     expect(logLink);
   });
 
   it('should render Read more button', () => {
-    const { getByText } = render(
-      <Notifications
-        data={[
-          {
-            id: 0,
-            type: 'informational',
-            title: 'LogRhythm connection failure',
-            description:
-              'Not able to establish connection with provided cluster. Please check your logs and memory allocation to resolve this issue further.',
-            timestamp: new Date(),
-          },
-        ]}
-        open
-        setOpen={() => {}}
-      />
-    );
-    expect(getByText(/read more/i)).toBeTruthy();
+    renderNotifications({
+      data: [
+        {
+          id: 0,
+          type: 'informational',
+          title: 'LogRhythm connection failure',
+          description:
+            'Not able to establish connection with provided cluster. Please check your logs and memory allocation to resolve this issue further.',
+          timestamp: new Date(),
+        },
+      ],
+    });
+    expect(screen.getByText(/read more/i)).toBeTruthy();
   });
 
   it('adds additional properties to the containing node', () => {
-    const { container } = render(
-      <Notifications
-        open
-        setOpen={() => {}}
-        data={[]}
-        data-testid={dataTestId}
-      />
-    );
+    const { container } = renderNotifications({
+      data: [],
+      'data-testid': dataTestId,
+    });
     expect(
       container.querySelector(
         `.${blockClass}__container[data-testid="${dataTestId}"]`
@@ -191,7 +174,10 @@ describe('Notifications', () => {
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
-    render(<Notifications ref={ref} open setOpen={() => {}} data={[]} />);
+    renderNotifications({
+      ref,
+      data: [],
+    });
     expect(
       ref.current.classList.contains(`${blockClass}__container`)
     ).toBeTruthy();


### PR DESCRIPTION
Contributes to #507 

Switch to the preferred `userEvent.click` rather than `fireEvent`. I also refactored some of the tests to remove `querySelector`s in preference of `getByText`/`getByRole` when possible. I also adopted the new rendering approach for the tests based on the example component.

#### What did you change?
`Notifications.test.js`
#### How did you test and verify your work?
`jest /Notifications/`