### PR TITLE
Put styles back in order after storybook updates

### DIFF
--- a/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
@@ -16,6 +16,7 @@
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin STYLE_NAME {
+  // The block part of our conventional BEM class names (blockClass__E--M).
   $block-class: #{$pkg-prefix}--STYLE_NAME;
 
   .#{$block-class} {

--- a/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
+++ b/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
@@ -21,17 +21,14 @@
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin about-modal {
+  // The block part of our conventional BEM class names (blockClass__E--M).
   $block-class: #{$pkg-prefix}--about-modal;
-
-  .#{$block-class} {
-    background-color: $ui-background;
-  }
 
   .#{$block-class} .bx--modal-container {
     grid-template-rows: auto auto 1fr auto;
   }
 
-  .#{$block-class}__logo {
+  .#{$block-class} .#{$block-class}__logo {
     margin: $spacing-05;
   }
 

--- a/packages/cloud-cognitive/src/components/ExampleComponent/_example-component.scss
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/_example-component.scss
@@ -14,6 +14,7 @@
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin example-component {
+  // The block part of our conventional BEM class names (blockClass__E--M).
   $block-class: #{$pkg-prefix}--example-component;
 
   .#{$block-class} {

--- a/packages/cloud-cognitive/src/components/_Canary/_canary.scss
+++ b/packages/cloud-cognitive/src/components/_Canary/_canary.scss
@@ -5,10 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import '../../global/styles/carbon-settings'; // goes before carbon imports as it affects how carbon is used.
-@import '../../global/styles/project-settings';
-
-$block-class: #{$pkg-prefix}-canary;
-
 @import 'carbon-components/scss/components/code-snippet/code-snippet';
 @import 'carbon-components/scss/components/copy-button/copy-button';

--- a/packages/cloud-cognitive/src/components/_index.scss
+++ b/packages/cloud-cognitive/src/components/_index.scss
@@ -7,20 +7,21 @@
 
 // Package all scss files here for those that want them all bundled up.
 
+@import './_Canary/canary';
+
 @import './AboutModal/index';
 @import './ActionBar/index';
 @import './BreadcrumbWithOverflow/index';
-@import './_Canary/canary';
 @import './EmptyStates/index';
 @import './ExampleComponent/index';
 @import './HTTPErrors/index';
 @import './ImportModal/index';
 @import './ModifiedTabs/index';
 @import './Notifications/index';
-@import './SidePanel/index';
-@import './StatusIcon/index';
 @import './PageHeader/index';
 @import './RemoveDeleteModal/index';
+@import './SidePanel/index';
+@import './StatusIcon/index';
 @import './TagSet/index';
 @import './Tearsheet/index';
 @import './WebTerminal/index';

--- a/packages/cloud-cognitive/src/components/_index.scss
+++ b/packages/cloud-cognitive/src/components/_index.scss
@@ -18,6 +18,7 @@
 @import './ModifiedTabs/index';
 @import './Notifications/index';
 @import './SidePanel/index';
+@import './StatusIcon/index';
 @import './PageHeader/index';
 @import './RemoveDeleteModal/index';
 @import './TagSet/index';

--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -5,24 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// pull in some Carbon settings for storybook
-@import '@carbon/type/scss/reset';
-@import 'carbon-components/scss/globals/scss/css--font-face';
-
-$css--reset: false;
-
-@import 'carbon-components/scss/globals/scss/css--body';
-
-@include carbon--type-reset;
-
 @import '../generated/feature-flags/feature-flags';
-@import '@carbon/themes/scss/themes';
-
-@import '@carbon/ibm-cloud-cognitive/css/index.min';
-@import 'carbon-components/css/carbon-components.min';
-
-// Uncomment next line if you want to use Canary in storybook
-//@import '@carbon/ibm-cloud-cognitive/scss/components/_Canary/canary';
+@import '../../cloud-cognitive/src/index';
+@import 'carbon-components/scss/globals/scss/styles';
 
 // Setting attribute storybook-carbon-theme="XXX" on the html element
 // will set the carbon theme used for the storybook pane.


### PR DESCRIPTION
There were some style oddities following our storybook build changes. This should straighten them out.

#### What did you change?

storybook master index.scss, plus some tweaks to individual style files.

#### How did you test and verify your work?

Ran storybook.