### PR TITLE
Update code guidelines to simpler handling of className

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -85,11 +85,13 @@ unclear.
     element to combine needed classes and the block class with the `className`
     prop:
     ```js
-    <html-element class={cx(
-      blockClass, {
-      // other classes we might need to attach
-      [className]: className  // this handles className omitted/falsy
-    })} ...
+    <html-element
+      className={cx(
+        blockClass, // Apply the block class to the main HTML element
+        className, // Apply any supplied class names to the main HTML element.
+        ...
+      )}
+      ...
     ```
   - `ref={ref}` should be included on a suitable DOM element (often the main DOM
     element) to enable a supplied ref to be passed to an appropriate node.

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
@@ -44,13 +44,8 @@ export let DISPLAY_NAME = React.forwardRef(
           ...rest
         }
         className={cx(
-          // Apply the block class to the main HTML element, along with
-          // any other classes we need.
-          blockClass,
-          {
-            // Apply any supplied class names to the main HTML element.
-            [className]: className, // this handles className omitted/falsy
-          }
+          blockClass, // Apply the block class to the main HTML element
+          className // Apply any supplied class names to the main HTML element.
         )}
         ref={ref}
         role="main">

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
@@ -45,7 +45,13 @@ export let DISPLAY_NAME = React.forwardRef(
         }
         className={cx(
           blockClass, // Apply the block class to the main HTML element
-          className // Apply any supplied class names to the main HTML element.
+          className, // Apply any supplied class names to the main HTML element.
+          `${blockClass}__template-string-class-${kind}-n-${size}`,
+          {
+            // switched classes dependant on props or state
+            [`${blockClass}__here-if-small`]: size === 'small',
+            [`${blockClass}__here-if-field`]: size === 'field'
+          }
         )}
         ref={ref}
         role="main">

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.js
@@ -50,7 +50,7 @@ export let DISPLAY_NAME = React.forwardRef(
           {
             // switched classes dependant on props or state
             [`${blockClass}__here-if-small`]: size === 'small',
-            [`${blockClass}__here-if-field`]: size === 'field'
+            [`${blockClass}__here-if-field`]: size === 'field',
           }
         )}
         ref={ref}

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
@@ -59,12 +59,14 @@ export let AboutModal = React.forwardRef(
         // Pass through any other property values as HTML attributes.
         ...rest
       }
-      className={cx(blockClass, {
-        [`${blockClass}--with-tabs`]:
-          additionalInfo && additionalInfo.length > 1,
-        // Apply any supplied class names to the main HTML element.
-        [className]: className, // this handles className omitted/falsy
-      })}
+      className={cx(
+        blockClass, // Apply the block class to the main HTML element
+        className, // Apply any supplied class names to the main HTML element.
+        {
+          [`${blockClass}--with-tabs`]:
+            additionalInfo && additionalInfo.length > 1,
+        }
+      )}
       {...{ onClose, open, ref }}>
       <div className={`${blockClass}__logo`}>{logo}</div>
       <ModalHeader

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.js
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.js
@@ -69,13 +69,10 @@ export let ExampleComponent = React.forwardRef(
           ...rest
         }
         className={cx(
-          // Apply the block class to the main HTML element, along with
-          // any other classes we need.
-          [blockClass, `${blockClass}--${size}`, modeClass],
-          {
-            // Apply any supplied class names to the main HTML element.
-            [className]: className, // this handles className omitted/falsy
-          }
+          blockClass, // Apply the block class to the main HTML element
+          className, // Apply any supplied class names to the main HTML element.
+          `${blockClass}--${size}`,
+          modeClass
         )}
         ref={ref}
         role="main"

--- a/packages/cloud-cognitive/src/components/_Canary/Canary.js
+++ b/packages/cloud-cognitive/src/components/_Canary/Canary.js
@@ -5,21 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import cx from 'classnames';
-import { string } from 'prop-types';
+// Import portions of React that are needed.
 import React from 'react';
-import { CodeSnippet } from 'carbon-components-react';
+
+// Other standard imports.
+import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 // load the package settings direct, because Canary is used by settings.js
 import pkg from '../../global/js/package-settings';
 
+// Carbon and package components we use.
+import { CodeSnippet } from 'carbon-components-react';
+
+// The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}-canary`;
 
 /**
  *  Canary component used when the component requested is not yet production
  */
 export const Canary = (
-  { componentName, className, ...rest } /*, originalArgs*/
+  { className, componentName, ...rest } /*, originalArgs*/
 ) => {
   const instructions = `
 import { pkg } from '@carbon/ibm-cloud-cognitive';
@@ -27,7 +33,7 @@ import { pkg } from '@carbon/ibm-cloud-cognitive';
 pkg.component.${componentName} = true;
 `;
   return (
-    <div className={cx(blockClass, className)} {...rest}>
+    <div {...rest} className={cx(blockClass, className)}>
       <h2>
         This component <strong>{componentName}</strong> is not ready yet.
       </h2>
@@ -42,7 +48,7 @@ pkg.component.${componentName} = true;
       <p>
         View a live example on{' '}
         <a href="https://codesandbox.io/s/example-component-olif5?file=/src/config.js">
-          codesadnbox
+          codesandbox
         </a>
         .
       </p>
@@ -52,12 +58,8 @@ pkg.component.${componentName} = true;
 
 Canary.propTypes = {
   /** Provide an optional class to be applied to the containing node */
-  className: string,
+  className: PropTypes.string,
 
   /** Name of the component that is not ready yet */
-  componentName: string.isRequired,
-};
-
-Canary.defaultProps = {
-  className: null,
+  componentName: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Contributes to #393

`cx({ [className]: className })` turns out to be a tadge unnecessary, so `cx(blockClass, className, ...)` is simpler and cleaner.

#### What did you change?

CLI, ExampleComponent, AboutModal, and Canary

#### How did you test and verify your work?

Ran build and tests.