### PR TITLE
Create ActionSet to do action button layouts

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -31,7 +31,7 @@ export const ActionSet = React.forwardRef(
       // The component props, in alphabetical order (for consistency).
       actions,
       className,
-      reverse,
+      size,
       // Collect any other property values passed in.
       ...rest
     },
@@ -39,7 +39,7 @@ export const ActionSet = React.forwardRef(
   ) => {
     // order the actions with ghost buttons first and primary buttons last
     // (or the opposite way around if reverse is true)
-    const direction = reverse ? -1 : 1;
+    const direction = size === 'xs' || size === 'sm' || size === 'md' ? -1 : 1;
     const sortedActions = (actions && actions.slice(0)) || [];
     sortedActions.sort((action1, action2) =>
       action1.kind === action2.kind
@@ -57,12 +57,16 @@ export const ActionSet = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className, {
-          [`${blockClass}--single-action`]: sortedActions.length === 1,
-          [`${blockClass}--multi-action`]: sortedActions.length === 2,
-          [`${blockClass}--multi-action-3-buttons-or-more`]:
-            sortedActions.length > 2,
-        })}
+        className={cx(
+          blockClass,
+          className,
+          {
+            [`${blockClass}--single`]: sortedActions.length === 1,
+            [`${blockClass}--double`]: sortedActions.length === 2,
+            [`${blockClass}--triple-plus`]: sortedActions.length >= 3,
+          },
+          `${blockClass}--${size}`
+        )}
         ref={ref}
         role="presentation">
         {sortedActions.map((action, index) => (
@@ -91,8 +95,9 @@ ActionSet.displayName = componentName;
 // and returns true if the component is to be treated as 'small', which means
 // that a limit of three buttons will be enforced as well as not combining
 // ghost buttons with other button types.
-ActionSet.validateActions = (isSmall) => (props, propName, componentName) => {
-  const small = isSmall ? isSmall(props) : false;
+ActionSet.validateActions = () => (props, propName, componentName) => {
+  const small =
+    props.size === 'xs' || props.size === 'sm' || props.size === 'md';
   const prop = props[propName];
 
   const badActions = (problem) =>
@@ -156,9 +161,8 @@ ActionSet.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Normally, ghost buttons are shown first and the primary buttons last.
-   * Set this to true to reverse the ordering so that primary buttons are
-   * shown first and ghost buttons last.
+   * Sets the size of the action set. Different button arrangements are used
+   * in different sizes, to make best use of the available space.
    */
-  reverse: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'max']),
 };

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+
+// Other standard imports.
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { pkg } from '../../settings';
+
+// Carbon and package components we use.
+import { Button, InlineLoading } from 'carbon-components-react';
+
+const blockClass = `${pkg.prefix}--action-set`;
+const componentName = 'ActionSet';
+
+// NOTE: the component SCSS is not imported here: it is rolled up separately.
+
+/**
+ * An ActionSet presents a set of action buttons, constructed from bundles
+ * of prop values and applying some layout rules.
+ */
+export const ActionSet = React.forwardRef(
+  (
+    {
+      // The component props, in alphabetical order (for consistency).
+      actions,
+      className,
+      reverse,
+      // Collect any other property values passed in.
+      ...rest
+    },
+    ref
+  ) => {
+    // order the actions with ghost buttons first and primary buttons last
+    // (or the opposite way around if reverse is true)
+    const direction = reverse ? -1 : 1;
+    const sortedActions = (actions && actions.slice(0)) || [];
+    sortedActions.sort((action1, action2) =>
+      action1.kind === action2.kind
+        ? 0
+        : action1.kind === 'ghost' || action2.kind === 'primary'
+        ? -direction
+        : action1.kind === 'primary' || action2.kind === 'ghost'
+        ? direction
+        : 0
+    );
+
+    return (
+      <div
+        {
+          // Pass through any other property values as HTML attributes.
+          ...rest
+        }
+        className={cx(blockClass, className, {
+          [`${blockClass}--single-action`]: sortedActions.length === 1,
+          [`${blockClass}--multi-action`]: sortedActions.length === 2,
+          [`${blockClass}--multi-action-3-buttons-or-more`]:
+            sortedActions.length > 2,
+        })}
+        ref={ref}
+        role="presentation">
+        {sortedActions.map((action, index) => (
+          <Button
+            key={index}
+            disabled={action.disabled || action.loading || false}
+            onClick={action.onClick}
+            kind={action.kind}
+            className={cx([
+              `${blockClass}__action-button`,
+              { [`${blockClass}__ghost-button`]: action.kind === 'ghost' },
+            ])}>
+            {action.label}
+            {action.loading && <InlineLoading />}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+);
+
+ActionSet.displayName = componentName;
+
+// We provide a validator function to help validate the actions supplied.
+// An optional parameter is a function which will be passed all the props
+// and returns true if the component is to be treated as 'small', which means
+// that a limit of three buttons will be enforced as well as not combining
+// ghost buttons with other button types.
+ActionSet.validateActions = (isSmall) => (props, propName, componentName) => {
+  const small = isSmall ? isSmall(props) : false;
+  const prop = props[propName];
+
+  const badActions = (problem) =>
+    new Error(
+      `Prop '${propName}' passed to ${componentName} is using an invalid combination of actions.\n\n${problem}`
+    );
+
+  if (prop && prop?.length > 0) {
+    if (small && prop.length > 3) {
+      throw badActions(
+        `You cannot have more than three actions in this size of ${componentName}.`
+      );
+    }
+
+    const primaryButtons = prop.filter((button) => button.kind === 'primary');
+
+    if (primaryButtons.length > 1) {
+      throw badActions(
+        `You cannot have more than one 'primary' action in a ${componentName}.`
+      );
+    }
+
+    const ghostButtons = prop.filter((button) => button.kind === 'ghost');
+
+    if (ghostButtons.length > 1) {
+      throw badActions(
+        `You cannot have more than one 'ghost' action in a ${componentName}.`
+      );
+    }
+
+    if (small && prop.length > 1 && ghostButtons.length > 0) {
+      throw badActions(
+        `You cannot have a 'ghost' button in conjuntion with other action types in this size of ${componentName}. Try using a 'secondary' button instead.`
+      );
+    }
+  }
+
+  return null;
+};
+
+ActionSet.propTypes = {
+  /**
+   * Specifies the action buttons to show.
+   */
+  actions: PropTypes.oneOfType([
+    ActionSet.validateActions(),
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string,
+        onClick: PropTypes.func,
+        kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
+        disabled: PropTypes.bool,
+        loading: PropTypes.bool,
+      })
+    ),
+  ]),
+
+  /**
+   * Sets an optional className to be added to the side panel outermost element.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Normally, ghost buttons are shown first and the primary buttons last.
+   * Set this to true to reverse the ordering so that primary buttons are
+   * shown first and ghost buttons last.
+   */
+  reverse: PropTypes.bool,
+};

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -166,3 +166,7 @@ ActionSet.propTypes = {
    */
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'max']),
 };
+
+ActionSet.defaultProps = {
+  size: 'md',
+};

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import { pkg } from '../../settings';
+import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
+import { getStorybookPrefix } from '../../../config';
+
+import { ActionSet } from '.';
+
+import styles from './_storybook-styles.scss';
+
+const storybookPrefix = getStorybookPrefix(pkg, ActionSet.displayName);
+
+export default {
+  title: `${storybookPrefix}/${ActionSet.displayName}`,
+  component: ActionSet,
+  parameters: {
+    styles,
+  },
+  argTypes: {
+    actions: {
+      control: {
+        type: 'select',
+        options: {
+          'One button': 0,
+          'One button (ghost)': 1,
+          'Two buttons': 2,
+          'Three buttons with ghost': 3,
+          'Three buttons': 4,
+          None: 5,
+        },
+        default: 0,
+      },
+    },
+    slideIn: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const actions_1 = [
+  {
+    label: 'Primary button',
+    onPrimaryActionClick: () => {},
+    kind: 'primary',
+  },
+];
+
+const actions_2 = [
+  {
+    label: 'Ghost button',
+    onPrimaryActionClick: () => {},
+    kind: 'ghost',
+  },
+];
+
+const actions_3 = [
+  {
+    label: 'Primary button',
+    onPrimaryActionClick: () => {},
+    kind: 'primary',
+  },
+  {
+    label: 'Secondary button',
+    onPrimaryActionClick: () => {},
+    kind: 'secondary',
+  },
+];
+
+const actions_4 = [
+  {
+    label: 'Primary button',
+    onPrimaryActionClick: () => {},
+    kind: 'primary',
+  },
+  {
+    label: 'Secondary button',
+    onPrimaryActionClick: () => {},
+    kind: 'secondary',
+  },
+  {
+    label: 'Ghost button',
+    onPrimaryActionClick: () => {},
+    kind: 'ghost',
+  },
+];
+
+const actions_5 = [
+  {
+    label: 'Primary button',
+    onPrimaryActionClick: () => {},
+    kind: 'primary',
+  },
+  {
+    label: 'Secondary button',
+    onPrimaryActionClick: () => {},
+    kind: 'secondary',
+  },
+  {
+    label: 'Secondary button',
+    onPrimaryActionClick: () => {},
+    kind: 'secondary',
+  },
+];
+
+const actionSets = [actions_1, actions_2, actions_3, actions_4, actions_5, []];
+
+// eslint-disable-next-line react/prop-types
+const Template = ({ actions, ...args }) => {
+  return <ActionSet {...args} actions={actionSets[actions]} />;
+};
+
+export const actionSet = Template.bind({});
+actionSet.args = { actions: 0 };

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { pkg } from '../../settings';
+import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
+
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { ActionSet } from '.';
+
+const blockClass = `${pkg.prefix}--action-set`;
+const componentName = ActionSet.displayName;
+
+const dataTestId = uuidv4();
+const label1 = `Button ${uuidv4()}`;
+const label2 = `Button ${uuidv4()}`;
+const label3 = `Button ${uuidv4()}`;
+
+describe(componentName, () => {
+  it('renders a component ActionSet', () => {
+    render(<ActionSet />);
+    expect(screen.getByRole('presentation')).toHaveClass(blockClass);
+  });
+
+  it('renders one action button', () => {
+    render(
+      <ActionSet
+        actions={[
+          {
+            label: label1,
+            kind: 'primary',
+          },
+        ]}
+      />
+    );
+    screen.getByRole('button', { name: label1 });
+  });
+
+  it('renders three action buttons', () => {
+    render(
+      <ActionSet
+        actions={[
+          {
+            label: label1,
+            kind: 'primary',
+          },
+          {
+            label: label2,
+            kind: 'secondary',
+          },
+          {
+            label: label3,
+            kind: 'ghost',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByRole('button', { name: label1 })).toHaveClass(
+      'bx--btn--primary'
+    );
+    expect(screen.getByRole('button', { name: label2 })).toHaveClass(
+      'bx--btn--secondary'
+    );
+    expect(screen.getByRole('button', { name: label3 })).toHaveClass(
+      'bx--btn--ghost'
+    );
+  });
+
+  it('renders a single ghost action button', () => {
+    render(
+      <ActionSet
+        actions={[
+          {
+            label: label1,
+            kind: 'ghost',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByRole('button', { name: label1 })).toHaveClass(
+      'bx--btn--ghost'
+    );
+  });
+
+  it('reports clicks on an action button', () => {
+    const onClick = jest.fn();
+    render(
+      <ActionSet
+        actions={[
+          {
+            label: label1,
+            onClick: onClick,
+          },
+        ]}
+      />
+    );
+    expect(onClick).toBeCalledTimes(0);
+    userEvent.click(screen.getByRole('button', { name: label1 }));
+    expect(onClick).toBeCalledTimes(1);
+  });
+
+  it('adds additional properties to the containing node', () => {
+    render(<ActionSet data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    render(<ActionSet ref={ref} />);
+    expect(ref.current).toEqual(screen.getByRole('presentation'));
+  });
+});

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -11,7 +11,17 @@
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/inline-loading/inline-loading';
 
+// The block part of our conventional BEM class names (blockClass__E--M).
 $block-class: #{$pkg-prefix}--action-set;
+
+@mixin smallButtonsStacked {
+  flex-direction: column;
+  &.#{$block-class}--triple-plus .#{$block-class}__action-button,
+  &.#{$block-class}--double .#{$block-class}__action-button {
+    width: 100%;
+    max-width: 100%;
+  }
+}
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
@@ -21,6 +31,75 @@ $block-class: #{$pkg-prefix}--action-set;
     flex-direction: row;
     justify-content: flex-end;
     width: 100%;
+  }
+
+  .#{$block-class}.#{$block-class}--xs {
+    @include smallButtonsStacked();
+  }
+
+  .#{$block-class}.#{$block-class}--sm {
+    @include smallButtonsStacked();
+  }
+
+  .#{$block-class}.#{$block-class}--md {
+    flex-direction: row;
+    &.#{$block-class}--triple-plus {
+      flex-direction: column;
+      .#{$block-class}__action-button {
+        width: 100%;
+      }
+    }
+  }
+
+  .#{$block-class}.#{$block-class}--lg {
+    &.#{$block-class}--triple-plus {
+      .#{$block-class}__action-button.#{$block-class}__ghost-button {
+        width: 50%;
+        max-width: 50%;
+      }
+    }
+    &.#{$block-class}--single {
+      .#{$block-class}__action-button.#{$block-class}__ghost-button {
+        width: 100%;
+        max-width: 100%;
+      }
+    }
+  }
+  .#{$block-class}.#{$block-class}__actions--max {
+    &.#{$block-class}--triple-plus {
+      .#{$block-class}__action-button.#{$block-class}__ghost-button {
+        width: 50%;
+        max-width: 50%;
+      }
+    }
+    &.#{$block-class}--single {
+      justify-content: flex-start;
+    }
+  }
+
+  .#{$block-class} .#{$block-class}__action-button {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+  }
+  .#{$block-class}.#{$block-class}--double .#{$block-class}__action-button {
+    width: 50%;
+    max-width: 50%;
+  }
+  .#{$block-class}.#{$block-class}--single.#{$block-class}--lg
+    .#{$block-class}__action-button,
+  .#{$block-class}.#{$block-class}--double.#{$block-class}--lg
+    .#{$block-class}__action-button {
+    width: 50%;
+    max-width: 50%;
+  }
+  .#{$block-class}.#{$block-class}--triple-plus.#{$block-class}--lg
+    .#{$block-class}__action-button,
+  .#{$block-class}.#{$block-class}--max .#{$block-class}__action-button {
+    width: 25%;
+    max-width: 25%;
   }
 
   .#{$block-class} .#{$block-class}__action-button .bx--inline-loading {

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -1,0 +1,36 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
+
+@import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/inline-loading/inline-loading';
+
+$block-class: #{$pkg-prefix}--action-set;
+
+// Define all component styles in a mixin which is then exported using
+// the Carbon import-once mechanism.
+@mixin action-set {
+  .#{$block-class} {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+  .#{$block-class} .#{$block-class}__action-button .bx--inline-loading {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: $spacing-07;
+  }
+}
+
+@include exports('action-set') {
+  @include action-set;
+}

--- a/packages/cloud-cognitive/src/components/ActionSet/_index.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import './action-set';

--- a/packages/cloud-cognitive/src/components/ActionSet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_storybook-styles.scss
@@ -1,0 +1,17 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import '../../global/styles/carbon-settings';
+@import '../../global/styles/project-settings';
+
+$block-class: #{$pkg-prefix}--action-set;
+
+.#{$block-class} {
+  min-width: 80vw;
+  border: 1px solid $decorative-01;
+  box-shadow: 0 0 10px 5px $ui-04;
+}

--- a/packages/cloud-cognitive/src/components/ActionSet/index.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { ActionSet } from './ActionSet';

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -185,21 +185,16 @@ export let SidePanel = React.forwardRef(
       }
     }, [slideIn, pageContentSelector, placement, shouldRender, size]);
 
-    const setSizeClassName = (panelSize, actions) => {
-      let sizeClassName;
-      if (!actions) {
-        sizeClassName = `${blockClass}__container-`;
-      } else {
-        sizeClassName = `${blockClass}__actions-`;
-      }
+    const setSizeClassName = (panelSize) => {
+      let sizeClassName = `${blockClass}__container-`;
       switch (panelSize) {
-        case 'extraSmall':
+        case 'xs':
           return (sizeClassName = `${sizeClassName}-extra-small`);
-        case 'small':
+        case 'sm':
           return (sizeClassName = `${sizeClassName}-small`);
-        case 'medium':
+        case 'md':
           return (sizeClassName = `${sizeClassName}-medium`);
-        case 'large':
+        case 'lg':
           return (sizeClassName = `${sizeClassName}-large`);
         case 'max':
           return (sizeClassName = `${sizeClassName}-max`);
@@ -238,7 +233,6 @@ export let SidePanel = React.forwardRef(
 
     const primaryActionContainerClassNames = cx([
       `${blockClass}__actions-container`,
-      setSizeClassName(size, true),
       {
         [`${blockClass}__actions-container-condensed`]: condensed,
       },
@@ -348,9 +342,7 @@ export let SidePanel = React.forwardRef(
             <div className={`${blockClass}__body-content`}>{children}</div>
             <ActionSet
               actions={primaryActions}
-              reverse={
-                size === 'small' || size === 'extraSmall' || size === 'medium'
-              }
+              size={size}
               className={primaryActionContainerClassNames}
             />
           </div>
@@ -447,15 +439,7 @@ SidePanel.propTypes = {
    * Sets the primary action buttons for the side panel
    */
   primaryActions: PropTypes.oneOfType([
-    // Use the ActionSet to validate the supplied actions, with the 'small'
-    // set constraints (limit of three actions) if the SidePanel size is
-    // extraSmall/small/medium.
-    ActionSet.validateActions(
-      (props) =>
-        props.size === 'small' ||
-        props.size === 'extraSmall' ||
-        props.size === 'medium'
-    ),
+    ActionSet.validateActions(),
     PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string,
@@ -478,7 +462,7 @@ SidePanel.propTypes = {
   /**
    * Sets the size of the side panel
    */
-  size: PropTypes.oneOf(['extraSmall', 'small', 'medium', 'large', 'max']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'max']),
   /**
    * Determines if this panel slides in
    */
@@ -500,7 +484,7 @@ SidePanel.propTypes = {
 SidePanel.defaultProps = {
   animateTitle: true,
   placement: 'right',
-  size: 'medium',
+  size: 'md',
   slideIn: false,
   theme: 'light',
   currentStep: 0,

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -447,6 +447,9 @@ SidePanel.propTypes = {
    * Sets the primary action buttons for the side panel
    */
   primaryActions: PropTypes.oneOfType([
+    // Use the ActionSet to validate the supplied actions, with the 'small'
+    // set constraints (limit of three actions) if the SidePanel size is
+    // extraSmall/small/medium.
     ActionSet.validateActions(
       (props) =>
         props.size === 'small' ||

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -410,7 +410,7 @@ LeftWithCondensedPrimaryActions.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -422,7 +422,7 @@ OnePrimaryActionExtraSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -435,7 +435,7 @@ OnePrimaryActionSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -448,7 +448,7 @@ OnePrimaryActionMedium.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -460,7 +460,7 @@ OnePrimaryActionLarge.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -473,7 +473,7 @@ OnePrimaryActionMax.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -487,12 +487,12 @@ TwoPrimaryActionExtraSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -505,12 +505,12 @@ TwoPrimaryActionSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -523,12 +523,12 @@ TwoPrimaryActionMedium.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -540,12 +540,12 @@ TwoPrimaryActionLarge.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -558,12 +558,12 @@ TwoPrimaryActionMax.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -577,17 +577,17 @@ ThreePrimaryActionExtraSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -600,17 +600,17 @@ ThreePrimaryActionSmall.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -623,17 +623,17 @@ ThreePrimaryActionMedium.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -645,17 +645,17 @@ ThreePrimaryActionLarge.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -668,17 +668,17 @@ ThreePrimaryActionMax.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
   ],
@@ -692,17 +692,17 @@ ThreePrimaryActionLargeWithGhost.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -715,17 +715,17 @@ ThreePrimaryActionMaxWithGhost.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
     {
       label: 'Secondary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'secondary',
     },
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -739,7 +739,7 @@ GhostPrimaryActionExtraSmall.args = {
   primaryActions: [
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -752,7 +752,7 @@ GhostPrimaryActionSmall.args = {
   primaryActions: [
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -765,7 +765,7 @@ GhostPrimaryActionMedium.args = {
   primaryActions: [
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -777,7 +777,7 @@ GhostPrimaryActionLarge.args = {
   primaryActions: [
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -791,7 +791,7 @@ GhostPrimaryActionMax.args = {
   primaryActions: [
     {
       label: 'Ghost button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'ghost',
     },
   ],
@@ -805,7 +805,7 @@ PanelWithSecondStep.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -819,7 +819,7 @@ DarkThemeSidePanel.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],
@@ -833,7 +833,7 @@ SpecifyElementToHaveInitialFocus.args = {
   primaryActions: [
     {
       label: 'Primary button',
-      onPrimaryActionClick: () => {},
+      onClick: () => {},
       kind: 'primary',
     },
   ],

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -14,6 +14,8 @@ import '../../utils/enable-all'; // must come before component is imported (dire
 import { SidePanel } from '.';
 
 const blockClass = `${pkg.prefix}--side-panel`;
+const actionSetBlockClass = `${pkg.prefix}--action-set`;
+
 const dataTestId = uuidv4();
 
 const renderSidePanel = ({ ...rest }, children) =>
@@ -163,7 +165,7 @@ describe('SidePanel', () => {
         primaryActions: [
           {
             label: 'Primary button',
-            onPrimaryActionClick: () => {},
+            onClick: () => {},
             kind: 'primary',
           },
         ],
@@ -180,12 +182,12 @@ describe('SidePanel', () => {
         primaryActions: [
           {
             label: 'Action button',
-            onPrimaryActionClick: () => {},
+            onClick: () => {},
             kind: 'primary',
           },
           {
             label: 'Action button',
-            onPrimaryActionClick: () => {},
+            onClick: () => {},
             kind: 'secondary',
           },
         ],
@@ -202,7 +204,7 @@ describe('SidePanel', () => {
         primaryActions: [
           {
             label: 'Ghost action button',
-            onPrimaryActionClick: () => {},
+            onClick: () => {},
             kind: 'ghost',
           },
         ],
@@ -210,7 +212,7 @@ describe('SidePanel', () => {
       'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${blockClass}__ghost-button`
+      `.${actionSetBlockClass}__ghost-button`
     );
     expect(sidePanelOuter).toBeTruthy();
   });
@@ -222,7 +224,7 @@ describe('SidePanel', () => {
         primaryActions: [
           {
             label: 'Primary button',
-            onPrimaryActionClick: () => {},
+            onClick: () => {},
           },
         ],
       },
@@ -230,8 +232,8 @@ describe('SidePanel', () => {
     );
     const sidePanelAction = screen.getByText(/Primary button/i);
     expect(
-      sidePanelAction.classList.contains(
-        `${blockClass}__primary-action-button-condensed`
+      sidePanelAction.parentElement.classList.contains(
+        `${blockClass}__actions-container-condensed`
       )
     ).toBeTruthy();
   });
@@ -270,13 +272,13 @@ describe('SidePanel', () => {
   it('should click the primary action button', () => {
     const { fn } = jest;
     const { click } = fireEvent;
-    const onPrimaryActionClick = fn();
+    const onClick = fn();
     renderSidePanel(
       {
         primaryActions: [
           {
             label: 'Primary button',
-            onPrimaryActionClick,
+            onClick,
           },
         ],
       },
@@ -284,7 +286,7 @@ describe('SidePanel', () => {
     );
     const sidePanelAction = screen.getByText(/Primary button/i);
     click(sidePanelAction);
-    expect(onPrimaryActionClick).toBeCalled();
+    expect(onClick).toBeCalled();
   });
 
   it('adds additional properties to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -81,7 +81,7 @@ describe('SidePanel', () => {
   it('should render an extra small side panel', () => {
     const { container } = renderSidePanel(
       {
-        size: 'extraSmall',
+        size: 'xs',
       },
       'content'
     );
@@ -94,7 +94,7 @@ describe('SidePanel', () => {
   it('should render a small side panel', () => {
     const { container } = renderSidePanel(
       {
-        size: 'small',
+        size: 'sm',
       },
       'content'
     );
@@ -115,7 +115,7 @@ describe('SidePanel', () => {
   it('should render a large side panel', () => {
     const { container } = renderSidePanel(
       {
-        size: 'large',
+        size: 'lg',
       },
       'content'
     );

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -15,6 +15,8 @@
 @import 'carbon-components/scss/components/inline-loading/inline-loading';
 
 $block-class: #{$pkg-prefix}--side-panel;
+$action-set-block-class: #{$pkg-prefix}--action-set;
+
 $extra-small-panel-size: 16rem;
 $small-panel-size: 20rem;
 $medium-panel-size: 30rem;
@@ -66,10 +68,10 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
 
 @mixin smallButtonsStacked {
   flex-direction: column;
-  &.#{$block-class}__actions-container--multi-action-3-buttons-or-more
-    .#{$block-class}-primary-action-button,
-  &.#{$block-class}__actions-container--multi-action
-    .#{$block-class}-primary-action-button {
+  &.#{$action-set-block-class}--multi-action-3-buttons-or-more
+    .#{$action-set-block-class}__action-button,
+  &.#{$action-set-block-class}--multi-action
+    .#{$action-set-block-class}__action-button {
     width: 100%;
     max-width: 100%;
   }
@@ -239,10 +241,6 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
     .#{$block-class}__actions-container {
       position: sticky;
       bottom: 0;
-      display: flex;
-      flex-direction: row;
-      justify-content: flex-end;
-      width: 100%;
       height: $layout-05;
       background-color: $ui-01;
       border-top: 1px solid $decorative-01;
@@ -258,9 +256,9 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
         @include setActionBarSize($medium-panel-size);
 
         flex-direction: row;
-        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
+        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
           flex-direction: column;
-          .#{$block-class}__primary-action-button {
+          .#{$action-set-block-class}__action-button {
             width: 100%;
           }
         }
@@ -268,27 +266,27 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       &.#{$block-class}__actions--large {
         @include setActionBarSize($large-panel-size);
 
-        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
-          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
+          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
             width: 50%;
             max-width: 50%;
           }
         }
-        &.#{$block-class}__actions-container--single-action {
-          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+        &.#{$action-set-block-class}--single-action {
+          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
             width: 100%;
             max-width: 100%;
           }
         }
       }
       &.#{$block-class}__actions--max {
-        &.#{$block-class}__actions-container--multi-action-3-buttons-or-more {
-          .#{$block-class}__primary-action-button.#{$block-class}__ghost-button {
+        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
+          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
             width: 50%;
             max-width: 50%;
           }
         }
-        &.#{$block-class}__actions-container--single-action {
+        &.#{$action-set-block-class}--single-action {
           justify-content: flex-start;
         }
       }
@@ -297,38 +295,32 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       }
     }
     .#{$block-class}__actions-container
-      .#{$block-class}__primary-action-button {
+      .#{$action-set-block-class}__action-button {
       display: flex;
       align-items: flex-start;
       width: 100%;
       max-width: 100%;
       height: 100%;
     }
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action
-      .#{$block-class}__primary-action-button {
+    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action
+      .#{$action-set-block-class}__action-button {
       width: 50%;
       max-width: 50%;
     }
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--single-action.#{$block-class}__actions--large
-      .#{$block-class}__primary-action-button,
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action.#{$block-class}__actions--large
-      .#{$block-class}__primary-action-button {
+    .#{$block-class}__actions-container.#{$action-set-block-class}--single-action.#{$block-class}__actions--large
+      .#{$action-set-block-class}__action-button,
+    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action.#{$block-class}__actions--large
+      .#{$action-set-block-class}__action-button {
       width: 50%;
       max-width: 50%;
     }
-    .#{$block-class}__actions-container.#{$block-class}__actions-container--multi-action-3-buttons-or-more.#{$block-class}__actions--large
-      .#{$block-class}__primary-action-button,
+    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action-3-buttons-or-more.#{$block-class}__actions--large
+      .#{$action-set-block-class}__action-button,
     .#{$block-class}__actions-container.#{$block-class}__actions--max
-      .#{$block-class}__primary-action-button {
+      .#{$action-set-block-class}__action-button {
       width: 25%;
       max-width: 25%;
     }
-  }
-  .#{$block-class}__primary-action-button .bx--inline-loading {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: $spacing-07;
   }
 
   @keyframes sidePanelOverlayEntrance {

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -65,17 +65,6 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
   max-width: $size;
 }
 
-@mixin smallButtonsStacked {
-  flex-direction: column;
-  &.#{$action-set-block-class}--multi-action-3-buttons-or-more
-    .#{$action-set-block-class}__action-button,
-  &.#{$action-set-block-class}--multi-action
-    .#{$action-set-block-class}__action-button {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-
 @mixin side-panel {
   @keyframes sidePanelExitLeft {
     0% {
@@ -235,82 +224,21 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       height: $layout-05;
       background-color: $ui-01;
       border-top: 1px solid $decorative-01;
-      &.#{$block-class}__actions--extra-small {
+      &.#{$action-set-block-class}--xs {
         @include setActionBarSize($extra-small-panel-size);
-        @include smallButtonsStacked();
       }
-      &.#{$block-class}__actions--small {
+      &.#{$action-set-block-class}__sm {
         @include setActionBarSize($small-panel-size);
-        @include smallButtonsStacked();
       }
-      &.#{$block-class}__actions--medium {
+      &.#{$action-set-block-class}__md {
         @include setActionBarSize($medium-panel-size);
-
-        flex-direction: row;
-        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
-          flex-direction: column;
-          .#{$action-set-block-class}__action-button {
-            width: 100%;
-          }
-        }
       }
-      &.#{$block-class}__actions--large {
+      &.#{$action-set-block-class}__lg {
         @include setActionBarSize($large-panel-size);
-
-        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
-          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
-            width: 50%;
-            max-width: 50%;
-          }
-        }
-        &.#{$action-set-block-class}--single-action {
-          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
-            width: 100%;
-            max-width: 100%;
-          }
-        }
-      }
-      &.#{$block-class}__actions--max {
-        &.#{$action-set-block-class}--multi-action-3-buttons-or-more {
-          .#{$action-set-block-class}__action-button.#{$action-set-block-class}__ghost-button {
-            width: 50%;
-            max-width: 50%;
-          }
-        }
-        &.#{$action-set-block-class}--single-action {
-          justify-content: flex-start;
-        }
       }
       &.#{$block-class}__actions-container-condensed {
         height: $layout-04;
       }
-    }
-    .#{$block-class}__actions-container
-      .#{$action-set-block-class}__action-button {
-      display: flex;
-      align-items: flex-start;
-      width: 100%;
-      max-width: 100%;
-      height: 100%;
-    }
-    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action
-      .#{$action-set-block-class}__action-button {
-      width: 50%;
-      max-width: 50%;
-    }
-    .#{$block-class}__actions-container.#{$action-set-block-class}--single-action.#{$block-class}__actions--large
-      .#{$action-set-block-class}__action-button,
-    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action.#{$block-class}__actions--large
-      .#{$action-set-block-class}__action-button {
-      width: 50%;
-      max-width: 50%;
-    }
-    .#{$block-class}__actions-container.#{$action-set-block-class}--multi-action-3-buttons-or-more.#{$block-class}__actions--large
-      .#{$action-set-block-class}__action-button,
-    .#{$block-class}__actions-container.#{$block-class}__actions--max
-      .#{$action-set-block-class}__action-button {
-      width: 25%;
-      max-width: 25%;
     }
   }
 

--- a/packages/cloud-cognitive/src/components/SidePanel/constants.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/constants.js
@@ -6,9 +6,9 @@
  */
 
 export const SIDE_PANEL_SIZES = {
-  extraSmall: '16rem',
-  small: '20rem',
-  medium: '30rem',
-  large: '40rem',
+  xs: '16rem',
+  sm: '20rem',
+  md: '30rem',
+  lg: '40rem',
   max: '75%',
 };

--- a/packages/cloud-cognitive/src/components/SidePanel/utils.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/utils.js
@@ -1,6 +1,0 @@
-export const changeArrayPosition = (arr, originalPosition, newPosition) => {
-  const newArr = [...arr];
-  const cutOut = newArr.splice(originalPosition, 1)[0];
-  newArr.splice(newPosition, 0, cutOut);
-  return newArr;
-};

--- a/packages/cloud-cognitive/src/components/_index.scss
+++ b/packages/cloud-cognitive/src/components/_index.scss
@@ -9,6 +9,7 @@
 
 @import './AboutModal/index';
 @import './ActionBar/index';
+@import './ActionSet/index';
 @import './BreadcrumbWithOverflow/index';
 @import './_Canary/canary';
 @import './EmptyStates/index';


### PR DESCRIPTION
Contributes to #487

Creates a new ActionSet component based on the primary actions logic from SidePanel. This lays out action buttons, and also provides validation logic for the structured prop. I also looked through the layout logic and streamlined it a little. NB I have left most of the style rules in SidePanel, as I am not sure how many of them will be general and how many are specific to the SidePanel design: I may move some of those style rules into the ActionSet when I investigate how to use the ActionSet for the TearSheet action buttons.

#### What did you change?

SidePanel files, including tests and stories. Also created ActionSet files, including tests, and added action-set scss to main component roll-up.

#### How did you test and verify your work?

Ran build, tests, and ran storybook and checked multiple configurations. I may not have checked every relevant configuration, though, so do verify this!
