### PR TITLE
chore(SidePanel): update per review guidance to prep for review

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -162,7 +162,7 @@ export let SidePanel = React.forwardRef(
             (button) => button.kind === 'ghost'
           );
           if (ghostButton.length) {
-            const ghostIndex = primaryActionButtons.findIndex(
+            const ghostIndex = newArray.findIndex(
               (item) => item.kind === 'ghost'
             );
             newArray = changeArrayPosition(
@@ -178,7 +178,7 @@ export let SidePanel = React.forwardRef(
             primaryActionButtons.length - 1
           ); // put the primary button as the last button in the group
           if (ghostButton.length) {
-            const ghostIndex = primaryActionButtons.findIndex(
+            const ghostIndex = newArray.findIndex(
               (item) => item.kind === 'ghost'
             );
             newArray = changeArrayPosition(newArray, ghostIndex, 0); // put the ghost button as the first button in the group

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -1,448 +1,468 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+// Import portions of React that are needed.
 import React, { useState, useEffect, useRef } from 'react';
+
+// Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, InlineLoading } from 'carbon-components-react';
-import { SIDE_PANEL_SIZES } from './constants';
-import { Close20, ArrowLeft20 } from '@carbon/icons-react';
 import wrapFocus from '../../global/js/utils/wrapFocus';
-
 import { pkg } from '../../settings';
+import { changeArrayPosition } from './utils';
+import { SIDE_PANEL_SIZES } from './constants';
 
-const changeArrayPosition = (arr, originalPosition, newPosition) => {
-  let cutOut = arr.splice(originalPosition, 1)[0];
-  arr.splice(newPosition, 0, cutOut);
-  return arr;
-};
+// Carbon and package components we use.
+import { Button, InlineLoading } from 'carbon-components-react';
+import { Close20, ArrowLeft20 } from '@carbon/icons-react';
 
-const blockClass = `${pkg.prefix}-side-panel`;
+const blockClass = `${pkg.prefix}--side-panel`;
 const componentName = 'SidePanel';
 
-export let SidePanel = ({
-  open,
-  setOpen,
-  placement,
-  size,
-  slideIn,
-  pageContentSelector,
-  theme,
-  includeOverlay,
-  titleText,
-  labelText,
-  subtitleText,
-  actionToolbarButtons,
-  children,
-  condensed,
-  primaryActions,
-  animateTitle,
-  currentStep,
-  onNavigationBack,
-  selectorPrimaryFocus,
-  className,
-}) => {
-  const [shouldRender, setRender] = useState(open);
-  const [animationComplete, setAnimationComplete] = useState(false);
-  const [primaryPanelActions, setPrimaryPanelActions] = useState([]);
-  const sidePanelRef = useRef();
-  const sidePanelTitleRef = useRef();
-  const sidePanelOverlayRef = useRef();
-  const startTrapRef = useRef();
-  const endTrapRef = useRef();
-  const sidePanelInnerRef = useRef();
-  const sidePanelCloseRef = useRef();
+// NOTE: the component SCSS is not imported here: it is rolled up separately.
 
-  // set initial focus when side panel opens
-  useEffect(() => {
-    const initialFocus = (focusContainerElement) => {
-      const containerElement = focusContainerElement || sidePanelRef.current;
-      const primaryFocusElement = containerElement
-        ? containerElement.querySelector(selectorPrimaryFocus)
-        : null;
+/**
+ * Side panels keep users in-context of a page while performing tasks like navigating, editing, viewing details, or configuring something new.
+ */
+export let SidePanel = React.forwardRef(
+  (
+    {
+      actionToolbarButtons,
+      animateTitle,
+      children,
+      className,
+      condensed,
+      currentStep,
+      includeOverlay,
+      labelText,
+      onNavigationBack,
+      open,
+      pageContentSelector,
+      placement,
+      primaryActions,
+      selectorPrimaryFocus,
+      setOpen,
+      size,
+      slideIn,
+      subtitleText,
+      theme,
+      titleText,
+      // Collect any other property values passed in.
+      ...rest
+    },
+    ref
+  ) => {
+    const [shouldRender, setRender] = useState(open);
+    const [animationComplete, setAnimationComplete] = useState(false);
+    const [primaryPanelActions, setPrimaryPanelActions] = useState([]);
+    const sidePanelRef = useRef();
+    const sidePanelTitleRef = useRef();
+    const sidePanelOverlayRef = useRef();
+    const startTrapRef = useRef();
+    const endTrapRef = useRef();
+    const sidePanelInnerRef = useRef();
+    const sidePanelCloseRef = useRef();
 
-      if (primaryFocusElement) {
-        return primaryFocusElement;
+    // set initial focus when side panel opens
+    useEffect(() => {
+      const initialFocus = (focusContainerElement) => {
+        const containerElement = focusContainerElement || sidePanelRef.current;
+        const primaryFocusElement = containerElement
+          ? containerElement.querySelector(selectorPrimaryFocus)
+          : null;
+
+        if (primaryFocusElement) {
+          return primaryFocusElement;
+        }
+
+        return sidePanelCloseRef && sidePanelCloseRef.current;
+      };
+
+      const focusButton = (focusContainerElement) => {
+        const target = initialFocus(focusContainerElement);
+        if (target) {
+          target.focus();
+        }
+      };
+      if (open && animationComplete) {
+        focusButton(sidePanelInnerRef.current);
       }
+    }, [selectorPrimaryFocus, open, animationComplete]);
 
-      return sidePanelCloseRef && sidePanelCloseRef.current;
-    };
-
-    const focusButton = (focusContainerElement) => {
-      const target = initialFocus(focusContainerElement);
-      if (target) {
-        target.focus();
+    // Title animaton
+    useEffect(() => {
+      if (open && animateTitle && animationComplete) {
+        const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
+        sidePanelOuter &&
+          sidePanelOuter.addEventListener('scroll', () => {
+            const scrollTop = sidePanelRef.current.scrollTop;
+            const scrollBottom =
+              sidePanelRef.current.scrollHeight -
+              document.documentElement.clientHeight;
+            let scrollPercent = (scrollTop / scrollBottom) * 100;
+            if (scrollPercent >= 25) {
+              sidePanelOuter.classList.add(
+                `${blockClass}__with-condensed-header`
+              );
+            } else if (scrollPercent < 25) {
+              sidePanelOuter.classList.remove(
+                `${blockClass}__with-condensed-header`
+              );
+            }
+          });
       }
-    };
-    if (open && animationComplete) {
-      focusButton(sidePanelInnerRef.current);
-    }
-  }, [selectorPrimaryFocus, open, animationComplete]);
+    }, [open, animateTitle, animationComplete]);
 
-  // Title animaton
-  useEffect(() => {
-    if (open && animateTitle && animationComplete) {
-      const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
-      sidePanelOuter &&
-        sidePanelOuter.addEventListener('scroll', () => {
-          const scrollTop = sidePanelRef.current.scrollTop;
-          const scrollBottom =
-            sidePanelRef.current.scrollHeight -
-            document.documentElement.clientHeight;
-          let scrollPercent = (scrollTop / scrollBottom) * 100;
-          if (scrollPercent >= 25) {
-            sidePanelOuter.classList.add(`${blockClass}-with-condensed-header`);
-          } else if (scrollPercent < 25) {
-            sidePanelOuter.classList.remove(
-              `${blockClass}-with-condensed-header`
-            );
-          }
-        });
-    }
-  }, [open, animateTitle, animationComplete]);
-
-  // click outside functionality if `includeOverlay` prop is set
-  useEffect(() => {
-    const handleOutsideClick = (e) => {
-      if (
-        sidePanelRef.current &&
-        sidePanelOverlayRef.current &&
-        sidePanelOverlayRef.current.contains(e.target)
-      ) {
-        setOpen(!open);
+    // click outside functionality if `includeOverlay` prop is set
+    useEffect(() => {
+      const handleOutsideClick = (e) => {
+        if (
+          sidePanelRef.current &&
+          sidePanelOverlayRef.current &&
+          sidePanelOverlayRef.current.contains(e.target)
+        ) {
+          setOpen(!open);
+        }
+      };
+      if (includeOverlay) {
+        document.addEventListener('click', handleOutsideClick);
       }
-    };
-    if (includeOverlay) {
-      document.addEventListener('click', handleOutsideClick);
-    }
-    return () => {
-      document.removeEventListener('click', handleOutsideClick);
-    };
-  }, [includeOverlay, setOpen, open]);
+      return () => {
+        document.removeEventListener('click', handleOutsideClick);
+      };
+    }, [includeOverlay, setOpen, open]);
 
-  // initialize the side panel to open
-  useEffect(() => {
-    if (open) setRender(true);
-  }, [open]);
+    // initialize the side panel to open
+    useEffect(() => {
+      if (open) setRender(true);
+    }, [open]);
 
-  // used to properly order the primary action buttons according to the designs
-  useEffect(() => {
-    const primaryActionButtons = primaryActions || [];
-    if (primaryActionButtons && primaryActionButtons.length > 1) {
-      const primaryIndex = primaryActionButtons.findIndex(
-        (item) => item.kind === 'primary'
-      );
-      const ghostButton = primaryActionButtons.filter(
-        (button) => button.kind === 'ghost'
-      );
-      let newArray = [];
-      if (
-        size === 'extraSmall' ||
-        size === 'small' ||
-        (size === 'medium' && primaryActionButtons.length > 2)
-      ) {
-        newArray = changeArrayPosition(primaryActionButtons, primaryIndex, 0); // put the primary button as the first button in the group
+    // used to properly order the primary action buttons according to the designs
+    useEffect(() => {
+      const primaryActionButtons = primaryActions || [];
+      if (primaryActionButtons && primaryActionButtons.length > 1) {
+        const primaryIndex = primaryActionButtons.findIndex(
+          (item) => item.kind === 'primary'
+        );
         const ghostButton = primaryActionButtons.filter(
           (button) => button.kind === 'ghost'
         );
-        if (ghostButton.length) {
-          const ghostIndex = primaryActionButtons.findIndex(
-            (item) => item.kind === 'ghost'
+        let newArray = [];
+        if (
+          size === 'extraSmall' ||
+          size === 'small' ||
+          (size === 'medium' && primaryActionButtons.length > 2)
+        ) {
+          newArray = changeArrayPosition(primaryActionButtons, primaryIndex, 0); // put the primary button as the first button in the group
+          const ghostButton = primaryActionButtons.filter(
+            (button) => button.kind === 'ghost'
           );
+          if (ghostButton.length) {
+            const ghostIndex = primaryActionButtons.findIndex(
+              (item) => item.kind === 'ghost'
+            );
+            newArray = changeArrayPosition(
+              newArray,
+              ghostIndex,
+              primaryActionButtons.length - 1
+            ); // put the ghost button as the last button in the group
+          }
+        } else {
           newArray = changeArrayPosition(
-            newArray,
-            ghostIndex,
+            primaryActionButtons,
+            primaryIndex,
             primaryActionButtons.length - 1
-          ); // put the ghost button as the last button in the group
+          ); // put the primary button as the last button in the group
+          if (ghostButton.length) {
+            const ghostIndex = primaryActionButtons.findIndex(
+              (item) => item.kind === 'ghost'
+            );
+            newArray = changeArrayPosition(newArray, ghostIndex, 0); // put the ghost button as the first button in the group
+          }
         }
-      } else {
-        newArray = changeArrayPosition(
-          primaryActionButtons,
-          primaryIndex,
-          primaryActionButtons.length - 1
-        ); // put the primary button as the last button in the group
-        if (ghostButton.length) {
-          const ghostIndex = primaryActionButtons.findIndex(
-            (item) => item.kind === 'ghost'
-          );
-          newArray = changeArrayPosition(newArray, ghostIndex, 0); // put the ghost button as the first button in the group
+        if (newArray.length) {
+          setPrimaryPanelActions([...newArray]);
+        } else {
+          setPrimaryPanelActions([...primaryActionButtons]);
         }
-      }
-      if (newArray.length) {
-        setPrimaryPanelActions([...newArray]);
       } else {
         setPrimaryPanelActions([...primaryActionButtons]);
       }
-    } else {
-      setPrimaryPanelActions([...primaryActionButtons]);
-    }
-  }, [primaryActions, size]);
+    }, [primaryActions, size]);
 
-  // initialize the side panel to close
-  const onAnimationEnd = () => {
-    if (!open) setRender(false);
-    if (sidePanelRef && sidePanelRef.current) {
-      sidePanelRef.current.style.overflow = 'auto';
-    }
-    setAnimationComplete(true);
-  };
-
-  // prevents the side panel from being scrolled during animation
-  const onAnimationStart = () => {
-    if (sidePanelRef && sidePanelRef.current) {
-      sidePanelRef.current.style.overflow = 'hidden';
-    }
-    setAnimationComplete(false);
-  };
-
-  // used to reset margins of the slide in panel when closed/closing
-  useEffect(() => {
-    if (!open && slideIn) {
-      const pageContentElement = document.querySelector(pageContentSelector);
-      if (placement && placement === 'right') {
-        pageContentElement.style.marginRight = 0;
-      } else {
-        pageContentElement.style.marginLeft = 0;
+    // initialize the side panel to close
+    const onAnimationEnd = () => {
+      if (!open) setRender(false);
+      if (sidePanelRef && sidePanelRef.current) {
+        sidePanelRef.current.style.overflow = 'auto';
       }
-    }
-  }, [open, placement, pageContentSelector, slideIn]);
+      setAnimationComplete(true);
+    };
 
-  // used to set margins of content for slide in panel version
-  useEffect(() => {
-    if (shouldRender && slideIn) {
-      const pageContentElement = document.querySelector(pageContentSelector);
-      if (placement && placement === 'right') {
-        pageContentElement.style.marginRight = 0;
-        pageContentElement.style.transition = 'margin-right 250ms';
-        pageContentElement.style.marginRight = SIDE_PANEL_SIZES[size];
-      } else {
-        pageContentElement.style.marginLeft = 0;
-        pageContentElement.style.transition = 'margin-left 250ms';
-        pageContentElement.style.marginLeft = SIDE_PANEL_SIZES[size];
+    // initializes the side panel to open and prevents the side panel from being scrolled during animation
+    const onAnimationStart = () => {
+      if (sidePanelRef && sidePanelRef.current) {
+        sidePanelRef.current.style.overflow = 'hidden';
       }
-    }
-  }, [slideIn, pageContentSelector, placement, shouldRender, size]);
+      setAnimationComplete(false);
+    };
 
-  const setSizeClassName = (panelSize, actions) => {
-    let sizeClassName;
-    if (!actions) {
-      sizeClassName = `${blockClass}-container-`;
-    } else {
-      sizeClassName = `${blockClass}-actions-`;
-    }
-    switch (panelSize) {
-      case 'extraSmall':
-        return (sizeClassName = `${sizeClassName}-extra-small`);
-      case 'small':
-        return (sizeClassName = `${sizeClassName}-small`);
-      case 'medium':
-        return (sizeClassName = `${sizeClassName}-medium`);
-      case 'large':
-        return (sizeClassName = `${sizeClassName}-large`);
-      case 'max':
-        return (sizeClassName = `${sizeClassName}-max`);
-      default:
-        return (sizeClassName = `${sizeClassName}-medium`);
-    }
-  };
+    // used to reset margins of the slide in panel when closed/closing
+    useEffect(() => {
+      if (!open && slideIn) {
+        const pageContentElement = document.querySelector(pageContentSelector);
+        if (placement && placement === 'right') {
+          pageContentElement.style.marginRight = 0;
+        } else {
+          pageContentElement.style.marginLeft = 0;
+        }
+      }
+    }, [open, placement, pageContentSelector, slideIn]);
 
-  const setPrimaryActionsBarClass = (buttonCount) => {
-    let buttonCountClassName = `${blockClass}-actions-container-`;
-    if (buttonCount === 1) {
-      buttonCountClassName = `${buttonCountClassName}-single-action`;
-    } else if (buttonCount === 2) {
-      buttonCountClassName = `${buttonCountClassName}-multi-action`;
-    } else if (buttonCount > 2) {
-      buttonCountClassName = `${buttonCountClassName}-multi-action-3-buttons-or-more`;
-    }
-    return buttonCountClassName;
-  };
+    // used to set margins of content for slide in panel version
+    useEffect(() => {
+      if (shouldRender && slideIn) {
+        const pageContentElement = document.querySelector(pageContentSelector);
+        if (placement && placement === 'right') {
+          pageContentElement.style.marginRight = 0;
+          pageContentElement.style.transition = 'margin-right 250ms';
+          pageContentElement.style.marginRight = SIDE_PANEL_SIZES[size];
+        } else {
+          pageContentElement.style.marginLeft = 0;
+          pageContentElement.style.transition = 'margin-left 250ms';
+          pageContentElement.style.marginLeft = SIDE_PANEL_SIZES[size];
+        }
+      }
+    }, [slideIn, pageContentSelector, placement, shouldRender, size]);
 
-  // adds focus trap functionality
-  const handleBlur = ({
-    target: oldActiveNode,
-    relatedTarget: currentActiveNode,
-  }) => {
-    // focus trap should only be set if the side panel is a `slideOver` type
-    if (open && sidePanelInnerRef && !slideIn) {
-      wrapFocus({
-        bodyNode: sidePanelInnerRef.current,
-        startTrapRef,
-        endTrapRef,
-        currentActiveNode,
-        oldActiveNode,
-      });
-    }
-  };
+    const setSizeClassName = (panelSize, actions) => {
+      let sizeClassName;
+      if (!actions) {
+        sizeClassName = `${blockClass}__container-`;
+      } else {
+        sizeClassName = `${blockClass}__actions-`;
+      }
+      switch (panelSize) {
+        case 'extraSmall':
+          return (sizeClassName = `${sizeClassName}-extra-small`);
+        case 'small':
+          return (sizeClassName = `${sizeClassName}-small`);
+        case 'medium':
+          return (sizeClassName = `${sizeClassName}-medium`);
+        case 'large':
+          return (sizeClassName = `${sizeClassName}-large`);
+        case 'max':
+          return (sizeClassName = `${sizeClassName}-max`);
+        default:
+          return (sizeClassName = `${sizeClassName}-medium`);
+      }
+    };
 
-  const mainPanelClassNames = cx([
-    `${blockClass}-container`,
-    `${blockClass}-container-${theme}`,
-    setSizeClassName(size),
-    {
-      [`${blockClass}-container-right-placement`]: placement === 'right',
-      [`${blockClass}-container-left-placement`]: placement === 'left',
-    },
-  ]);
+    const setPrimaryActionsBarClass = (buttonCount) => {
+      let buttonCountClassName = `${blockClass}__actions-container-`;
+      if (buttonCount === 1) {
+        buttonCountClassName = `${buttonCountClassName}-single-action`;
+      } else if (buttonCount === 2) {
+        buttonCountClassName = `${buttonCountClassName}-multi-action`;
+      } else if (buttonCount > 2) {
+        buttonCountClassName = `${buttonCountClassName}-multi-action-3-buttons-or-more`;
+      }
+      return buttonCountClassName;
+    };
 
-  const primaryActionContainerClassNames = cx([
-    `${blockClass}-actions-container`,
-    setSizeClassName(size, true),
-    setPrimaryActionsBarClass(
-      primaryPanelActions && primaryPanelActions.length
-    ),
-    {
-      [`${blockClass}-actions-container-condensed`]: condensed,
-    },
-  ]);
+    // adds focus trap functionality
+    const handleBlur = ({
+      target: oldActiveNode,
+      relatedTarget: currentActiveNode,
+    }) => {
+      // focus trap should only be set if the side panel is a `slideOver` type
+      if (open && sidePanelInnerRef && !slideIn) {
+        wrapFocus({
+          bodyNode: sidePanelInnerRef.current,
+          startTrapRef,
+          endTrapRef,
+          currentActiveNode,
+          oldActiveNode,
+        });
+      }
+    };
 
-  return shouldRender ? (
-    <>
-      <div
-        id={`${blockClass}-outer`}
-        className={cx(mainPanelClassNames, {
-          [className]: className,
-        })}
-        style={{
-          animation: `${
-            open
-              ? placement === 'right'
-                ? 'sidePanelEntranceRight 250ms'
-                : 'sidePanelEntranceLeft 250ms'
-              : placement === 'right'
-              ? 'sidePanelExitRight 250ms'
-              : 'sidePanelExitLeft 250ms'
-          }`,
-        }}
-        onAnimationEnd={onAnimationEnd}
-        onAnimationStart={onAnimationStart}
-        ref={sidePanelRef}
-        onBlur={handleBlur}>
-        <span
-          ref={startTrapRef}
-          tabIndex="0"
-          role="link"
-          className={`${blockClass}--visually-hidden`}>
-          Focus sentinel
-        </span>
-        <div ref={sidePanelInnerRef}>
-          <div className={`${blockClass}-header`}>
-            {currentStep > 0 && (
+    const mainPanelClassNames = cx([
+      blockClass,
+      `${blockClass}__container`,
+      `${blockClass}__container-${theme}`,
+      setSizeClassName(size),
+      {
+        [`${blockClass}__container-right-placement`]: placement === 'right',
+        [`${blockClass}__container-left-placement`]: placement === 'left',
+      },
+    ]);
+
+    const primaryActionContainerClassNames = cx([
+      `${blockClass}__actions-container`,
+      setSizeClassName(size, true),
+      setPrimaryActionsBarClass(
+        primaryPanelActions && primaryPanelActions.length
+      ),
+      {
+        [`${blockClass}__actions-container-condensed`]: condensed,
+      },
+    ]);
+
+    return shouldRender ? (
+      <>
+        <div
+          {
+            // Pass through any other property values as HTML attributes.
+            ...rest
+          }
+          id={`${blockClass}-outer`}
+          className={cx(mainPanelClassNames, {
+            [className]: className,
+          })}
+          style={{
+            animation: `${
+              open
+                ? placement === 'right'
+                  ? 'sidePanelEntranceRight 250ms'
+                  : 'sidePanelEntranceLeft 250ms'
+                : placement === 'right'
+                ? 'sidePanelExitRight 250ms'
+                : 'sidePanelExitLeft 250ms'
+            }`,
+          }}
+          onAnimationEnd={onAnimationEnd}
+          onAnimationStart={onAnimationStart}
+          onBlur={handleBlur}
+          ref={ref || sidePanelRef}
+          role="complementary">
+          <span
+            ref={startTrapRef}
+            tabIndex="0"
+            role="link"
+            className={`${blockClass}__visually-hidden`}>
+            Focus sentinel
+          </span>
+          <div ref={sidePanelInnerRef}>
+            <div className={`${blockClass}__header`}>
+              {currentStep > 0 && (
+                <Button
+                  kind="ghost"
+                  size="small"
+                  disabled={false}
+                  renderIcon={ArrowLeft20}
+                  iconDescription="Back"
+                  tooltipPosition="right"
+                  tooltipAlignment="center"
+                  className={`${blockClass}__navigation-back-button`}
+                  onClick={() => onNavigationBack((prev) => prev - 1)}
+                />
+              )}
+              {labelText && labelText.length && (
+                <p className={`${blockClass}__label-text`}>{labelText}</p>
+              )}
+              {titleText && titleText.length && (
+                <h2
+                  className={`${blockClass}__title-text`}
+                  ref={sidePanelTitleRef}
+                  title={titleText}>
+                  {titleText}
+                </h2>
+              )}
+              {subtitleText && subtitleText.length && (
+                <p className={`${blockClass}__subtitle-text`}>{subtitleText}</p>
+              )}
+              {actionToolbarButtons && actionToolbarButtons.length && (
+                <div className={`${blockClass}__action-toolbar`}>
+                  {actionToolbarButtons.map((action) => (
+                    <Button
+                      key={action.label}
+                      kind={action.leading ? action.kind : 'ghost'}
+                      size="small"
+                      disabled={false}
+                      renderIcon={action.icon}
+                      iconDescription={action.label}
+                      tooltipPosition="bottom"
+                      tooltipAlignment="center"
+                      className={cx([
+                        `${blockClass}__action-toolbar-button`,
+                        {
+                          [`${blockClass}__action-toolbar-icon-only-button`]: action.icon,
+                          [`${blockClass}__action-toolbar-leading-button`]: !action.icon,
+                        },
+                      ])}
+                      onClick={() => action.onActionToolbarButtonClick()}>
+                      {action.leading ? action.label : ''}
+                    </Button>
+                  ))}
+                </div>
+              )}
               <Button
                 kind="ghost"
                 size="small"
                 disabled={false}
-                renderIcon={ArrowLeft20}
-                iconDescription="Back"
-                tooltipPosition="right"
+                renderIcon={Close20}
+                iconDescription="Close"
+                tooltipPosition="bottom"
                 tooltipAlignment="center"
-                className={`${blockClass}-navigation-back-button`}
-                onClick={() => onNavigationBack((prev) => prev - 1)}
+                className={`${blockClass}__close-button`}
+                onClick={() => setOpen(false)}
+                ref={sidePanelCloseRef}
               />
-            )}
-            {labelText && labelText.length && (
-              <p className={`${blockClass}-label-text`}>{labelText}</p>
-            )}
-            {titleText && titleText.length && (
-              <h2
-                className={`${blockClass}-title-text`}
-                ref={sidePanelTitleRef}
-                title={titleText}>
-                {titleText}
-              </h2>
-            )}
-            {subtitleText && subtitleText.length && (
-              <p className={`${blockClass}-subtitle-text`}>{subtitleText}</p>
-            )}
-            {actionToolbarButtons && actionToolbarButtons.length && (
-              <div className={`${blockClass}-action-toolbar`}>
-                {actionToolbarButtons.map((action) => (
+            </div>
+            <div className={`${blockClass}__body-content`}>{children}</div>
+            {primaryPanelActions && primaryPanelActions.length ? (
+              <div className={primaryActionContainerClassNames}>
+                {primaryPanelActions.map((action, index) => (
                   <Button
-                    key={action.label}
-                    kind={action.leading ? action.kind : 'ghost'}
-                    size="small"
-                    disabled={false}
-                    renderIcon={action.icon}
-                    iconDescription={action.label}
-                    tooltipPosition="bottom"
-                    tooltipAlignment="center"
+                    key={index}
+                    disabled={action.disabled || action.loading || false}
+                    onClick={() => action.onPrimaryActionClick()}
+                    kind={action.kind || 'primary'}
                     className={cx([
-                      `${blockClass}-action-toolbar-button`,
+                      `${blockClass}__primary-action-button`,
                       {
-                        [`${blockClass}-action-toolbar-icon-only-button`]: action.icon,
-                        [`${blockClass}-action-toolbar-leading-button`]: !action.icon,
+                        [`${blockClass}__ghost-button`]:
+                          action.kind === 'ghost',
+                        [`${blockClass}__primary-action-button-condensed`]: condensed,
                       },
-                    ])}
-                    onClick={() => action.onActionToolbarButtonClick()}>
-                    {action.leading ? action.label : ''}
+                    ])}>
+                    {action.label}
+                    {action.loading && <InlineLoading />}
                   </Button>
                 ))}
               </div>
-            )}
-            <Button
-              kind="ghost"
-              size="small"
-              disabled={false}
-              renderIcon={Close20}
-              iconDescription="Close"
-              tooltipPosition="bottom"
-              tooltipAlignment="center"
-              className={`${blockClass}-close-button`}
-              onClick={() => setOpen(false)}
-              ref={sidePanelCloseRef}
-            />
+            ) : null}
           </div>
-          <div className={`${blockClass}-body-content`}>{children}</div>
-          {primaryPanelActions && primaryPanelActions.length ? (
-            <div className={primaryActionContainerClassNames}>
-              {primaryPanelActions.map((action, index) => (
-                <Button
-                  key={index}
-                  disabled={action.disabled || action.loading || false}
-                  onClick={() => action.onPrimaryActionClick()}
-                  kind={action.kind || 'primary'}
-                  className={cx([
-                    `${blockClass}-primary-action-button`,
-                    {
-                      [`${blockClass}-ghost-button`]: action.kind === 'ghost',
-                      [`${blockClass}-primary-action-button-condensed`]: condensed,
-                    },
-                  ])}>
-                  {action.label}
-                  {action.loading && <InlineLoading />}
-                </Button>
-              ))}
-            </div>
-          ) : null}
+          <span
+            ref={endTrapRef}
+            tabIndex="0"
+            role="link"
+            className={`${blockClass}__visually-hidden`}>
+            Focus sentinel
+          </span>
         </div>
-        <span
-          ref={endTrapRef}
-          tabIndex="0"
-          role="link"
-          className={`${blockClass}--visually-hidden`}>
-          Focus sentinel
-        </span>
-      </div>
-      {includeOverlay && (
-        <div
-          ref={sidePanelOverlayRef}
-          className={`${blockClass}-overlay`}
-          style={{
-            animation: `${
-              open
-                ? 'sidePanelOverlayEntrance 250ms'
-                : 'sidePanelOverlayExit 250ms'
-            }`,
-          }}
-        />
-      )}
-    </>
-  ) : null;
-};
+        {includeOverlay && (
+          <div
+            ref={sidePanelOverlayRef}
+            className={`${blockClass}__overlay`}
+            style={{
+              animation: `${
+                open
+                  ? 'sidePanelOverlayEntrance 250ms'
+                  : 'sidePanelOverlayExit 250ms'
+              }`,
+            }}
+          />
+        )}
+      </>
+    ) : null;
+  }
+);
 
 // Return a placeholder if not released and not enabled by feature flag
 SidePanel = pkg.checkComponentEnabled(SidePanel, componentName);

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -9,127 +9,134 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import React from 'react';
 import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
 import { SidePanel } from '.';
 
+const blockClass = `${pkg.prefix}--side-panel`;
+const dataTestId = uuidv4();
+
+const renderSidePanel = ({ ...rest }, children) =>
+  render(
+    <SidePanel
+      {...{
+        open: true,
+        setOpen: () => {},
+        ...rest,
+      }}>
+      {children}
+    </SidePanel>
+  );
+
 describe('SidePanel', () => {
-  test('renders the side panel', () => {
-    render(
-      <SidePanel setOpen={() => {}} open titleText="Test side panel">
-        Body content
-      </SidePanel>
+  it('renders the side panel', () => {
+    renderSidePanel(
+      {
+        titleText: 'Test side panel',
+      },
+      'content'
     );
     expect(screen.queryAllByText(/Test side panel/i)).toBeTruthy();
   });
 
-  test('should render a side panel with an overlay', () => {
-    const { container } = render(
-      <SidePanel open includeOverlay setOpen={() => {}}>
-        Content
-      </SidePanel>
+  it('should render a side panel with an overlay', () => {
+    const { container } = renderSidePanel(
+      {
+        includeOverlay: true,
+      },
+      'content'
     );
-    const overlayElement = container.querySelector(
-      `.${pkg.prefix}-side-panel-overlay`
-    );
+    const overlayElement = container.querySelector(`.${blockClass}__overlay`);
     expect(overlayElement).toBeTruthy();
   });
 
-  test('should render a side panel from the right', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} placement="right">
-        Content
-      </SidePanel>
+  it('should render a side panel from the right', () => {
+    const { container } = renderSidePanel(
+      {
+        placement: 'right',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container-right-placement`
+      `.${blockClass}__container-right-placement`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a side panel from the left', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} placement="left">
-        Content
-      </SidePanel>
+  it('should render a side panel from the left', () => {
+    const { container } = renderSidePanel(
+      {
+        placement: 'left',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container-left-placement`
-    );
-    expect(sidePanelOuter).toBeTruthy();
-  });
-  test('should render a side panel from the left', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} placement="left">
-        Content
-      </SidePanel>
-    );
-    const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container-left-placement`
+      `.${blockClass}__container-left-placement`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render an extra small side panel', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} size="extraSmall">
-        Content
-      </SidePanel>
+  it('should render an extra small side panel', () => {
+    const { container } = renderSidePanel(
+      {
+        size: 'extraSmall',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container--extra-small`
+      `.${blockClass}__container--extra-small`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a small side panel', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} size="small">
-        Content
-      </SidePanel>
+  it('should render a small side panel', () => {
+    const { container } = renderSidePanel(
+      {
+        size: 'small',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container--small`
+      `.${blockClass}__container--small`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a medium side panel', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}}>
-        Content
-      </SidePanel>
-    );
+  it('should render a medium side panel', () => {
+    const { container } = renderSidePanel({}, 'content');
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container--medium`
+      `.${blockClass}__container--medium`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a large side panel', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} size="large">
-        Content
-      </SidePanel>
+  it('should render a large side panel', () => {
+    const { container } = renderSidePanel(
+      {
+        size: 'large',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container--large`
+      `.${blockClass}__container--large`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a max side panel', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} size="max">
-        Content
-      </SidePanel>
+  it('should render a max side panel', () => {
+    const { container } = renderSidePanel(
+      {
+        size: 'max',
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-container--max`
+      `.${blockClass}__container--max`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a slide in panel version', () => {
+  it('should render a slide in panel version', () => {
     const { container } = render(
       <div>
         <SidePanel
@@ -150,31 +157,27 @@ describe('SidePanel', () => {
     expect(style.marginRight).toBe('30rem');
   });
 
-  test('should render one primary action button', () => {
-    render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        primaryActions={[
+  it('should render one primary action button', () => {
+    renderSidePanel(
+      {
+        primaryActions: [
           {
             label: 'Primary button',
             onPrimaryActionClick: () => {},
             kind: 'primary',
           },
-        ]}>
-        Content
-      </SidePanel>
+        ],
+      },
+      'content'
     );
     const submitButtons = screen.queryAllByText('Primary button');
     expect(submitButtons).toHaveLength(1);
   });
 
-  test('should render two action buttons', () => {
-    render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        primaryActions={[
+  it('should render two action buttons', () => {
+    renderSidePanel(
+      {
+        primaryActions: [
           {
             label: 'Action button',
             onPrimaryActionClick: () => {},
@@ -185,109 +188,113 @@ describe('SidePanel', () => {
             onPrimaryActionClick: () => {},
             kind: 'secondary',
           },
-        ]}>
-        Content
-      </SidePanel>
+        ],
+      },
+      'content'
     );
     const submitButtons = screen.queryAllByText('Action button');
     expect(submitButtons).toHaveLength(2);
   });
 
-  test('should render a single ghost action button', () => {
-    const { container } = render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        primaryActions={[
+  it('should render a single ghost action button', () => {
+    const { container } = renderSidePanel(
+      {
+        primaryActions: [
           {
             label: 'Ghost action button',
             onPrimaryActionClick: () => {},
             kind: 'ghost',
           },
-        ]}>
-        Content
-      </SidePanel>
+        ],
+      },
+      'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${pkg.prefix}-side-panel-ghost-button`
+      `.${blockClass}__ghost-button`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
 
-  test('should render a condensed side panel version', () => {
-    render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        condensed
-        primaryActions={[
+  it('should render a condensed side panel version', () => {
+    renderSidePanel(
+      {
+        condensed: true,
+        primaryActions: [
           {
             label: 'Primary button',
             onPrimaryActionClick: () => {},
           },
-        ]}>
-        Content
-      </SidePanel>
+        ],
+      },
+      'content'
     );
     const sidePanelAction = screen.getByText(/Primary button/i);
     expect(
       sidePanelAction.classList.contains(
-        `${pkg.prefix}-side-panel-primary-action-button-condensed`
+        `${blockClass}__primary-action-button-condensed`
       )
     ).toBeTruthy();
   });
 
-  test('should render navigation button', () => {
-    const { container } = render(
-      <SidePanel open setOpen={() => {}} currentStep={1}>
-        Content
-      </SidePanel>
+  it('should render navigation button', () => {
+    const { container } = renderSidePanel(
+      {
+        currentStep: 1,
+      },
+      'content'
     );
     const navigationAction = container.querySelector(
-      `.${pkg.prefix}-side-panel-navigation-back-button`
+      `.${blockClass}__navigation-back-button`
     );
     expect(navigationAction).toBeTruthy();
   });
 
-  test('should click the navigation button', () => {
+  it('should click the navigation button', () => {
     const { fn } = jest;
     const { click } = fireEvent;
     const onNavigationBack = fn();
-    const { container } = render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        currentStep={1}
-        onNavigationBack={onNavigationBack}>
-        Content
-      </SidePanel>
+    const { container } = renderSidePanel(
+      {
+        currentStep: 1,
+        onNavigationBack: onNavigationBack,
+      },
+      'content'
     );
     const navigationAction = container.querySelector(
-      `.${pkg.prefix}-side-panel-navigation-back-button`
+      `.${blockClass}__navigation-back-button`
     );
     click(navigationAction);
     expect(onNavigationBack).toBeCalled();
   });
 
-  test('should click the primary action button', () => {
+  it('should click the primary action button', () => {
     const { fn } = jest;
     const { click } = fireEvent;
     const onPrimaryActionClick = fn();
-    render(
-      <SidePanel
-        open
-        setOpen={() => {}}
-        primaryActions={[
+    renderSidePanel(
+      {
+        primaryActions: [
           {
             label: 'Primary button',
             onPrimaryActionClick,
           },
-        ]}>
-        Content
-      </SidePanel>
+        ],
+      },
+      'content'
     );
     const sidePanelAction = screen.getByText(/Primary button/i);
     click(sidePanelAction);
     expect(onPrimaryActionClick).toBeCalled();
+  });
+
+  it('adds additional properties to the containing node', () => {
+    renderSidePanel({ 'data-testid': dataTestId }, 'content');
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    renderSidePanel({ ref }, 'content');
+    expect(ref.current).toEqual(screen.getByRole('complementary'));
   });
 });

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -245,15 +245,16 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       width: 100%;
       height: $layout-05;
       background-color: $ui-01;
-      &.#{$block-class}-actions--extra-small {
+      border-top: 1px solid $decorative-01;
+      &.#{$block-class}__actions--extra-small {
         @include setActionBarSize($extra-small-panel-size);
         @include smallButtonsStacked();
       }
-      &.#{$block-class}-actions--small {
+      &.#{$block-class}__actions--small {
         @include setActionBarSize($small-panel-size);
         @include smallButtonsStacked();
       }
-      &.#{$block-class}-actions--medium {
+      &.#{$block-class}__actions--medium {
         @include setActionBarSize($medium-panel-size);
 
         flex-direction: row;
@@ -264,7 +265,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
           }
         }
       }
-      &.#{$block-class}-actions--large {
+      &.#{$block-class}__actions--large {
         @include setActionBarSize($large-panel-size);
 
         &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
@@ -280,7 +281,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
           }
         }
       }
-      &.#{$block-class}-actions--max {
+      &.#{$block-class}__actions--max {
         &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
           .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
             width: 50%;
@@ -288,10 +289,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
           }
         }
         &.#{$block-class}__actions-container--single-action {
-          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
-            width: 100%;
-            max-width: 100%;
-          }
+          justify-content: flex-start;
         }
       }
       &.#{$block-class}__actions-container-condensed {
@@ -311,16 +309,16 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       width: 50%;
       max-width: 50%;
     }
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--single-action.#{$block-class}-actions--large
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--single-action.#{$block-class}__actions--large
       .#{$block-class}__primary-action-button,
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action.#{$block-class}-actions--large
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action.#{$block-class}__actions--large
       .#{$block-class}__primary-action-button {
       width: 50%;
       max-width: 50%;
     }
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action-3-buttons-or-more.#{$block-class}-actions--large
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action-3-buttons-or-more.#{$block-class}__actions--large
       .#{$block-class}__primary-action-button,
-    .#{$block-class}__actions-container.#{$block-class}-actions--max
+    .#{$block-class}__actions-container.#{$block-class}__actions--max
       .#{$block-class}__primary-action-button {
       width: 25%;
       max-width: 25%;

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -14,38 +14,12 @@
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/inline-loading/inline-loading';
 
-$block-class: #{$pkg-prefix}-side-panel;
+$block-class: #{$pkg-prefix}--side-panel;
 $extra-small-panel-size: 16rem;
 $small-panel-size: 20rem;
 $medium-panel-size: 30rem;
 $large-panel-size: 40rem;
 $max-panel-size: 75%; // set max-width on max panels to 75%
-
-@keyframes sidePanelExitLeft {
-  0% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  100% {
-    // stylelint-disable-next-line carbon/layout-token-use
-    transform: translateX(-#{$medium-panel-size});
-
-    opacity: 0;
-  }
-}
-
-@keyframes sidePanelExitRight {
-  0% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  100% {
-    // stylelint-disable-next-line carbon/layout-token-use
-    transform: translateX($medium-panel-size);
-
-    opacity: 0;
-  }
-}
 
 @mixin sidePanelEntranceRight($size: $medium-panel-size) {
   @keyframes sidePanelEntranceRight {
@@ -92,287 +66,320 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
 
 @mixin smallButtonsStacked {
   flex-direction: column;
-  &.#{$block-class}-actions-container--multi-action-3-buttons-or-more
+  &.#{$block-class}__actions-container--multi-action-3-buttons-or-more
     .#{$block-class}-primary-action-button,
-  &.#{$block-class}-actions-container--multi-action
+  &.#{$block-class}__actions-container--multi-action
     .#{$block-class}-primary-action-button {
     width: 100%;
     max-width: 100%;
   }
 }
 
-.#{$block-class}-container {
-  &.#{$block-class}-container-light {
-    @include carbon--theme($carbon--theme--g10, true);
-  }
-  &.#{$block-class}-container-dark,
-  &.#{$block-class}-container-dark .#{$block-class}-body-content {
-    @include carbon--theme($carbon--theme--g100, true);
-  }
-
-  position: fixed;
-  top: $spacing-09;
-  z-index: 3;
-  box-sizing: border-box;
-  min-width: $medium-panel-size; // set default panel size
-  max-width: $medium-panel-size; // set default panel size
-  height: calc(100% - 3rem);
-  overflow: auto;
-  color: $text-01;
-  background-color: $ui-01;
-  transition: transform $duration--moderate-02;
-  transition-timing-function: carbon--motion(standard);
-  &.#{$block-class}-container-right-placement {
-    right: 0;
-    border-left: 1px solid $decorative-01;
-  }
-  &.#{$block-class}-container-right-placement.#{$block-class}-container--extra-small {
-    @include sidePanelEntrance(right, $extra-small-panel-size);
-  }
-  &.#{$block-class}-container-right-placement.#{$block-class}-container--small {
-    @include sidePanelEntrance(right, $small-panel-size);
-  }
-  &.#{$block-class}-container-right-placement.#{$block-class}-container--medium {
-    @include sidePanelEntrance(right, $medium-panel-size);
-  }
-  &.#{$block-class}-container-right-placement.#{$block-class}-container--large {
-    @include sidePanelEntrance(right, $large-panel-size);
-  }
-  &.#{$block-class}-container-right-placement.#{$block-class}-container--max {
-    @include sidePanelEntrance(right, $max-panel-size);
-  }
-  &.#{$block-class}-container-left-placement {
-    left: 0;
-    border-right: 1px solid $decorative-01;
-  }
-  &.#{$block-class}-container-left-placement.#{$block-class}-container--extra-small {
-    @include sidePanelEntrance(left, $extra-small-panel-size);
-  }
-  &.#{$block-class}-container-left-placement.#{$block-class}-container--small {
-    @include sidePanelEntrance(left, $small-panel-size);
-  }
-  &.#{$block-class}-container-left-placement.#{$block-class}-container--medium {
-    @include sidePanelEntrance(left, $medium-panel-size);
-  }
-  &.#{$block-class}-container-left-placement.#{$block-class}-container--large {
-    @include sidePanelEntrance(left, $large-panel-size);
-  }
-  &.#{$block-class}-container-left-placement.#{$block-class}-container--max {
-    @include sidePanelEntrance(left, $max-panel-size);
-  }
-  &.#{$block-class}-with-condensed-header {
-    .#{$block-class}-title-text {
-      @include carbon--type-style('productive-heading-02');
+@mixin side-panel {
+  @keyframes sidePanelExitLeft {
+    0% {
+      transform: translateX(0);
+      opacity: 1;
     }
-    .#{$block-class}-header {
-      border-bottom: 1px solid $decorative-01;
+    100% {
+      // stylelint-disable-next-line carbon/layout-token-use
+      transform: translateX(-#{$medium-panel-size});
+
+      opacity: 0;
     }
   }
-  .#{$block-class}-title-text {
-    @include carbon--type-style('productive-heading-03');
 
-    display: -webkit-box;
-    margin-right: $spacing-07;
-    margin-bottom: $spacing-03;
-    overflow: hidden;
-    transition: font-size $duration--moderate-01,
-      font-weight $duration--moderate-02;
-    transition-timing-function: carbon--motion(standard);
+  @keyframes sidePanelExitRight {
+    0% {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    100% {
+      // stylelint-disable-next-line carbon/layout-token-use
+      transform: translateX($medium-panel-size);
 
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-  }
-  .#{$block-class}-subtitle-text {
-    @include carbon--type-style('body-short-01');
-
-    margin-bottom: $spacing-05;
-    overflow: hidden;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-  }
-  .#{$block-class}-label-text {
-    @include carbon--type-style('label-01');
-  }
-  .#{$block-class}-action-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    margin-bottom: $spacing-03;
-    .#{$block-class}-action-toolbar-button {
-      min-width: 2rem;
-      &.#{$block-class}-action-toolbar-icon-only-button {
-        padding: 0;
-        color: $text-01;
-      }
-      &.#{$block-class}-action-toolbar-icon-only-button svg {
-        margin-left: $spacing-03;
-      }
-      &.#{$block-class}-action-toolbar-leading-button {
-        margin-right: $spacing-03;
-      }
+      opacity: 0;
     }
   }
-  .bx--btn.#{$block-class}-navigation-back-button,
-  .bx--btn.#{$block-class}-close-button {
-    min-width: 2rem;
-    padding: 0;
+
+  .#{$block-class}__container {
+    &.#{$block-class}__container-light {
+      @include carbon--theme($carbon--theme--g10, true);
+    }
+    &.#{$block-class}__container-dark,
+    &.#{$block-class}__container-dark .#{$block-class}__body-content {
+      @include carbon--theme($carbon--theme--g100, true);
+    }
+
+    position: fixed;
+    top: $spacing-09;
+    z-index: 3;
+    box-sizing: border-box;
+    min-width: $medium-panel-size; // set default panel size
+    max-width: $medium-panel-size; // set default panel size
+    height: calc(100% - 3rem);
+    overflow: auto;
     color: $text-01;
-  }
-  .bx--btn.#{$block-class}-close-button {
-    position: absolute;
-    top: $spacing-03;
-    right: $spacing-03;
-  }
-  .#{$block-class}-body-content {
-    padding: $spacing-05;
-    padding-top: 0;
-    padding-bottom: $layout-07;
-  }
-  .#{$block-class}-header {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    padding: $spacing-05;
     background-color: $ui-01;
-  }
-  .#{$block-class}-actions-container {
-    position: sticky;
-    bottom: 0;
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    width: 100%;
-    height: $layout-05;
-    background-color: $ui-01;
-    &.#{$block-class}-actions--extra-small {
-      @include setActionBarSize($extra-small-panel-size);
-      @include smallButtonsStacked();
+    transition: transform $duration--moderate-02;
+    transition-timing-function: carbon--motion(standard);
+    &.#{$block-class}__container-right-placement {
+      right: 0;
+      border-left: 1px solid $decorative-01;
     }
-    &.#{$block-class}-actions--small {
-      @include setActionBarSize($small-panel-size);
-      @include smallButtonsStacked();
+    &.#{$block-class}__container-right-placement.#{$block-class}__container--extra-small {
+      @include sidePanelEntrance(right, $extra-small-panel-size);
     }
-    &.#{$block-class}-actions--medium {
-      @include setActionBarSize($medium-panel-size);
+    &.#{$block-class}__container-right-placement.#{$block-class}__container--small {
+      @include sidePanelEntrance(right, $small-panel-size);
+    }
+    &.#{$block-class}__container-right-placement.#{$block-class}__container--medium {
+      @include sidePanelEntrance(right, $medium-panel-size);
+    }
+    &.#{$block-class}__container-right-placement.#{$block-class}__container--large {
+      @include sidePanelEntrance(right, $large-panel-size);
+    }
+    &.#{$block-class}__container-right-placement.#{$block-class}__container--max {
+      @include sidePanelEntrance(right, $max-panel-size);
+    }
+    &.#{$block-class}__container-left-placement {
+      left: 0;
+      border-right: 1px solid $decorative-01;
+    }
+    &.#{$block-class}__container-left-placement.#{$block-class}__container--extra-small {
+      @include sidePanelEntrance(left, $extra-small-panel-size);
+    }
+    &.#{$block-class}__container-left-placement.#{$block-class}__container--small {
+      @include sidePanelEntrance(left, $small-panel-size);
+    }
+    &.#{$block-class}__container-left-placement.#{$block-class}__container--medium {
+      @include sidePanelEntrance(left, $medium-panel-size);
+    }
+    &.#{$block-class}__container-left-placement.#{$block-class}__container--large {
+      @include sidePanelEntrance(left, $large-panel-size);
+    }
+    &.#{$block-class}__container-left-placement.#{$block-class}__container--max {
+      @include sidePanelEntrance(left, $max-panel-size);
+    }
+    &.#{$block-class}__with-condensed-header {
+      .#{$block-class}__title-text {
+        @include carbon--type-style('productive-heading-02');
+      }
+      .#{$block-class}__header {
+        border-bottom: 1px solid $decorative-01;
+      }
+    }
+    .#{$block-class}__title-text {
+      @include carbon--type-style('productive-heading-03');
 
+      display: -webkit-box;
+      margin-right: $spacing-07;
+      margin-bottom: $spacing-03;
+      overflow: hidden;
+      transition: font-size $duration--moderate-01,
+        font-weight $duration--moderate-02;
+      transition-timing-function: carbon--motion(standard);
+
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
+    .#{$block-class}__subtitle-text {
+      @include carbon--type-style('body-short-01');
+
+      margin-bottom: $spacing-05;
+      overflow: hidden;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+    }
+    .#{$block-class}__label-text {
+      @include carbon--type-style('label-01');
+    }
+    .#{$block-class}__action-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      margin-bottom: $spacing-03;
+      .#{$block-class}__action-toolbar-button {
+        min-width: 2rem;
+        &.#{$block-class}__action-toolbar-icon-only-button {
+          padding: 0;
+          color: $text-01;
+        }
+        &.#{$block-class}__action-toolbar-icon-only-button svg {
+          margin-left: $spacing-03;
+        }
+        &.#{$block-class}__action-toolbar-leading-button {
+          margin-right: $spacing-03;
+        }
+      }
+    }
+    .bx--btn.#{$block-class}__navigation-back-button,
+    .bx--btn.#{$block-class}__close-button {
+      min-width: 2rem;
+      padding: 0;
+      color: $text-01;
+    }
+    .bx--btn.#{$block-class}__close-button {
+      position: absolute;
+      top: $spacing-03;
+      right: $spacing-03;
+    }
+    .#{$block-class}__body-content {
+      padding: $spacing-05;
+      padding-top: 0;
+      padding-bottom: $layout-07;
+    }
+    .#{$block-class}__header {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      padding: $spacing-05;
+      background-color: $ui-01;
+    }
+    .#{$block-class}__actions-container {
+      position: sticky;
+      bottom: 0;
+      display: flex;
       flex-direction: row;
-      &.#{$block-class}-actions-container--multi-action-3-buttons-or-more {
-        flex-direction: column;
-        .#{$block-class}-primary-action-button {
-          width: 100%;
-        }
+      justify-content: flex-end;
+      width: 100%;
+      height: $layout-05;
+      background-color: $ui-01;
+      &.#{$block-class}-actions--extra-small {
+        @include setActionBarSize($extra-small-panel-size);
+        @include smallButtonsStacked();
       }
-    }
-    &.#{$block-class}-actions--large {
-      @include setActionBarSize($large-panel-size);
+      &.#{$block-class}-actions--small {
+        @include setActionBarSize($small-panel-size);
+        @include smallButtonsStacked();
+      }
+      &.#{$block-class}-actions--medium {
+        @include setActionBarSize($medium-panel-size);
 
-      &.#{$block-class}-actions-container--multi-action-3-buttons-or-more {
-        .#{$block-class}-primary-action-button.#{$block-class}-ghost-button {
-          width: 50%;
-          max-width: 50%;
+        flex-direction: row;
+        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
+          flex-direction: column;
+          .#{$block-class}__primary-action-button {
+            width: 100%;
+          }
         }
       }
-      &.#{$block-class}-actions-container--single-action {
-        .#{$block-class}-primary-action-button.#{$block-class}-ghost-button {
-          width: 100%;
-          max-width: 100%;
+      &.#{$block-class}-actions--large {
+        @include setActionBarSize($large-panel-size);
+
+        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
+          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+            width: 50%;
+            max-width: 50%;
+          }
         }
+        &.#{$block-class}__actions-container--single-action {
+          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+            width: 100%;
+            max-width: 100%;
+          }
+        }
+      }
+      &.#{$block-class}-actions--max {
+        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
+          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+            width: 50%;
+            max-width: 50%;
+          }
+        }
+        &.#{$block-class}__actions-container--single-action {
+          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+            width: 100%;
+            max-width: 100%;
+          }
+        }
+      }
+      &.#{$block-class}__actions-container-condensed {
+        height: $layout-04;
       }
     }
-    &.#{$block-class}-actions--max {
-      &.#{$block-class}-actions-container--multi-action-3-buttons-or-more {
-        .#{$block-class}-primary-action-button.#{$block-class}-ghost-button {
-          width: 50%;
-          max-width: 50%;
-        }
-      }
-      &.#{$block-class}-actions-container--single-action {
-        .#{$block-class}-primary-action-button.#{$block-class}-ghost-button {
-          width: 100%;
-          max-width: 100%;
-        }
-      }
+    .#{$block-class}__actions-container
+      .#{$block-class}__primary-action-button {
+      display: flex;
+      align-items: flex-start;
+      width: 100%;
+      max-width: 100%;
+      height: 100%;
     }
-    &.#{$block-class}-actions-container-condensed {
-      height: $layout-04;
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action
+      .#{$block-class}__primary-action-button {
+      width: 50%;
+      max-width: 50%;
+    }
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--single-action.#{$block-class}-actions--large
+      .#{$block-class}__primary-action-button,
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action.#{$block-class}-actions--large
+      .#{$block-class}__primary-action-button {
+      width: 50%;
+      max-width: 50%;
+    }
+    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action-3-buttons-or-more.#{$block-class}-actions--large
+      .#{$block-class}__primary-action-button,
+    .#{$block-class}__actions-container.#{$block-class}-actions--max
+      .#{$block-class}__primary-action-button {
+      width: 25%;
+      max-width: 25%;
     }
   }
-  .#{$block-class}-actions-container .#{$block-class}-primary-action-button {
-    display: flex;
-    align-items: flex-start;
+  .#{$block-class}__primary-action-button .bx--inline-loading {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: $spacing-07;
+  }
+
+  @keyframes sidePanelOverlayEntrance {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes sidePanelOverlayExit {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .#{$block-class}__visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    // stylelint-disable-next-line carbon/layout-token-use
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    border: 0;
+    visibility: inherit;
+    clip: rect(0, 0, 0, 0);
+  }
+
+  .#{$block-class}__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
     width: 100%;
-    max-width: 100%;
     height: 100%;
-  }
-  .#{$block-class}-actions-container.#{$block-class}-actions-container--multi-action
-    .#{$block-class}-primary-action-button {
-    width: 50%;
-    max-width: 50%;
-  }
-  .#{$block-class}-actions-container.#{$block-class}-actions-container--single-action.#{$block-class}-actions--large
-    .#{$block-class}-primary-action-button,
-  .#{$block-class}-actions-container.#{$block-class}-actions-container--multi-action.#{$block-class}-actions--large
-    .#{$block-class}-primary-action-button {
-    width: 50%;
-    max-width: 50%;
-  }
-  .#{$block-class}-actions-container.#{$block-class}-actions-container--multi-action-3-buttons-or-more.#{$block-class}-actions--large
-    .#{$block-class}-primary-action-button,
-  .#{$block-class}-actions-container.#{$block-class}-actions--max
-    .#{$block-class}-primary-action-button {
-    width: 25%;
-    max-width: 25%;
-  }
-}
-.#{$block-class}-primary-action-button .bx--inline-loading {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: $spacing-07;
-}
-
-@keyframes sidePanelOverlayEntrance {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
+    background-color: $overlay-01;
+    transition: background-color $duration--moderate-02;
+    transition-timing-function: carbon--motion(standard);
   }
 }
 
-@keyframes sidePanelOverlayExit {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-.#{$block-class}--visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  // stylelint-disable-next-line carbon/layout-token-use
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  border: 0;
-  visibility: inherit;
-  clip: rect(0, 0, 0, 0);
-}
-
-.#{$block-class}-overlay {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  width: 100%;
-  height: 100%;
-  background-color: $overlay-01;
-  transition: background-color $duration--moderate-02;
-  transition-timing-function: carbon--motion(standard);
+@include exports('side-panel') {
+  @include side-panel;
 }

--- a/packages/cloud-cognitive/src/components/SidePanel/utils.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/utils.js
@@ -1,5 +1,6 @@
 export const changeArrayPosition = (arr, originalPosition, newPosition) => {
-  let cutOut = arr.splice(originalPosition, 1)[0];
-  arr.splice(newPosition, 0, cutOut);
-  return arr;
+  const newArr = [...arr];
+  const cutOut = newArr.splice(originalPosition, 1)[0];
+  newArr.splice(newPosition, 0, cutOut);
+  return newArr;
 };

--- a/packages/cloud-cognitive/src/components/SidePanel/utils.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/utils.js
@@ -1,0 +1,5 @@
+export const changeArrayPosition = (arr, originalPosition, newPosition) => {
+  let cutOut = arr.splice(originalPosition, 1)[0];
+  arr.splice(newPosition, 0, cutOut);
+  return arr;
+};


### PR DESCRIPTION
Contributes to #490 

This preps the side panel for review. Restructured class names usage based on our guidelines, sass updates (for `import-once`), forward ref capability added, tests to ensure props spreading and passing a ref work.

#### What did you change?
`SidePanel.js`
`SidePanel.test.js`
`_side-panel.scss`
`utils.js`
#### How did you test and verify your work?
Everything still works in storybook and all tests for this component pass `jest /SidePanel/`