### PR TITLE
Speed up the storybook build and load

### DIFF
--- a/packages/cloud-cognitive/src/components/APIKeyModal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/_storybook-styles.scss
@@ -1,4 +1,5 @@
-@import './index';
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
 
 .#{$pkg-prefix}--apikey-modal .bx--radio-button-wrapper {
   margin-bottom: $spacing-02;

--- a/packages/cloud-cognitive/src/components/AboutModal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/AboutModal/_storybook-styles.scss
@@ -4,7 +4,8 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';
+
+@import '../../global/styles/carbon-settings';
 
 .about-modal-stories--tech-logo {
   width: 2.25rem;
@@ -12,8 +13,3 @@
   margin-right: $spacing-05;
   object-fit: contain;
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/ActionBar/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ActionBar/_storybook-styles.scss
@@ -4,8 +4,9 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
-@import './index';
+
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
 
 $block-class: #{$pkg-prefix}--action-bar;
 
@@ -22,8 +23,3 @@ $block-class: #{$pkg-prefix}--action-bar;
   white-space: nowrap;
   content: 'NOTE: Containing box only used to show extent of available space';
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_storybook-styles.scss
@@ -4,8 +4,8 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
-@import './index';
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
 
 $block-class: #{$pkg-prefix}-breadcrumb-with-overflow;
 

--- a/packages/cloud-cognitive/src/components/Card/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Card/_storybook-styles.scss
@@ -1,4 +1,3 @@
-@import './index';
 @import '../../global/styles/project-settings';
 @import '../../global/styles/carbon-settings';
 

--- a/packages/cloud-cognitive/src/components/ContextHeader/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ContextHeader/_storybook-styles.scss
@@ -4,5 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-
-@import './index';

--- a/packages/cloud-cognitive/src/components/EmptyStates/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/EmptyStates/_storybook-styles.scss
@@ -4,5 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-
-@import './index';

--- a/packages/cloud-cognitive/src/components/ExampleComponent/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/_storybook-styles.scss
@@ -4,10 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-
-@import './index';
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/ExportModal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ExportModal/_storybook-styles.scss
@@ -1,1 +1,6 @@
-@import './index';
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/cloud-cognitive/src/components/HTTPErrors/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/_storybook-styles.scss
@@ -4,4 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './_http-errors';

--- a/packages/cloud-cognitive/src/components/ImportModal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ImportModal/_storybook-styles.scss
@@ -1,1 +1,6 @@
-@import './index';
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/_storybook-styles.scss
@@ -1,4 +1,6 @@
-@import './index';
-
-@import 'carbon-components/scss/components/modal/modal';
-@import 'carbon-components/scss/components/radio-button/radio-button';
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/cloud-cognitive/src/components/Notifications/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Notifications/_storybook-styles.scss
@@ -4,6 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/ui-shell/ui-shell';

--- a/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
@@ -4,7 +4,6 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';
 
 @import 'carbon-components/scss/components/ui-shell/ui-shell';
 

--- a/packages/cloud-cognitive/src/components/RemoveDeleteModal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/RemoveDeleteModal/_storybook-styles.scss
@@ -1,1 +1,6 @@
-@import './index';
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//

--- a/packages/cloud-cognitive/src/components/Saving/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Saving/_storybook-styles.scss
@@ -5,8 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-@import '../../global/styles/project-settings';
 @import '../../global/styles/carbon-settings';
 
 .saving-story-textarea {

--- a/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
@@ -4,13 +4,8 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/data-table-v2/data-table-v2';
-@import 'carbon-components/scss/components/text-area/text-area';
-@import 'carbon-components/scss/components/text-input/text-input';
-@import 'carbon-components/scss/components/ui-shell/ui-shell';
-@import '@carbon/themes/scss/themes';
+
+@import '../../global/styles/carbon-settings';
 
 $carbon-prefix: side-panel-stories__;
 

--- a/packages/cloud-cognitive/src/components/StatusIcon/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/StatusIcon/_storybook-styles.scss
@@ -4,6 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';
-
-// TODO: @import(s) of additional styles files used by StatusIcon.stories.js

--- a/packages/cloud-cognitive/src/components/TagSet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_storybook-styles.scss
@@ -4,8 +4,9 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
-@import './index';
+
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
 
 $block-class: #{$pkg-prefix}-tag-set;
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
@@ -5,10 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/tabs/tabs';
+@import '../../global/styles/carbon-settings';
 
 .tearsheet-stories__dummy-content-block {
   display: flex;
@@ -54,8 +51,3 @@
 .tearsheet-stories__tabs .#{$carbon-prefix}--tab-content {
   display: none;
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/UserProfileImage/_storybook.scss
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/_storybook.scss
@@ -4,4 +4,3 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import './index';

--- a/packages/cloud-cognitive/src/components/WebTerminal/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/WebTerminal/_storybook-styles.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable  */
-@import './index';
-@import 'carbon-components/scss/components/ui-shell/ui-shell';
+
+@import '../../global/styles/carbon-settings';
 
 .example-terminal {
   padding: $spacing-05;

--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -18,6 +18,9 @@ $css--reset: false;
 @import '../generated/feature-flags/feature-flags';
 @import '@carbon/themes/scss/themes';
 
+@import '@carbon/ibm-cloud-cognitive/css/index.min';
+@import 'carbon-components/css/carbon-components.min';
+
 // Uncomment next line if you want to use Canary in storybook
 //@import '@carbon/ibm-cloud-cognitive/scss/components/_Canary/canary';
 


### PR DESCRIPTION
Instead of importing carbon and package component SCSS into the storybook-styles scss files, keep those files *just* for the style definitions particular to the stories and import built and minimised carbon and package component css into the master storybook scss file. Not only does it make the storybook build and load faster, but it means we are seeing the actual built css in action in our stories.

#### What did you change?

Every component's storybook-styles scss, and the storybook master index.scss.

#### How did you test and verify your work?

Ran storybook
