### PR TITLE
Make an internal category for stories for non-public components

### DIFF
--- a/packages/cloud-cognitive/config.js
+++ b/packages/cloud-cognitive/config.js
@@ -7,17 +7,23 @@
 
 export const storybookPrefixCanary = 'Cloud & Cognitive/Canary';
 export const storybookPrefixReleased = 'Cloud & Cognitive/Released';
+export const storybookPrefixInternal = 'Cloud & Cognitive/Internal';
+
 export const getStorybookPrefix = (pkg, componentName) => {
   return pkg.isComponentEnabled(componentName, true)
     ? storybookPrefixReleased
-    : storybookPrefixCanary;
+    : pkg.isComponentPublic(componentName, true)
+    ? storybookPrefixCanary
+    : storybookPrefixInternal;
 };
 
 export const getStorybookSlug = (pkg, componentName, scenario) => {
   const lcName = componentName.toLocaleLowerCase();
   const state = pkg.isComponentEnabled(componentName, true)
     ? 'released'
-    : 'canary';
+    : pkg.isComponentPublic(componentName, true)
+    ? 'canary'
+    : 'internal';
 
   return `cloud-cognitive-${state}-${lcName}--${scenario}`;
 };

--- a/packages/cloud-cognitive/src/__tests__/index.test.js
+++ b/packages/cloud-cognitive/src/__tests__/index.test.js
@@ -31,7 +31,12 @@ describe(name, () => {
       if (key.startsWith('ComboButton')) continue;
 
       if (!pkg.isComponentEnabled(key)) {
-        // We check that unreleased components render a Canary.
+        // We check that exported components are listed in package settings.
+        it(`has a component flag in package settings for "${key}"`, () => {
+          expect(pkg.isComponentPublic(key)).toBeTruthy();
+        });
+
+        // We check that unreleased public components render a Canary.
         // Non-canary components are tested elsewhere.
         it(`renders a canary by default for "${key}"`, () => {
           const { container } = render(<TestComponent />);

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
@@ -14,7 +14,7 @@ import { pkg } from '../../settings';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
 import { getStorybookPrefix } from '../../../config';
 import { ActionBar, ActionBarItem } from '.';
-const storybookPrefix = getStorybookPrefix(pkg, ActionBar.displayName);
+const storybookPrefix = getStorybookPrefix(pkg, ActionBarItem.displayName);
 
 const blockClass = `${pkg.prefix}--action-bar`;
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
@@ -13,17 +13,21 @@ import '../../utils/enable-all'; // must come before component is imported (dire
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
 import mdx from './EmptyState.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 
-import { EmptyState } from '.';
-import { ErrorEmptyState } from './ErrorEmptyState';
-import { NoDataEmptyState } from './NoDataEmptyState';
-import { NoTagsEmptyState } from './NoTagsEmptyState';
-import { NotFoundEmptyState } from './NotFoundEmptyState';
-import { NotificationsEmptyState } from './NotificationsEmptyState';
-import { UnauthorizedEmptyState } from './UnauthorizedEmptyState';
+import {
+  EmptyState,
+  ErrorEmptyState,
+  NoDataEmptyState,
+  NoTagsEmptyState,
+  NotFoundEmptyState,
+  NotificationsEmptyState,
+  UnauthorizedEmptyState,
+} from '.';
 
 import styles from './_storybook-styles.scss';
+
+const storybookPrefix = getStorybookPrefix(pkg, EmptyState.displayName);
+console.log(EmptyState.displayName, storybookPrefix);
 
 export default {
   title: `${storybookPrefix}/EmptyStates/EmptyState`,

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -12,14 +12,15 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './ErrorEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 
 import { ErrorEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, ErrorEmptyState.displayName);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/ErrorEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${ErrorEmptyState.displayName}`,
   component: ErrorEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -12,14 +12,15 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './NoDataEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 
 import { NoDataEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, NoDataEmptyState.displayName);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/NoDataEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${NoDataEmptyState.displayName}`,
   component: NoDataEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -12,14 +12,15 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './NoTagsEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 
 import { NoTagsEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, NoTagsEmptyState.displayName);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/NoTagsEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${NoTagsEmptyState.displayName}`,
   component: NoTagsEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -12,14 +12,14 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './NotFoundEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
-
 import { NotFoundEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, NotFoundEmptyState.displayName);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/NotFoundEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${NotFoundEmptyState.displayName}`,
   component: NotFoundEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -12,13 +12,17 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './NotificationsEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 import { NotificationsEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(
+  pkg,
+  NotificationsEmptyState.displayName
+);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/NotificationsEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${NotificationsEmptyState.displayName}`,
   component: NotificationsEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -12,13 +12,17 @@ import '../../../utils/enable-all'; // must come before component is imported (d
 import mdx from './UnauthorizedEmptyState.mdx';
 import { pkg } from '../../../settings';
 import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'EmptyStates');
 import { UnauthorizedEmptyState } from '.';
 
 import styles from '../_index.scss';
 
+const storybookPrefix = getStorybookPrefix(
+  pkg,
+  UnauthorizedEmptyState.displayName
+);
+
 export default {
-  title: `${storybookPrefix}/EmptyStates/UnauthorizedEmptyState`,
+  title: `${storybookPrefix}/EmptyStates/${UnauthorizedEmptyState.displayName}`,
   component: UnauthorizedEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/index.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/index.js
@@ -6,3 +6,9 @@
  */
 
 export { EmptyState } from './EmptyState';
+export { ErrorEmptyState } from './ErrorEmptyState';
+export { NoDataEmptyState } from './NoDataEmptyState';
+export { NoTagsEmptyState } from './NoTagsEmptyState';
+export { NotFoundEmptyState } from './NotFoundEmptyState';
+export { NotificationsEmptyState } from './NotificationsEmptyState';
+export { UnauthorizedEmptyState } from './UnauthorizedEmptyState';

--- a/packages/cloud-cognitive/src/components/HTTPErrors/index.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/index.js
@@ -5,4 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export { HTTPErrors } from './HTTPErrors';
+export { HTTPError403 } from './HTTPError403';
+export { HTTPError404 } from './HTTPError404';
+export { HTTPErrorOther } from './HTTPErrorOther';

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -8,18 +8,18 @@
 export { AboutModal } from './AboutModal';
 export { ActionBarItem } from './ActionBar';
 export { BreadcrumbWithOverflow } from './BreadcrumbWithOverflow';
-export { EmptyState } from './EmptyStates/EmptyState';
-export { ErrorEmptyState } from './EmptyStates/ErrorEmptyState';
-export { NoDataEmptyState } from './EmptyStates/NoDataEmptyState';
-export { NoTagsEmptyState } from './EmptyStates/NoTagsEmptyState';
-export { NotFoundEmptyState } from './EmptyStates/NotFoundEmptyState';
-export { NotificationsEmptyState } from './EmptyStates/NotificationsEmptyState';
-export { UnauthorizedEmptyState } from './EmptyStates/UnauthorizedEmptyState';
 export { ContextHeader } from './ContextHeader';
+export {
+  EmptyState,
+  ErrorEmptyState,
+  NoDataEmptyState,
+  NoTagsEmptyState,
+  NotFoundEmptyState,
+  NotificationsEmptyState,
+  UnauthorizedEmptyState,
+} from './EmptyStates';
 export { ExampleComponent } from './ExampleComponent';
-export { HTTPError403 } from './HTTPErrors/HTTPError403';
-export { HTTPError404 } from './HTTPErrors/HTTPError404';
-export { HTTPErrorOther } from './HTTPErrors/HTTPErrorOther';
+export { HTTPError403, HTTPError404, HTTPErrorOther } from './HTTPErrors';
 export { ImportModal } from './ImportModal';
 export { ModifiedTabs } from './ModifiedTabs';
 export { Notifications } from './Notifications';

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -13,38 +13,40 @@ const defaults = {
     // reviewed and released components:
     AboutModal: true,
 
-    // other components not yet reviewed and released:
+    // other public components not yet reviewed and released:
     ActionBarItem: false,
-    APIKeyDownlaoder: false,
+    APIKeyDownloader: false,
     APIKeyModal: false,
     BreadcrumbWithOverflow: false,
     Card: false,
     ContextHeader: false,
     EmptyState: false,
     ErrorEmptyState: false,
-    NoDataEmptyState: false,
-    NoTagsEmptyState: false,
-    NotFoundEmptyState: false,
-    NotificationsEmptyState: false,
-    UnauthorizedEmptyState: false,
     ExampleComponent: false,
     ExportModal: false,
-    HTTPErrors: false,
+    ExpressiveCard: false,
     HTTPError403: false,
     HTTPError404: false,
     HTTPErrorOther: false,
     ImportModal: false,
     ModifiedTabs: false,
+    NoDataEmptyState: false,
+    NoTagsEmptyState: false,
+    NotFoundEmptyState: false,
     Notifications: false,
+    NotificationsEmptyState: false,
     PageActionItem: false,
     PageHeader: false,
+    ProductiveCard: false,
     RemoveDeleteModal: false,
+    Saving: false,
     SidePanel: false,
     StatusIcon: false,
     TagSet: false,
     Tearsheet: false,
     TearsheetNarrow: false,
-    TearsheetShell: false,
+    UnauthorizedEmptyState: false,
+    UserProfileImage: false,
     WebTerminal: false,
     /* new component flags here - comment used by generate CLI */
   },
@@ -114,8 +116,24 @@ export default {
       : component[componentName];
   },
 
+  isComponentPublic: (componentOrName, byDefault = false) => {
+    const componentName =
+      componentOrName?.displayName || componentOrName?.name || componentOrName;
+    return Object.prototype.hasOwnProperty.call(
+      byDefault ? defaults.component : component,
+      componentName
+    );
+  },
+
   isFeatureEnabled: (featureName, byDefault = false) => {
     return byDefault ? defaults.feature[featureName] : feature[featureName];
+  },
+
+  isFeaturePublic: (featureName, byDefault = false) => {
+    return Object.prototype.hasOwnProperty.call(
+      byDefault ? defaults.feature : feature,
+      featureName
+    );
   },
 
   setAllComponents: (enabled) => {


### PR DESCRIPTION
Contributes to #487

The stories for ActionSet don't seem to belong in 'Canary', and certainly don't belong in 'Released', so this PR makes a third category 'Internal' for stories for non-public components. The stories for TearsheetShell are in there too. There may be other stories for internal-only components that could go there. It would be nice to hide this category in an externally-published storybook -- if anyone knows how to do that we can make that happen :-)

#### What did you change?

Added methods to package-settings to find out whether a component is known to the package settings at all, and updated config to return a third category for non-public components. Also tidied up exports from several components, and made sure they were getting their storybookPrefix using the right component name so they appeared in the right category.

#### How did you test and verify your work?

Ran build, ran tests, ran up storybook.