### PR TITLE
test(styles): add styles public API test

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,10 +56,14 @@ See example component enabled via feature flags on
 For more information on how this affects components see
 [CANARY_STRUCTURE.md](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CANARY_STRUCTURE.md).
 
-## 4. Test your JavaScript code
+## 4. Test your code
 
 If you're contributing to our JavaScript code, test your changes by running
 `yarn test`.
+
+If you're contributing to our styles, the continuous integration check will fail
+because of a public API snapshot change. Update the snapshot by running
+`yarn test -u`.
 
 New tests are written in
 [React Testing Library](https://testing-library.com/docs/react-testing-library/intro),

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1,0 +1,14562 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Styles Public API 1`] = `
+"html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
+  border: 0;
+}
+
+button,
+select,
+input,
+textarea {
+  font-family: inherit;
+  border-radius: 0;
+}
+
+input[type='text']::-ms-clear {
+  display: none;
+}
+
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section {
+  display: block;
+}
+
+body {
+  line-height: 1;
+}
+
+sup {
+  vertical-align: super;
+}
+
+sub {
+  vertical-align: sub;
+}
+
+ol,
+ul {
+  list-style: none;
+}
+
+blockquote,
+q {
+  quotes: none;
+}
+
+blockquote::before,
+blockquote::after,
+q::before,
+q::after {
+  content: '';
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  margin: 0;
+}
+
+html {
+  font-size: 100%;
+}
+
+body {
+  font-weight: 400;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+}
+
+strong {
+  font-weight: 600;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  svg {
+    fill: ButtonText;
+  }
+}
+
+h1 {
+  font-size: var(--cds-productive-heading-06-font-size, 2.625rem);
+  font-weight: var(--cds-productive-heading-06-font-weight, 300);
+  line-height: var(--cds-productive-heading-06-line-height, 1.199);
+  letter-spacing: var(--cds-productive-heading-06-letter-spacing, 0);
+}
+
+h2 {
+  font-size: var(--cds-productive-heading-05-font-size, 2rem);
+  font-weight: var(--cds-productive-heading-05-font-weight, 400);
+  line-height: var(--cds-productive-heading-05-line-height, 1.25);
+  letter-spacing: var(--cds-productive-heading-05-letter-spacing, 0);
+}
+
+h3 {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+}
+
+h4 {
+  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-productive-heading-03-font-weight, 400);
+  line-height: var(--cds-productive-heading-03-line-height, 1.4);
+  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+}
+
+h5 {
+  font-size: var(--cds-productive-heading-02-font-size, 1rem);
+  font-weight: var(--cds-productive-heading-02-font-weight, 600);
+  line-height: var(--cds-productive-heading-02-line-height, 1.375);
+  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
+}
+
+h6 {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+}
+
+p {
+  font-size: var(--cds-body-long-02-font-size, 1rem);
+  font-weight: var(--cds-body-long-02-font-weight, 400);
+  line-height: var(--cds-body-long-02-line-height, 1.5);
+  letter-spacing: var(--cds-body-long-02-letter-spacing, 0);
+}
+
+a {
+  color: #0f62fe;
+}
+
+em {
+  font-style: italic;
+}
+
+@keyframes skeleton {
+  0% {
+    transform: scaleX(0);
+    transform-origin: left;
+    opacity: 0.3;
+  }
+  20% {
+    transform: scaleX(1);
+    transform-origin: left;
+    opacity: 1;
+  }
+  28% {
+    transform: scaleX(1);
+    transform-origin: right;
+  }
+  51% {
+    transform: scaleX(0);
+    transform-origin: right;
+  }
+  58% {
+    transform: scaleX(0);
+    transform-origin: right;
+  }
+  82% {
+    transform: scaleX(1);
+    transform-origin: right;
+  }
+  83% {
+    transform: scaleX(1);
+    transform-origin: left;
+  }
+  96% {
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+  100% {
+    transform: scaleX(0);
+    transform-origin: left;
+    opacity: 0.3;
+  }
+}
+
+.bx--link {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  color: var(--cds-link-01, #0f62fe);
+  text-decoration: none;
+  outline: none;
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--link *,
+.bx--link *::before,
+.bx--link *::after {
+  box-sizing: inherit;
+}
+
+.bx--link:hover {
+  color: var(--cds-hover-primary-text, #0043ce);
+  text-decoration: underline;
+}
+
+.bx--link:active, .bx--link:active:visited, .bx--link:active:visited:hover {
+  color: var(--cds-text-01, #161616);
+  text-decoration: underline;
+}
+
+.bx--link:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--link:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--link:visited {
+  color: var(--cds-link-01, #0f62fe);
+}
+
+.bx--link:visited:hover {
+  color: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--link--disabled,
+.bx--link--disabled:hover {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: inline;
+  color: var(--cds-disabled-02, #c6c6c6);
+  font-weight: 400;
+  text-decoration: none;
+  cursor: not-allowed;
+}
+
+.bx--link--disabled *,
+.bx--link--disabled *::before,
+.bx--link--disabled *::after,
+.bx--link--disabled:hover *,
+.bx--link--disabled:hover *::before,
+.bx--link--disabled:hover *::after {
+  box-sizing: inherit;
+}
+
+.bx--link.bx--link--visited:visited {
+  color: var(--cds-visited-link, #8a3ffc);
+}
+
+.bx--link.bx--link--visited:visited:hover {
+  color: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--link.bx--link--inline {
+  text-decoration: underline;
+}
+
+.bx--link.bx--link--inline:focus, .bx--link.bx--link--inline:visited {
+  text-decoration: none;
+}
+
+.bx--link--disabled.bx--link--inline {
+  text-decoration: underline;
+}
+
+.bx--link--sm {
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  line-height: var(--cds-helper-text-01-line-height, 1.34);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+}
+
+.bx--link--lg {
+  font-size: var(--cds-body-short-02-font-size, 1rem);
+  font-weight: var(--cds-body-short-02-font-weight, 400);
+  line-height: var(--cds-body-short-02-line-height, 1.375);
+  letter-spacing: var(--cds-body-short-02-letter-spacing, 0);
+}
+
+.bx--text-truncate--end {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--text-truncate--front {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  direction: rtl;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--assistive-text,
+.bx--visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--body {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  color: var(--cds-text-01, #161616);
+  line-height: 1;
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.bx--body *,
+.bx--body *::before,
+.bx--body *::after {
+  box-sizing: inherit;
+}
+
+.bx--btn {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 20rem;
+  min-height: 3rem;
+  margin: 0;
+  padding: calc(0.875rem - 3px) 63px calc(0.875rem - 3px) 15px;
+  text-align: left;
+  text-decoration: none;
+  vertical-align: top;
+  border-radius: 0;
+  outline: none;
+  cursor: pointer;
+  transition: background 70ms cubic-bezier(0, 0, 0.38, 0.9), box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9), border-color 70ms cubic-bezier(0, 0, 0.38, 0.9), outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--btn *,
+.bx--btn *::before,
+.bx--btn *::after {
+  box-sizing: inherit;
+}
+
+.bx--btn:disabled, .bx--btn:hover:disabled, .bx--btn:focus:disabled, .bx--btn.bx--btn--disabled, .bx--btn.bx--btn--disabled:hover, .bx--btn.bx--btn--disabled:focus {
+  color: var(--cds-disabled-03, #8d8d8d);
+  background: var(--cds-disabled-02, #c6c6c6);
+  border-color: var(--cds-disabled-02, #c6c6c6);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.bx--btn .bx--btn__icon {
+  position: absolute;
+  right: 1rem;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.bx--btn::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.bx--btn--primary {
+  color: var(--cds-text-04, #ffffff);
+  background-color: var(--cds-interactive-01, #0f62fe);
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--primary:hover {
+  background-color: var(--cds-hover-primary, #0353e9);
+}
+
+.bx--btn--primary:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--primary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--primary:active {
+  background-color: var(--cds-active-primary, #002d9c);
+}
+
+.bx--btn--primary .bx--btn__icon,
+.bx--btn--primary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--primary:hover {
+  color: var(--cds-text-04, #ffffff);
+}
+
+.bx--btn--secondary {
+  color: var(--cds-text-04, #ffffff);
+  background-color: var(--cds-interactive-02, #393939);
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--secondary:hover {
+  background-color: var(--cds-hover-secondary, #4c4c4c);
+}
+
+.bx--btn--secondary:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--secondary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--secondary:active {
+  background-color: var(--cds-active-secondary, #6f6f6f);
+}
+
+.bx--btn--secondary .bx--btn__icon,
+.bx--btn--secondary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--secondary:hover, .bx--btn--secondary:focus {
+  color: var(--cds-text-04, #ffffff);
+}
+
+.bx--btn--tertiary {
+  color: var(--cds-interactive-03, #0f62fe);
+  background-color: transparent;
+  border-color: var(--cds-interactive-03, #0f62fe);
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--tertiary:hover {
+  background-color: var(--cds-hover-tertiary, #0353e9);
+}
+
+.bx--btn--tertiary:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--tertiary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--tertiary:active {
+  background-color: var(--cds-active-tertiary, #002d9c);
+}
+
+.bx--btn--tertiary .bx--btn__icon,
+.bx--btn--tertiary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--tertiary:hover {
+  color: var(--cds-inverse-01, #ffffff);
+}
+
+.bx--btn--tertiary:focus {
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-interactive-03, #0f62fe);
+}
+
+.bx--btn--tertiary:active {
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-active-tertiary, #002d9c);
+  border-color: transparent;
+}
+
+.bx--btn--tertiary:disabled, .bx--btn--tertiary:hover:disabled, .bx--btn--tertiary:focus:disabled, .bx--btn--tertiary.bx--btn--disabled, .bx--btn--tertiary.bx--btn--disabled:hover, .bx--btn--tertiary.bx--btn--disabled:focus {
+  color: var(--cds-disabled-03, #8d8d8d);
+  background: transparent;
+  outline: none;
+}
+
+.bx--btn--ghost {
+  color: var(--cds-link-01, #0f62fe);
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  padding: calc(0.875rem - 3px) 16px;
+}
+
+.bx--btn--ghost:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--btn--ghost:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--ghost:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--ghost:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--btn--ghost .bx--btn__icon,
+.bx--btn--ghost .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--ghost .bx--btn__icon {
+  position: static;
+  margin-left: 0.5rem;
+}
+
+.bx--btn--ghost:hover, .bx--btn--ghost:active {
+  color: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--btn--ghost:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--btn--ghost:disabled, .bx--btn--ghost:hover:disabled, .bx--btn--ghost:focus:disabled, .bx--btn--ghost.bx--btn--disabled, .bx--btn--ghost.bx--btn--disabled:hover, .bx--btn--ghost.bx--btn--disabled:focus {
+  color: var(--cds-disabled-03, #8d8d8d);
+  background: transparent;
+  border-color: transparent;
+  outline: none;
+}
+
+.bx--btn--ghost.bx--btn--sm {
+  padding: calc(0.375rem - 3px) 16px;
+}
+
+.bx--btn--ghost.bx--btn--field {
+  padding: calc(0.675rem - 3px) 16px;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
+  content: attr(aria-label);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger svg,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover svg,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+  fill: currentColor;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  opacity: 0;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  border-color: var(--cds-focus, #0f62fe);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:active:not([disabled]) {
+  border-color: transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus
+svg {
+  outline-color: transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:hover,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:focus,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:active {
+  cursor: not-allowed;
+  fill: var(--cds-disabled-03, #8d8d8d);
+}
+
+.bx--btn--icon-only--top {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--btn--icon-only--top:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn--icon-only--top:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn--icon-only--top:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--btn--icon-only--top:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn--icon-only--top:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--a11y::before, .bx--btn--icon-only--top.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--btn--icon-only--top::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--btn--icon-only--top::after {
+  content: attr(aria-label);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible::before, .bx--btn--icon-only--top.bx--tooltip--visible::after, .bx--btn--icon-only--top:hover::before, .bx--btn--icon-only--top:hover::after, .bx--btn--icon-only--top:focus::before, .bx--btn--icon-only--top:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top:hover .bx--assistive-text,
+.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:focus .bx--assistive-text,
+.bx--btn--icon-only--top:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn--icon-only--top:hover .bx--assistive-text,
+.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:hover.bx--tooltip--a11y::before, .bx--btn--icon-only--top:focus .bx--assistive-text,
+.bx--btn--icon-only--top:focus + .bx--assistive-text, .bx--btn--icon-only--top:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--hidden .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--btn--icon-only--top::before {
+  top: -0.5rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  top: -0.8125rem;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--btn--icon-only--bottom::before, .bx--btn--icon-only--bottom::after,
+.bx--btn--icon-only--bottom .bx--assistive-text,
+.bx--btn--icon-only--bottom + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--btn--icon-only--bottom::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--btn--icon-only--bottom::after,
+.bx--btn--icon-only--bottom .bx--assistive-text,
+.bx--btn--icon-only--bottom + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--btn--icon-only {
+  padding-right: 0.9375rem;
+  padding-left: 0.9375rem;
+}
+
+.bx--btn--icon-only .bx--btn__icon {
+  position: static;
+}
+
+.bx--btn--icon-only.bx--btn--ghost .bx--btn__icon,
+.bx--btn--icon-only.bx--btn--danger--ghost .bx--btn__icon {
+  margin: 0;
+}
+
+.bx--btn--icon-only.bx--btn--selected {
+  background: var(--cds-selected-ui, #e0e0e0);
+}
+
+.bx--btn path[data-icon-path='inner-path'] {
+  fill: none;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost
+.bx--btn__icon path,
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost:hover
+.bx--btn__icon path {
+    fill: ButtonText;
+  }
+}
+
+.bx--btn--ghost.bx--btn--icon-only
+.bx--btn__icon
+path:not([data-icon-path]),
+.bx--btn--ghost.bx--btn--icon-only .bx--btn__icon {
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon
+path,
+.bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon,
+.bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
+.bx--btn__icon {
+  fill: var(--cds-disabled-03, #8d8d8d);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon
+path path,
+  .bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon path,
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
+.bx--btn__icon path {
+    fill: GrayText;
+  }
+}
+
+.bx--btn--ghost.bx--btn--icon-only[disabled] {
+  cursor: not-allowed;
+}
+
+.bx--btn--field.bx--btn--icon-only {
+  padding-right: 0.6875rem;
+  padding-left: 0.6875rem;
+}
+
+.bx--btn--sm.bx--btn--icon-only {
+  padding-right: 0.4375rem;
+  padding-left: 0.4375rem;
+}
+
+.bx--btn--danger {
+  color: var(--cds-text-04, #ffffff);
+  background-color: var(--cds-danger-01, #da1e28);
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--danger:hover {
+  background-color: var(--cds-hover-danger, #b81921);
+}
+
+.bx--btn--danger:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger:active {
+  background-color: var(--cds-active-danger, #750e13);
+}
+
+.bx--btn--danger .bx--btn__icon,
+.bx--btn--danger .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger:hover {
+  color: var(--cds-text-04, #ffffff);
+}
+
+.bx--btn--danger-tertiary, .bx--btn--danger--tertiary {
+  color: var(--cds-danger-02, #da1e28);
+  background-color: transparent;
+  border-color: var(--cds-danger-02, #da1e28);
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
+  background-color: var(--cds-hover-danger, #b81921);
+}
+
+.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
+  background-color: var(--cds-active-danger, #750e13);
+}
+
+.bx--btn--danger-tertiary .bx--btn__icon,
+.bx--btn--danger-tertiary .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--tertiary .bx--btn__icon,
+.bx--btn--danger--tertiary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
+  color: var(--cds-text-04, #ffffff);
+  border-color: var(--cds-hover-danger, #b81921);
+}
+
+.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+  color: var(--cds-text-04, #ffffff);
+  background-color: var(--cds-danger-01, #da1e28);
+}
+
+.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
+  color: var(--cds-text-04, #ffffff);
+  border-color: var(--cds-active-danger, #750e13);
+}
+
+.bx--btn--danger-tertiary:disabled, .bx--btn--danger-tertiary:hover:disabled, .bx--btn--danger-tertiary:focus:disabled, .bx--btn--danger-tertiary.bx--btn--disabled, .bx--btn--danger-tertiary.bx--btn--disabled:hover, .bx--btn--danger-tertiary.bx--btn--disabled:focus, .bx--btn--danger--tertiary:disabled, .bx--btn--danger--tertiary:hover:disabled, .bx--btn--danger--tertiary:focus:disabled, .bx--btn--danger--tertiary.bx--btn--disabled, .bx--btn--danger--tertiary.bx--btn--disabled:hover, .bx--btn--danger--tertiary.bx--btn--disabled:focus {
+  color: var(--cds-disabled-03, #8d8d8d);
+  background: transparent;
+  outline: none;
+}
+
+.bx--btn--danger-ghost, .bx--btn--danger--ghost {
+  color: var(--cds-danger-02, #da1e28);
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  padding: calc(0.875rem - 3px) 16px;
+}
+
+.bx--btn--danger-ghost:hover, .bx--btn--danger--ghost:hover {
+  background-color: var(--cds-hover-danger, #b81921);
+}
+
+.bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger-ghost:active, .bx--btn--danger--ghost:active {
+  background-color: var(--cds-active-danger, #750e13);
+}
+
+.bx--btn--danger-ghost .bx--btn__icon,
+.bx--btn--danger-ghost .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--ghost .bx--btn__icon,
+.bx--btn--danger--ghost .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger-ghost .bx--btn__icon, .bx--btn--danger--ghost .bx--btn__icon {
+  position: static;
+  margin-left: 0.5rem;
+}
+
+.bx--btn--danger-ghost:hover, .bx--btn--danger-ghost:active, .bx--btn--danger--ghost:hover, .bx--btn--danger--ghost:active {
+  color: var(--cds-text-04, #ffffff);
+}
+
+.bx--btn--danger-ghost:disabled, .bx--btn--danger-ghost:hover:disabled, .bx--btn--danger-ghost:focus:disabled, .bx--btn--danger-ghost.bx--btn--disabled, .bx--btn--danger-ghost.bx--btn--disabled:hover, .bx--btn--danger-ghost.bx--btn--disabled:focus, .bx--btn--danger--ghost:disabled, .bx--btn--danger--ghost:hover:disabled, .bx--btn--danger--ghost:focus:disabled, .bx--btn--danger--ghost.bx--btn--disabled, .bx--btn--danger--ghost.bx--btn--disabled:hover, .bx--btn--danger--ghost.bx--btn--disabled:focus {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background: transparent;
+  border-color: transparent;
+  outline: none;
+}
+
+.bx--btn--danger-ghost.bx--btn--sm, .bx--btn--danger--ghost.bx--btn--sm {
+  padding: calc(0.375rem - 3px) 16px;
+}
+
+.bx--btn--danger-ghost.bx--btn--field, .bx--btn--danger--ghost.bx--btn--field {
+  padding: calc(0.675rem - 3px) 16px;
+}
+
+.bx--btn--sm {
+  min-height: 2rem;
+  padding: calc(0.375rem - 3px) 60px calc(0.375rem - 3px) 12px;
+}
+
+.bx--btn--xl:not(.bx--btn--icon-only) {
+  align-items: baseline;
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-right: var(--cds-layout-05, 4rem);
+  padding-left: var(--cds-spacing-05, 1rem);
+  min-height: 5rem;
+}
+
+.bx--btn--lg:not(.bx--btn--icon-only) {
+  align-items: baseline;
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-right: var(--cds-layout-05, 4rem);
+  padding-left: var(--cds-spacing-05, 1rem);
+  min-height: 4rem;
+}
+
+.bx--btn--field {
+  min-height: 2.5rem;
+  padding: calc(0.675rem - 3px) 60px calc(0.675rem - 3px) 12px;
+}
+
+.bx--btn.bx--skeleton {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 9.375rem;
+}
+
+.bx--btn.bx--skeleton:hover, .bx--btn.bx--skeleton:focus, .bx--btn.bx--skeleton:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--btn.bx--skeleton::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--btn.bx--skeleton::before {
+    animation: none;
+  }
+}
+
+.bx--btn-set {
+  display: flex;
+}
+
+.bx--btn-set--stacked {
+  flex-direction: column;
+}
+
+.bx--btn-set .bx--btn {
+  width: 100%;
+  max-width: 12.25rem;
+}
+
+.bx--btn-set .bx--btn:not(:focus) {
+  box-shadow: -0.0625rem 0 0 0 var(--cds-button-separator, #e0e0e0);
+}
+
+.bx--btn-set .bx--btn:first-of-type:not(:focus) {
+  box-shadow: inherit;
+}
+
+.bx--btn-set .bx--btn:focus + .bx--btn {
+  box-shadow: inherit;
+}
+
+.bx--btn-set--stacked .bx--btn:not(:focus) {
+  box-shadow: 0 -0.0625rem 0 0 var(--cds-button-separator, #e0e0e0);
+}
+
+.bx--btn-set--stacked .bx--btn:first-of-type:not(:focus) {
+  box-shadow: inherit;
+}
+
+.bx--btn-set .bx--btn.bx--btn--disabled {
+  box-shadow: -0.0625rem 0 0 0 var(--cds-disabled-03, #8d8d8d);
+}
+
+.bx--btn-set .bx--btn.bx--btn--disabled:first-of-type {
+  box-shadow: none;
+}
+
+.bx--btn-set--stacked .bx--btn.bx--btn--disabled {
+  box-shadow: 0 -0.0625rem 0 0 var(--cds-disabled-03, #8d8d8d);
+}
+
+.bx--btn-set--stacked .bx--btn.bx--btn--disabled:first-of-type {
+  box-shadow: none;
+}
+
+.bx--modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  background-color: transparent;
+  visibility: hidden;
+  opacity: 0;
+  transition: background-color 720ms cubic-bezier(0.4, 0.14, 1, 1), opacity 240ms cubic-bezier(0.4, 0.14, 1, 1), visibility 0ms linear 240ms;
+  content: '';
+}
+
+.bx--modal.is-visible {
+  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
+  visibility: inherit;
+  opacity: 1;
+  transition: background-color 720ms cubic-bezier(0, 0, 0.3, 1), opacity 240ms cubic-bezier(0, 0, 0.3, 1), visibility 0ms linear;
+}
+
+.bx--modal .bx--text-input,
+.bx--modal .bx--text-area,
+.bx--modal .bx--search-input,
+.bx--modal .bx--select-input,
+.bx--modal .bx--dropdown,
+.bx--modal .bx--dropdown-list,
+.bx--modal .bx--number input[type='number'],
+.bx--modal .bx--date-picker__input {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--modal.is-visible .bx--modal-container {
+  transform: translate3d(0, 0, 0);
+  transition: transform 240ms cubic-bezier(0, 0, 0.3, 1);
+}
+
+.bx--modal-container {
+  position: fixed;
+  top: 0;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: auto;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  outline: 3px solid transparent;
+  outline-offset: -3px;
+  transform: translate3d(0, -24px, 0);
+  transform-origin: top center;
+  transition: transform 240ms cubic-bezier(0.4, 0.14, 1, 1);
+}
+
+@media (min-width: 42rem) {
+  .bx--modal-container {
+    position: static;
+    width: 84%;
+    height: auto;
+    max-height: 90%;
+  }
+  .bx--modal-container .bx--modal-header,
+  .bx--modal-container .bx--modal-content,
+  .bx--modal-container .bx--modal-content__regular-content {
+    padding-right: 20%;
+  }
+  .bx--modal-container .bx--modal-content--with-form {
+    padding-right: var(--cds-spacing-05, 1rem);
+  }
+}
+
+@media (min-width: 66rem) {
+  .bx--modal-container {
+    width: 60%;
+    max-height: 84%;
+  }
+}
+
+@media (min-width: 82rem) {
+  .bx--modal-container {
+    width: 48%;
+  }
+}
+
+.bx--modal-header,
+.bx--modal-content {
+  padding-left: var(--cds-spacing-05, 1rem);
+}
+
+.bx--modal-header,
+.bx--modal-content,
+.bx--modal-content__regular-content {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+.bx--modal-content--with-form {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+.bx--modal-container--xs .bx--modal-header {
+  padding-right: 3rem;
+}
+
+.bx--modal-container--xs .bx--modal-content,
+.bx--modal-container--xs .bx--modal-content__regular-content,
+.bx--modal-container--xs .bx--modal-content--with-form {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+@media (min-width: 42rem) {
+  .bx--modal-container--xs {
+    width: 48%;
+  }
+}
+
+@media (min-width: 66rem) {
+  .bx--modal-container--xs {
+    width: 32%;
+    max-height: 48%;
+  }
+}
+
+@media (min-width: 82rem) {
+  .bx--modal-container--xs {
+    width: 24%;
+  }
+}
+
+.bx--modal-container--sm .bx--modal-header {
+  padding-right: 3rem;
+}
+
+.bx--modal-container--sm .bx--modal-content,
+.bx--modal-container--sm .bx--modal-content__regular-content,
+.bx--modal-container--sm .bx--modal-content--with-form {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+@media (min-width: 42rem) {
+  .bx--modal-container--sm {
+    width: 60%;
+  }
+}
+
+@media (min-width: 66rem) {
+  .bx--modal-container--sm {
+    width: 42%;
+    max-height: 72%;
+  }
+}
+
+@media (min-width: 82rem) {
+  .bx--modal-container--sm {
+    width: 36%;
+  }
+  .bx--modal-container--sm .bx--modal-header,
+  .bx--modal-container--sm .bx--modal-content,
+  .bx--modal-container--sm .bx--modal-content__regular-content {
+    padding-right: 20%;
+  }
+  .bx--modal-container--sm .bx--modal-content--with-form {
+    padding-right: var(--cds-spacing-05, 1rem);
+  }
+}
+
+.bx--modal-container--lg .bx--modal-header {
+  padding-right: 3rem;
+}
+
+.bx--modal-container--lg .bx--modal-content,
+.bx--modal-container--lg .bx--modal-content__regular-content,
+.bx--modal-container--lg .bx--modal-content--with-form {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+@media (min-width: 42rem) {
+  .bx--modal-container--lg {
+    width: 96%;
+  }
+  .bx--modal-container--lg .bx--modal-header,
+  .bx--modal-container--lg .bx--modal-content,
+  .bx--modal-container--lg .bx--modal-content__regular-content {
+    padding-right: 20%;
+  }
+  .bx--modal-container--lg .bx--modal-content--with-form {
+    padding-right: var(--cds-spacing-05, 1rem);
+  }
+}
+
+@media (min-width: 66rem) {
+  .bx--modal-container--lg {
+    width: 84%;
+    max-height: 96%;
+  }
+}
+
+@media (min-width: 82rem) {
+  .bx--modal-container--lg {
+    width: 72%;
+  }
+}
+
+.bx--modal-header {
+  grid-row: 1/1;
+  grid-column: 1/-1;
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-right: var(--cds-spacing-09, 3rem);
+}
+
+.bx--modal-header__label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--modal-header__heading {
+  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-productive-heading-03-font-weight, 400);
+  line-height: var(--cds-productive-heading-03-line-height, 1.4);
+  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--modal-content {
+  font-size: var(--cds-body-long-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-long-01-font-weight, 400);
+  line-height: var(--cds-body-long-01-line-height, 1.43);
+  letter-spacing: var(--cds-body-long-01-letter-spacing, 0.16px);
+  position: relative;
+  grid-row: 2/-2;
+  grid-column: 1/-1;
+  margin-bottom: var(--cds-spacing-09, 3rem);
+  padding-top: var(--cds-spacing-03, 0.5rem);
+  overflow-y: auto;
+  color: var(--cds-text-01, #161616);
+  font-weight: 400;
+}
+
+.bx--modal-content:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--modal-content:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--modal-scroll-content > *:last-child {
+  padding-bottom: var(--cds-spacing-07, 2rem);
+}
+
+.bx--modal-content--overflow-indicator {
+  position: absolute;
+  bottom: var(--cds-spacing-09, 3rem);
+  left: 0;
+  grid-row: 2/-2;
+  grid-column: 1/-1;
+  width: 100%;
+  height: 2rem;
+  background-image: linear-gradient(to bottom, rgba(var(--cds-ui-01, #f4f4f4), 0), var(--cds-ui-01, #f4f4f4));
+  content: '';
+  pointer-events: none;
+}
+
+.bx--modal-content:focus
+~ .bx--modal-content--overflow-indicator {
+  width: calc(100% - 4px);
+  margin: 0 2px 2px;
+}
+
+@media screen and (-ms-high-contrast: active) {
+  .bx--modal-scroll-content > *:last-child {
+    padding-bottom: 0;
+  }
+  .bx--modal-content--overflow-indicator {
+    display: none;
+  }
+}
+
+.bx--modal-footer {
+  display: flex;
+  grid-row: -1/-1;
+  grid-column: 1/-1;
+  justify-content: flex-end;
+  height: 4rem;
+  margin-top: auto;
+}
+
+.bx--modal-footer .bx--btn {
+  flex: 0 1 50%;
+  max-width: none;
+  height: 4rem;
+  margin: 0;
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-bottom: var(--cds-spacing-07, 2rem);
+}
+
+.bx--modal-footer--three-button .bx--btn {
+  flex: 0 1 25%;
+  align-items: flex-start;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--modal-footer button.bx--btn:focus {
+    border: none;
+    outline-style: dotted;
+  }
+}
+
+.bx--modal-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 3rem;
+  height: 3rem;
+  padding: 0.75rem;
+  overflow: hidden;
+  background-color: transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: background-color 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--modal-close:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--modal-close:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  outline: none;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--modal-close:focus {
+    border-style: dotted;
+  }
+}
+
+.bx--modal-close::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--modal-close__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: var(--cds-icon-01, #161616);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--modal-close__icon {
+    fill: ButtonText;
+  }
+}
+
+.bx--body--with-modal-open {
+  overflow: hidden;
+}
+
+.bx--body--with-modal-open .bx--tooltip {
+  z-index: 9000;
+}
+
+.bx--tabs {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  position: relative;
+  width: 100%;
+  height: auto;
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--tabs *,
+.bx--tabs *::before,
+.bx--tabs *::after {
+  box-sizing: inherit;
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs {
+    min-height: 2.5rem;
+    background: none;
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container {
+    min-height: 3rem;
+  }
+}
+
+.bx--tabs-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 2.5rem;
+  padding: 0 var(--cds-spacing-09, 3rem) 0 var(--cds-spacing-05, 1rem);
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-field-01, #f4f4f4);
+  border-bottom: 1px solid var(--cds-ui-04, #8d8d8d);
+  outline: 2px solid transparent;
+  cursor: pointer;
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs-trigger {
+    display: none;
+  }
+}
+
+.bx--tabs-trigger:focus,
+.bx--tabs-trigger:active {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tabs-trigger:focus,
+  .bx--tabs-trigger:active {
+    outline-style: dotted;
+  }
+}
+
+.bx--tabs-trigger svg {
+  position: absolute;
+  right: var(--cds-spacing-05, 1rem);
+  transition: transform 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-ui-05, #161616);
+}
+
+.bx--tabs-trigger--open:focus,
+.bx--tabs-trigger--open:active {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transition: outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs-trigger--open {
+  background: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs-trigger--open svg {
+  transform: rotate(-180deg);
+  transform-origin: 50% 45%;
+  transition: transform 70ms;
+}
+
+.bx--tabs--light.bx--tabs-trigger {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--tabs-trigger-text {
+  padding-top: 2px;
+  overflow: hidden;
+  color: var(--cds-text-01, #161616);
+  font-weight: 400;
+  white-space: nowrap;
+  text-decoration: none;
+  text-overflow: ellipsis;
+}
+
+.bx--tabs-trigger-text:hover {
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--tabs-trigger-text:focus {
+  outline: none;
+}
+
+.bx--tabs__nav {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: 600px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: var(--cds-ui-01, #f4f4f4);
+  transition: max-height 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav {
+    z-index: auto;
+    flex-direction: row;
+    width: auto;
+    background: none;
+    box-shadow: none;
+    transition: inherit;
+  }
+}
+
+.bx--tabs__nav--hidden {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav--hidden {
+    display: flex;
+    max-width: 100%;
+    max-height: none;
+    overflow-x: auto;
+    transition: inherit;
+  }
+}
+
+.bx--tabs__nav-item {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: flex;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  cursor: pointer;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs__nav-item *,
+.bx--tabs__nav-item *::before,
+.bx--tabs__nav-item *::after {
+  box-sizing: inherit;
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav-item {
+    height: auto;
+    background: transparent;
+  }
+  .bx--tabs__nav-item + .bx--tabs__nav-item {
+    margin-left: 0.0625rem;
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container .bx--tabs__nav-item {
+    background-color: var(--cds-ui-03, #e0e0e0);
+  }
+  .bx--tabs--container .bx--tabs__nav-item + .bx--tabs__nav-item {
+    margin-left: 0;
+    box-shadow: -1px 0 0 0 var(--cds-ui-04, #8d8d8d);
+  }
+  .bx--tabs--container .bx--tabs__nav-item + .bx--tabs__nav-item.bx--tabs__nav-item--selected,
+  .bx--tabs--container .bx--tabs__nav-item.bx--tabs__nav-item--selected + .bx--tabs__nav-item {
+    box-shadow: none;
+  }
+}
+
+.bx--tabs__nav-item .bx--tabs__nav-link {
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), border-bottom-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected) {
+    background: transparent;
+  }
+}
+
+.bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--disabled) {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+  box-shadow: 0 -1px 0 var(--cds-hover-ui, #e5e5e5);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--disabled) {
+    background-color: transparent;
+  }
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--disabled) + .bx--tabs__nav-item {
+    box-shadow: none;
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container
+.bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--disabled) {
+    background-color: var(--cds-hover-selected-ui, #cacaca);
+  }
+}
+
+.bx--tabs__nav-item--disabled,
+.bx--tabs__nav-item--disabled:hover {
+  outline: none;
+  cursor: not-allowed;
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container
+.bx--tabs__nav-item.bx--tabs__nav-item--disabled,
+  .bx--tabs--container
+.bx--tabs__nav-item.bx--tabs__nav-item--disabled:hover {
+    background-color: var(--cds-disabled-02, #c6c6c6);
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container
+.bx--tabs__nav-item--disabled
+.bx--tabs__nav-link {
+    color: var(--cds-disabled-03, #8d8d8d);
+    border-bottom: none;
+  }
+}
+
+.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) {
+  display: none;
+  border: none;
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) {
+    display: flex;
+  }
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:focus,
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:active {
+    font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+    font-weight: var(--cds-productive-heading-01-font-weight, 600);
+    line-height: var(--cds-productive-heading-01-line-height, 1.29);
+    letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+    color: var(--cds-text-01, #161616);
+    border-bottom: 2px solid var(--cds-interactive-04, #0f62fe);
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled),
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:hover:not(.bx--tabs__nav-item--disabled) {
+    background-color: var(--cds-ui-01, #f4f4f4);
+  }
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:hover:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+    padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+    line-height: calc(3rem - (var(--cds-spacing-03, 0.5rem) * 2));
+    border-bottom: none;
+    box-shadow: inset 0 2px 0 0 var(--cds-interactive-04, #0f62fe);
+  }
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:focus,
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:active,
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:hover:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:focus,
+  .bx--tabs--container
+.bx--tabs__nav-item--selected:hover:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link:active {
+    box-shadow: none;
+  }
+}
+
+a.bx--tabs__nav-link {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  display: inline-block;
+  width: calc(100% - 32px);
+  height: 2.5rem;
+  margin: 0 var(--cds-spacing-05, 1rem);
+  padding: var(--cds-spacing-04, 0.75rem) 0;
+  overflow: hidden;
+  color: var(--cds-text-02, #525252);
+  font-weight: 400;
+  line-height: 1rem;
+  white-space: nowrap;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
+  transition: border 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  width: 100%;
+  margin: 0;
+  padding-left: 16px;
+}
+
+@media screen and (prefers-contrast) {
+  a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
+    outline-style: dotted;
+  }
+}
+
+@media (min-width: 42rem) {
+  a.bx--tabs__nav-link {
+    width: 10rem;
+    margin: 0;
+    padding: var(--cds-spacing-04, 0.75rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-03, 0.5rem);
+    line-height: inherit;
+    border-bottom: 2px solid var(--cds-ui-03, #e0e0e0);
+  }
+  a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
+    width: 10rem;
+    border-bottom: 2px;
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container a.bx--tabs__nav-link {
+    height: 3rem;
+    padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+    line-height: calc(3rem - (var(--cds-spacing-03, 0.5rem) * 2));
+    border-bottom: none;
+  }
+}
+
+.bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
+.bx--tabs__nav-link {
+  color: var(--cds-text-01, #161616);
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
+.bx--tabs__nav-link {
+    color: var(--cds-text-01, #161616);
+    border-bottom: 2px solid var(--cds-ui-04, #8d8d8d);
+  }
+}
+
+@media (min-width: 42rem) {
+  .bx--tabs--container
+.bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
+.bx--tabs__nav-link {
+    border-bottom: none;
+  }
+}
+
+.bx--tabs__nav-item--disabled .bx--tabs__nav-link {
+  color: var(--cds-disabled-02, #c6c6c6);
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  pointer-events: none;
+}
+
+.bx--tabs__nav-item--disabled:hover .bx--tabs__nav-link {
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  cursor: no-drop;
+}
+
+.bx--tabs__nav-item--disabled .bx--tabs__nav-link:focus,
+.bx--tabs__nav-item--disabled a.bx--tabs__nav-link:active {
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  outline: none;
+}
+
+.bx--tabs__nav-item:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled):not(.bx--tabs__nav-item--selected)
+.bx--tabs__nav-link:focus,
+.bx--tabs__nav-item:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled):not(.bx--tabs__nav-item--selected)
+a.bx--tabs__nav-link:active {
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--tab-content {
+  padding: 1rem;
+}
+
+.bx--tabs.bx--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.bx--tabs.bx--skeleton .bx--tabs__nav-link {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 4.6875rem;
+  height: 0.75rem;
+}
+
+.bx--tabs.bx--skeleton .bx--tabs__nav-link:hover, .bx--tabs.bx--skeleton .bx--tabs__nav-link:focus, .bx--tabs.bx--skeleton .bx--tabs__nav-link:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--tabs.bx--skeleton .bx--tabs__nav-link::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--tabs.bx--skeleton .bx--tabs__nav-link::before {
+    animation: none;
+  }
+}
+
+.bx--tabs.bx--skeleton .bx--tabs-trigger {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 6.25rem;
+}
+
+.bx--tabs.bx--skeleton .bx--tabs-trigger:hover, .bx--tabs.bx--skeleton .bx--tabs-trigger:focus, .bx--tabs.bx--skeleton .bx--tabs-trigger:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--tabs.bx--skeleton .bx--tabs-trigger::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--tabs.bx--skeleton .bx--tabs-trigger::before {
+    animation: none;
+  }
+}
+
+.bx--tabs.bx--skeleton .bx--tabs-trigger svg {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tabs--scrollable {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: flex;
+  width: 100%;
+  height: auto;
+  min-height: 2.5rem;
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--tabs--scrollable *,
+.bx--tabs--scrollable *::before,
+.bx--tabs--scrollable *::after {
+  box-sizing: inherit;
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container {
+  min-height: 3rem;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav {
+  display: flex;
+  flex-direction: row;
+  width: auto;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: auto hidden;
+  list-style: none;
+  outline: 0;
+  transition: max-height 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  scrollbar-width: none;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav::-webkit-scrollbar {
+  display: none;
+}
+
+.bx--tabs--scrollable .bx--tabs__overflow-indicator--left,
+.bx--tabs--scrollable .bx--tabs__overflow-indicator--right {
+  z-index: 1;
+  flex: 1 0 auto;
+  width: 0.5rem;
+}
+
+.bx--tabs--scrollable .bx--tabs__overflow-indicator--left {
+  margin-right: -0.5rem;
+  background-image: linear-gradient(to left, transparent, var(--cds-ui-background, #ffffff));
+}
+
+.bx--tabs--scrollable .bx--tabs__overflow-indicator--right {
+  margin-left: -0.5rem;
+  background-image: linear-gradient(to right, transparent, var(--cds-ui-background, #ffffff));
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs__overflow-indicator--left {
+  background-image: linear-gradient(to left, transparent, var(--cds-ui-01, #f4f4f4));
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, var(--cds-ui-01, #f4f4f4));
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs__overflow-indicator--left {
+  background-image: linear-gradient(to left, transparent, var(--cds-ui-03, #e0e0e0));
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, var(--cds-ui-03, #e0e0e0));
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .bx--tabs--scrollable .bx--tabs__overflow-indicator--left {
+      background-image: linear-gradient(to left, rgba(var(--cds-ui-background, #ffffff), 0), var(--cds-ui-background, #ffffff));
+    }
+    .bx--tabs--scrollable .bx--tabs__overflow-indicator--right {
+      background-image: linear-gradient(to right, rgba(var(--cds-ui-background, #ffffff), 0), var(--cds-ui-background, #ffffff));
+    }
+    .bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs__overflow-indicator--left {
+      background-image: linear-gradient(to left, rgba(var(--cds-ui-03, #e0e0e0), 0), var(--cds-ui-03, #e0e0e0));
+    }
+    .bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs__overflow-indicator--right {
+      background-image: linear-gradient(to right, rgba(var(--cds-ui-03, #e0e0e0), 0), var(--cds-ui-03, #e0e0e0));
+    }
+  }
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  width: 100%;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button *,
+.bx--tabs--scrollable .bx--tab--overflow-nav-button *::before,
+.bx--tabs--scrollable .bx--tab--overflow-nav-button *::after {
+  box-sizing: inherit;
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tabs--scrollable .bx--tab--overflow-nav-button:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button--hidden {
+  display: none;
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tab--overflow-nav-button {
+  width: 3rem;
+  margin: 0;
+  background-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs--scrollable .bx--tab--overflow-nav-button svg {
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: flex;
+  padding: 0;
+  cursor: pointer;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item *,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item *::before,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item *::after {
+  box-sizing: inherit;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item
++ .bx--tabs--scrollable__nav-item {
+  margin-left: 0.0625rem;
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item {
+  background-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item
++ .bx--tabs--scrollable__nav-item {
+  margin-left: 0;
+  box-shadow: -0.0625rem 0 0 0 var(--cds-ui-04, #8d8d8d);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item
++ .bx--tabs--scrollable__nav-item.bx--tabs--scrollable__nav-item--selected,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item.bx--tabs--scrollable__nav-item--selected
++ .bx--tabs--scrollable__nav-item {
+  box-shadow: none;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item
+.bx--tabs--scrollable__nav-link {
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), border-bottom-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item:hover {
+  background-color: var(--cds-hover-selected-ui, #cacaca);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled:hover {
+  background-color: transparent;
+  outline: none;
+  cursor: not-allowed;
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item.bx--tabs--scrollable__nav-item--disabled,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item.bx--tabs--scrollable__nav-item--disabled:hover {
+  background-color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--selected {
+  transition: color 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--selected
+.bx--tabs--scrollable__nav-link,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--selected
+.bx--tabs--scrollable__nav-link:focus,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--selected
+.bx--tabs--scrollable__nav-link:active {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  color: var(--cds-text-01, #161616);
+  border-bottom: 2px solid var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected:hover {
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected .bx--tabs--scrollable__nav-link:focus,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected .bx--tabs--scrollable__nav-link:active,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected:hover .bx--tabs--scrollable__nav-link:focus,
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected:hover .bx--tabs--scrollable__nav-link:active {
+  box-shadow: none;
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected
+.bx--tabs--scrollable__nav-link {
+  line-height: calc(3rem - (var(--cds-spacing-03, 0.5rem) * 2));
+  box-shadow: inset 0 2px 0 0 var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--light.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected,
+.bx--tabs--scrollable.bx--tabs--scrollable--light.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--selected:hover {
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  width: 10rem;
+  padding: var(--cds-spacing-04, 0.75rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-03, 0.5rem);
+  overflow: hidden;
+  color: var(--cds-text-02, #525252);
+  white-space: nowrap;
+  text-align: left;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  border-bottom: 2px solid var(--cds-ui-03, #e0e0e0);
+  transition: border 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link *,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link *::before,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link *::after {
+  box-sizing: inherit;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-link:focus, .bx--tabs--scrollable .bx--tabs--scrollable__nav-link:active {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tabs--scrollable .bx--tabs--scrollable__nav-link:focus, .bx--tabs--scrollable .bx--tabs--scrollable__nav-link:active {
+    outline-style: dotted;
+  }
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-link {
+  height: 3rem;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+  line-height: calc(3rem - (var(--cds-spacing-03, 0.5rem) * 2));
+  border-bottom: 0;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item:hover
+.bx--tabs--scrollable__nav-link {
+  color: var(--cds-text-01, #161616);
+  border-bottom: 2px solid var(--cds-ui-04, #8d8d8d);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item
+.bx--tabs--scrollable__nav-link {
+  border-bottom: none;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link {
+  color: var(--cds-disabled-02, #c6c6c6);
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled:hover
+.bx--tabs--scrollable__nav-link {
+  color: var(--cds-disabled-02, #c6c6c6);
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link:focus,
+.bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link:active {
+  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  outline: none;
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link {
+  border-bottom-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs--scrollable__nav-item--disabled:hover
+.bx--tabs--scrollable__nav-link {
+  border-bottom-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link:focus,
+.bx--tabs--scrollable .bx--tabs--scrollable--light
+.bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link:active {
+  border-bottom-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item--disabled
+.bx--tabs--scrollable__nav-link {
+  color: var(--cds-disabled-03, #8d8d8d);
+  border-bottom: none;
+}
+
+.bx--tabs--scrollable .bx--tab-content {
+  padding: 1rem;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 4.6875rem;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link:hover, .bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link:focus, .bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--tabs--scrollable .bx--tabs.bx--skeleton
+.bx--tabs--scrollable__nav-link::before {
+    animation: none;
+  }
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 4.6875rem;
+  margin-right: 0.0625rem;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger:hover, .bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger:focus, .bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger::before {
+    animation: none;
+  }
+}
+
+.bx--tabs--scrollable .bx--tabs.bx--skeleton .bx--tabs-trigger svg {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.exp--about-modal {
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp--about-modal .bx--modal-container {
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.exp--about-modal__logo {
+  margin: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__header {
+  grid-row: auto;
+  margin-bottom: 0;
+  padding: 0 20% var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__title {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--about-modal .exp--about-modal__body {
+  font-size: var(--cds-body-short-02-font-size, 1rem);
+  font-weight: var(--cds-body-short-02-font-weight, 400);
+  line-height: var(--cds-body-short-02-line-height, 1.375);
+  letter-spacing: var(--cds-body-short-02-letter-spacing, 0);
+  grid-row: auto;
+  min-height: var(--cds-layout-05, 4rem);
+  margin-bottom: 0;
+  padding: 0 20% 0 var(--cds-spacing-05, 1rem);
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .exp--about-modal__body {
+  min-height: calc(var(--cds-layout-05, 4rem) + var(--cds-spacing-08, 2.5rem));
+}
+
+.exp--about-modal .exp--about-modal__body-content {
+  margin-bottom: var(--cds-spacing-09, 3rem);
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .exp--about-modal__body-content {
+  margin-bottom: calc(var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem));
+}
+
+.exp--about-modal .exp--about-modal__links-container {
+  margin-top: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__links-container a + a {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+  padding-left: var(--cds-spacing-03, 0.5rem);
+  border-left: 1px solid var(--cds-text-01, #161616);
+}
+
+.exp--about-modal .exp--about-modal__legal-text,
+.exp--about-modal .exp--about-modal__copyright-text {
+  margin-top: var(--cds-spacing-07, 2rem);
+  color: var(--cds-text-03, #a8a8a8);
+}
+
+.exp--about-modal .exp--about-modal__copyright-text {
+  margin-top: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__footer {
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  height: 4.5rem;
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-inverse-02, #393939);
+}
+
+.exp--about-modal .exp--about-modal__footer::before {
+  position: absolute;
+  top: calc(-1 * var(--cds-spacing-09, 3rem));
+  width: 80%;
+  height: var(--cds-spacing-09, 3rem);
+  background: linear-gradient(to bottom, transparent, var(--cds-ui-01, #f4f4f4) 45%);
+  content: '';
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .bx--modal-footer::before {
+  top: calc(-1 * (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem)));
+  height: calc(var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem));
+  background: linear-gradient(to bottom, transparent, var(--cds-ui-01, #f4f4f4) 25%);
+}
+
+.exp--about-modal .exp--about-modal__tab-container {
+  position: absolute;
+  bottom: 100%;
+}
+
+.exp--about-modal .exp--about-modal__version-label,
+.exp--about-modal .exp--about-modal__version-number {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  padding-left: var(--cds-spacing-05, 1rem);
+  color: var(--cds-inverse-01, #ffffff);
+}
+
+.exp--about-modal .exp--about-modal__version-label {
+  font-weight: 600;
+}
+
+.bx--overflow-menu,
+.bx--overflow-menu__trigger {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  transition: outline 110ms cubic-bezier(0, 0, 0.38, 0.9), background-color 110ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--overflow-menu *,
+.bx--overflow-menu *::before,
+.bx--overflow-menu *::after,
+.bx--overflow-menu__trigger *,
+.bx--overflow-menu__trigger *::before,
+.bx--overflow-menu__trigger *::after {
+  box-sizing: inherit;
+}
+
+.bx--overflow-menu::-moz-focus-inner,
+.bx--overflow-menu__trigger::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--overflow-menu *,
+.bx--overflow-menu *::before,
+.bx--overflow-menu *::after,
+.bx--overflow-menu__trigger *,
+.bx--overflow-menu__trigger *::before,
+.bx--overflow-menu__trigger *::after {
+  box-sizing: inherit;
+}
+
+.bx--overflow-menu:focus,
+.bx--overflow-menu__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--overflow-menu:focus,
+  .bx--overflow-menu__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--overflow-menu:hover,
+.bx--overflow-menu__trigger:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--overflow-menu--sm {
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--overflow-menu--xl {
+  width: 3rem;
+  height: 3rem;
+}
+
+.bx--overflow-menu__trigger.bx--tooltip--a11y.bx--tooltip__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--overflow-menu__trigger.bx--tooltip--a11y.bx--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--overflow-menu__trigger.bx--tooltip--a11y.bx--tooltip__trigger:focus svg {
+  outline: none;
+}
+
+.bx--overflow-menu.bx--overflow-menu--open,
+.bx--overflow-menu.bx--overflow-menu--open
+.bx--overflow-menu__trigger {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  background-color: var(--cds-field-01, #f4f4f4);
+  transition: none;
+}
+
+.bx--overflow-menu--light.bx--overflow-menu--open,
+.bx--overflow-menu--light.bx--overflow-menu--open
+.bx--overflow-menu__trigger {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--overflow-menu__icon {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--cds-icon-01, #161616);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--overflow-menu__icon {
+    fill: ButtonText;
+  }
+}
+
+.bx--overflow-menu-options {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  top: 32px;
+  left: 0;
+  z-index: 6000;
+  display: none;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 10rem;
+  list-style: none;
+  background-color: var(--cds-field-01, #f4f4f4);
+}
+
+.bx--overflow-menu-options *,
+.bx--overflow-menu-options *::before,
+.bx--overflow-menu-options *::after {
+  box-sizing: inherit;
+}
+
+.bx--overflow-menu-options::after {
+  position: absolute;
+  display: block;
+  background-color: var(--cds-field-01, #f4f4f4);
+  transition: background-color 110ms cubic-bezier(0, 0, 0.38, 0.9);
+  content: '';
+}
+
+.bx--overflow-menu.bx--overflow-menu--open:hover {
+  background-color: var(--cds-field-01, #f4f4f4);
+}
+
+.bx--overflow-menu-options--light {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--overflow-menu-options--light::after {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--overflow-menu.bx--overflow-menu--light.bx--overflow-menu--open:hover {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+  top: -0.1875rem;
+  left: 0;
+  width: 2.5rem;
+  height: 0.1875rem;
+}
+
+.bx--overflow-menu-options[data-floating-menu-direction='top']::after {
+  bottom: -0.5rem;
+  left: 0;
+  width: 2.5rem;
+  height: 0.5rem;
+}
+
+.bx--overflow-menu-options[data-floating-menu-direction='left']::after {
+  top: 0;
+  right: -0.375rem;
+  width: 0.375rem;
+  height: 2.5rem;
+}
+
+.bx--overflow-menu-options[data-floating-menu-direction='right']::after {
+  top: 0;
+  left: -0.375rem;
+  width: 0.375rem;
+  height: 2.5rem;
+}
+
+.bx--overflow-menu-options--sm.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after, .bx--overflow-menu-options--sm.bx--overflow-menu-options[data-floating-menu-direction='top']::after {
+  width: 2rem;
+}
+
+.bx--overflow-menu-options--sm.bx--overflow-menu-options[data-floating-menu-direction='left']::after, .bx--overflow-menu-options--sm.bx--overflow-menu-options[data-floating-menu-direction='right']::after {
+  height: 2rem;
+}
+
+.bx--overflow-menu-options--xl.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after, .bx--overflow-menu-options--xl.bx--overflow-menu-options[data-floating-menu-direction='top']::after {
+  width: 3rem;
+}
+
+.bx--overflow-menu-options--xl.bx--overflow-menu-options[data-floating-menu-direction='left']::after, .bx--overflow-menu-options--xl.bx--overflow-menu-options[data-floating-menu-direction='right']::after {
+  height: 3rem;
+}
+
+.bx--overflow-menu--flip.bx--overflow-menu-options[data-floating-menu-direction='top']::after,
+.bx--overflow-menu--flip.bx--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+  right: 0;
+  left: auto;
+}
+
+.bx--overflow-menu--flip.bx--overflow-menu-options[data-floating-menu-direction='left']::after,
+.bx--overflow-menu--flip.bx--overflow-menu-options[data-floating-menu-direction='right']::after {
+  top: auto;
+  bottom: 0;
+}
+
+.bx--overflow-menu-options--open {
+  display: flex;
+}
+
+.bx--overflow-menu-options__content {
+  width: 100%;
+}
+
+.bx--overflow-menu-options__option {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0;
+  background-color: transparent;
+  transition: background-color 110ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--overflow-menu-options__option *,
+.bx--overflow-menu-options__option *::before,
+.bx--overflow-menu-options__option *::after {
+  box-sizing: inherit;
+}
+
+.bx--overflow-menu-options--sm
+.bx--overflow-menu-options__option {
+  height: 2rem;
+}
+
+.bx--overflow-menu-options--xl
+.bx--overflow-menu-options__option {
+  height: 3rem;
+}
+
+.bx--overflow-menu--divider {
+  border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--overflow-menu--light .bx--overflow-menu--divider {
+  border-top: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+a.bx--overflow-menu-options__btn::before {
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+  content: '';
+}
+
+.bx--overflow-menu-options__btn {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  max-width: 11.25rem;
+  height: 100%;
+  padding: 0 1rem;
+  color: var(--cds-text-02, #525252);
+  font-weight: 400;
+  text-align: left;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  transition: outline 110ms cubic-bezier(0, 0, 0.38, 0.9), background-color 110ms cubic-bezier(0, 0, 0.38, 0.9), color 110ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--overflow-menu-options__btn:hover {
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--overflow-menu-options__btn:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--overflow-menu-options__btn:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--overflow-menu-options__btn::-moz-focus-inner {
+  border: none;
+}
+
+.bx--overflow-menu-options__btn svg {
+  fill: var(--cds-icon-02, #525252);
+}
+
+.bx--overflow-menu-options__btn:hover svg {
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--overflow-menu-options__option-content {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--overflow-menu-options__option:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--overflow-menu-options__option--danger {
+  border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--overflow-menu--light
+.bx--overflow-menu-options__option--danger {
+  border-top: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.bx--overflow-menu-options__option--danger
+.bx--overflow-menu-options__btn:hover,
+.bx--overflow-menu-options__option--danger
+.bx--overflow-menu-options__btn:focus {
+  color: var(--cds-text-04, #ffffff);
+  background-color: var(--cds-danger-01, #da1e28);
+}
+
+.bx--overflow-menu-options__option--danger
+.bx--overflow-menu-options__btn:hover svg,
+.bx--overflow-menu-options__option--danger
+.bx--overflow-menu-options__btn:focus svg {
+  fill: currentColor;
+}
+
+.bx--overflow-menu-options__option--disabled:hover {
+  background-color: var(--cds-ui-01, #f4f4f4);
+  cursor: not-allowed;
+}
+
+.bx--overflow-menu-options__option--disabled
+.bx--overflow-menu-options__btn {
+  color: var(--cds-disabled-02, #c6c6c6);
+  pointer-events: none;
+}
+
+.bx--overflow-menu-options__option--disabled
+.bx--overflow-menu-options__btn:hover, .bx--overflow-menu-options__option--disabled
+.bx--overflow-menu-options__btn:active, .bx--overflow-menu-options__option--disabled
+.bx--overflow-menu-options__btn:focus {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.bx--overflow-menu-options__option--disabled
+.bx--overflow-menu-options__btn
+svg {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--overflow-menu--flip {
+  left: -140px;
+}
+
+.bx--overflow-menu--flip::before {
+  left: 145px;
+}
+
+.bx--tooltip__label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--tooltip__label:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__label:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger svg {
+  fill: var(--cds-icon-02, #525252);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger svg {
+    fill: ButtonText;
+  }
+}
+
+.bx--tooltip__trigger:not(.bx--btn--icon-only) {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger:not(.bx--btn--icon-only) *,
+.bx--tooltip__trigger:not(.bx--btn--icon-only) *::before,
+.bx--tooltip__trigger:not(.bx--btn--icon-only) *::after {
+  box-sizing: inherit;
+}
+
+.bx--tooltip__trigger:not(.bx--btn--icon-only)::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--tooltip__trigger:not(.bx--btn--icon-only):focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+  fill: var(--cds-hover-primary, #0353e9);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger:not(.bx--btn--icon-only):focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__label .bx--tooltip__trigger {
+  margin-left: 0.5rem;
+}
+
+.bx--tooltip__label--bold {
+  font-weight: 600;
+}
+
+.bx--tooltip {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: absolute;
+  z-index: 6000;
+  display: none;
+  min-width: 13rem;
+  max-width: 18rem;
+  margin-top: 0.25rem;
+  padding: 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  word-wrap: break-word;
+  background: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+}
+
+.bx--tooltip *,
+.bx--tooltip *::before,
+.bx--tooltip *::after {
+  box-sizing: inherit;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 1px var(--cds-inverse-02, #393939), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+.bx--tooltip.bx--tooltip--top.bx--tooltip--align-start, .bx--tooltip.bx--tooltip--bottom.bx--tooltip--align-start {
+  transform: translate(calc(50% - 22px), 0);
+}
+
+.bx--tooltip.bx--tooltip--top.bx--tooltip--align-start .bx--tooltip__caret, .bx--tooltip.bx--tooltip--bottom.bx--tooltip--align-start .bx--tooltip__caret {
+  margin-left: 15px;
+}
+
+.bx--tooltip.bx--tooltip--top.bx--tooltip--align-end, .bx--tooltip.bx--tooltip--bottom.bx--tooltip--align-end {
+  transform: translate(calc(22px - 50%), 0);
+}
+
+.bx--tooltip.bx--tooltip--top.bx--tooltip--align-end .bx--tooltip__caret, .bx--tooltip.bx--tooltip--bottom.bx--tooltip--align-end .bx--tooltip__caret {
+  margin-right: 15px;
+}
+
+.bx--tooltip.bx--tooltip--left.bx--tooltip--align-start {
+  transform: translate(0, calc(-15px + 50%));
+}
+
+.bx--tooltip.bx--tooltip--left.bx--tooltip--align-start .bx--tooltip__caret {
+  top: 14px;
+}
+
+.bx--tooltip.bx--tooltip--left.bx--tooltip--align-end {
+  transform: translate(0, calc(31px - 50%));
+}
+
+.bx--tooltip.bx--tooltip--left.bx--tooltip--align-end .bx--tooltip__caret {
+  top: initial;
+  bottom: 25px;
+}
+
+.bx--tooltip.bx--tooltip--right.bx--tooltip--align-start {
+  transform: translate(0, calc(-26px + 50%));
+}
+
+.bx--tooltip.bx--tooltip--right.bx--tooltip--align-start .bx--tooltip__caret {
+  top: 26px;
+}
+
+.bx--tooltip.bx--tooltip--right.bx--tooltip--align-end {
+  transform: translate(0, calc(20px - 50%));
+}
+
+.bx--tooltip.bx--tooltip--right.bx--tooltip--align-end .bx--tooltip__caret {
+  top: initial;
+  bottom: 12px;
+}
+
+.bx--tooltip p {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+.bx--tooltip button {
+  padding-right: 2rem;
+}
+
+.bx--tooltip .bx--btn:focus {
+  border-color: var(--cds-inverse-focus-ui, #ffffff);
+  outline-color: var(--cds-inverse-02, #393939);
+}
+
+.bx--tooltip .bx--link {
+  color: var(--cds-inverse-link, #78a9ff);
+  font-size: 0.875rem;
+}
+
+.bx--tooltip .bx--link:focus {
+  outline: 1px solid var(--cds-inverse-focus-ui, #ffffff);
+  outline-offset: 2px;
+}
+
+.bx--tooltip .bx--link:active, .bx--tooltip .bx--link:active:visited, .bx--tooltip .bx--link:active:visited:hover {
+  color: var(--cds-inverse-01, #ffffff);
+}
+
+.bx--tooltip .bx--link:visited {
+  color: var(--cds-inverse-link, #78a9ff);
+}
+
+.bx--tooltip .bx--tooltip__content[tabindex='-1']:focus {
+  outline: none;
+}
+
+.bx--tooltip .bx--tooltip__caret {
+  position: absolute;
+  top: calc(-0.42969rem + 1px);
+  right: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  margin: 0 auto;
+  border-right: 0.42969rem solid transparent;
+  border-bottom: 0.42969rem solid var(--cds-inverse-02, #393939);
+  border-left: 0.42969rem solid transparent;
+  content: '';
+}
+
+.bx--tooltip .bx--tooltip__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.bx--tooltip[data-floating-menu-direction='left'] .bx--tooltip__caret {
+  top: 50%;
+  right: calc(-0.42969rem + 1px);
+  left: auto;
+  transform: rotate(90deg) translate(50%, -50%);
+}
+
+.bx--tooltip[data-floating-menu-direction='top'] .bx--tooltip__caret {
+  top: auto;
+  bottom: calc(-0.42969rem + 1px);
+  transform: rotate(180deg);
+}
+
+.bx--tooltip[data-floating-menu-direction='right'] .bx--tooltip__caret {
+  top: 50%;
+  right: auto;
+  left: calc(-0.42969rem + 1px);
+  transform: rotate(270deg) translate(50%, -50%);
+}
+
+.bx--tooltip__heading {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.bx--tooltip--shown {
+  display: block;
+}
+
+/* begin legacy definition tooltip TODO: deprecate */
+.bx--tooltip--definition {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+}
+
+.bx--tooltip--definition *,
+.bx--tooltip--definition *::before,
+.bx--tooltip--definition *::after {
+  box-sizing: inherit;
+}
+
+.bx--tooltip--definition .bx--tooltip__trigger {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  position: relative;
+  display: inline-flex;
+  color: var(--cds-text-01, #161616);
+  border-bottom: 1px dotted var(--cds-interactive-01, #0f62fe);
+}
+
+.bx--tooltip--definition .bx--tooltip__trigger:hover {
+  cursor: pointer;
+}
+
+.bx--tooltip--definition .bx--tooltip__trigger:hover + .bx--tooltip--definition__top,
+.bx--tooltip--definition .bx--tooltip__trigger:hover + .bx--tooltip--definition__bottom {
+  display: block;
+}
+
+.bx--tooltip--definition .bx--tooltip__trigger:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip--definition .bx--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip--definition .bx--tooltip__trigger:focus + .bx--tooltip--definition__top,
+.bx--tooltip--definition .bx--tooltip__trigger:focus + .bx--tooltip--definition__bottom {
+  display: block;
+}
+
+.bx--tooltip--definition__bottom,
+.bx--tooltip--definition__top {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  position: absolute;
+  z-index: 1;
+  display: none;
+  width: 13rem;
+  margin-top: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  cursor: pointer;
+  pointer-events: none;
+}
+
+.bx--tooltip--definition__bottom p,
+.bx--tooltip--definition__top p {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  color: var(--cds-inverse-01, #ffffff);
+}
+
+.bx--tooltip--definition__bottom .bx--tooltip__caret,
+.bx--tooltip--definition__top .bx--tooltip__caret {
+  position: absolute;
+  right: 0;
+  left: 0;
+  width: 0.6rem;
+  height: 0.6rem;
+  margin-left: 1rem;
+  background: var(--cds-inverse-02, #393939);
+}
+
+.bx--tooltip--definition__bottom .bx--tooltip__caret {
+  top: -0.2rem;
+  transform: rotate(-135deg);
+}
+
+.bx--tooltip--definition__top {
+  margin-top: -2rem;
+  transform: translateY(-100%);
+}
+
+.bx--tooltip--definition__top .bx--tooltip__caret {
+  bottom: -0.2rem;
+  transform: rotate(45deg);
+}
+
+.bx--tooltip--definition__align-end {
+  right: 0;
+}
+
+.bx--tooltip--definition__align-center {
+  margin-left: 50%;
+  transform: translateX(-50%);
+}
+
+.bx--tooltip--definition__top.bx--tooltip--definition__align-center {
+  margin-left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip--definition__align-center .bx--tooltip__caret {
+  left: auto;
+  margin-right: calc(50% - 6px);
+  margin-left: auto;
+}
+
+.bx--tooltip--definition__align-end .bx--tooltip__caret {
+  left: auto;
+  margin-right: 1rem;
+  margin-left: auto;
+}
+
+/* end legacy definition tooltip */
+.bx--tooltip--definition.bx--tooltip--a11y {
+  display: inline-flex;
+}
+
+.bx--tooltip--definition button.bx--tooltip--a11y {
+  margin: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  border-bottom: 0.0625rem dotted var(--cds-text-02, #525252);
+  transition: border-color 110ms;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition:hover,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition:focus {
+  border-bottom-color: var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.5rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover::after, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::before {
+  top: -0.25rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top + .bx--assistive-text {
+  top: -0.5625rem;
+  left: 0;
+  transform: translate(0, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start::before {
+  top: -0.25rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-start + .bx--assistive-text {
+  top: -0.5625rem;
+  left: 0;
+  transform: translate(0, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center::before {
+  top: -0.25rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-center + .bx--assistive-text {
+  top: -0.5625rem;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end::before {
+  top: -0.25rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--top.bx--tooltip--align-end + .bx--assistive-text {
+  top: -0.5625rem;
+  right: 0;
+  left: auto;
+  transform: translate(0, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.5rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover::after, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::before {
+  bottom: -0.25rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom + .bx--assistive-text {
+  bottom: -0.5625rem;
+  left: 0;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--a11y + .bx--assistive-text {
+  bottom: -0.5rem;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start::before {
+  bottom: -0.25rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start + .bx--assistive-text {
+  bottom: -0.5625rem;
+  left: 0;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-start.bx--tooltip--a11y + .bx--assistive-text {
+  bottom: -0.5rem;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center::before {
+  bottom: -0.25rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center + .bx--assistive-text {
+  bottom: -0.5625rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-center.bx--tooltip--a11y + .bx--assistive-text {
+  bottom: -0.5rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end::before {
+  bottom: -0.25rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end + .bx--assistive-text {
+  bottom: -0.5625rem;
+  right: 0;
+  left: auto;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip__trigger--definition.bx--tooltip--bottom.bx--tooltip--align-end.bx--tooltip--a11y + .bx--assistive-text {
+  bottom: -0.5rem;
+  transform: translate(0, 100%);
+}
+
+/* begin tooltip icon (TODO: deprecate) */
+.bx--tooltip--icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.bx--tooltip--icon__top,
+.bx--tooltip--icon__bottom {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip--icon__top *,
+.bx--tooltip--icon__top *::before,
+.bx--tooltip--icon__top *::after,
+.bx--tooltip--icon__bottom *,
+.bx--tooltip--icon__bottom *::before,
+.bx--tooltip--icon__bottom *::after {
+  box-sizing: inherit;
+}
+
+.bx--tooltip--icon__top::before, .bx--tooltip--icon__top::after,
+.bx--tooltip--icon__bottom::before,
+.bx--tooltip--icon__bottom::after {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  position: absolute;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  pointer-events: none;
+}
+
+.bx--tooltip--icon__top::before,
+.bx--tooltip--icon__bottom::before {
+  right: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  margin: 0 auto;
+  margin-top: 1px;
+  margin-left: 50%;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-style: solid;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  content: '';
+}
+
+.bx--tooltip--icon__top::after,
+.bx--tooltip--icon__bottom::after {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: 1.5rem;
+  margin-left: 50%;
+  padding: 0 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  white-space: nowrap;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  content: attr(aria-label);
+  pointer-events: none;
+}
+
+.bx--tooltip--icon__top:hover::before, .bx--tooltip--icon__top:hover::after, .bx--tooltip--icon__top:focus::before, .bx--tooltip--icon__top:focus::after,
+.bx--tooltip--icon__bottom:hover::before,
+.bx--tooltip--icon__bottom:hover::after,
+.bx--tooltip--icon__bottom:focus::before,
+.bx--tooltip--icon__bottom:focus::after {
+  opacity: 1;
+}
+
+.bx--tooltip--icon__top:hover svg, .bx--tooltip--icon__top:focus svg,
+.bx--tooltip--icon__bottom:hover svg,
+.bx--tooltip--icon__bottom:focus svg {
+  fill: var(--cds-icon-02, #525252);
+}
+
+.bx--tooltip--icon__top:focus,
+.bx--tooltip--icon__bottom:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--tooltip--icon__top:focus svg,
+.bx--tooltip--icon__bottom:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip--icon__top:focus svg,
+  .bx--tooltip--icon__bottom:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip--icon__top::before {
+  transform: translate(-50%, calc(-100% - 9px)) rotate(180deg);
+  top: 1px;
+}
+
+.bx--tooltip--icon__top::after {
+  transform: translate(-50%, calc(-100% - 12px));
+  top: 0;
+}
+
+.bx--tooltip--icon__bottom::before {
+  transform: translate(-50%, 10px) rotate(0);
+  bottom: 0;
+}
+
+.bx--tooltip--icon__bottom::after {
+  transform: translate(-50%, calc(100% + 10px));
+  bottom: 0;
+}
+
+.bx--tooltip--icon__top.bx--tooltip--icon__align-start::before {
+  transform: translate(0, calc(-100% - 9px)) rotate(180deg);
+  top: 1px;
+  margin-left: 4px;
+}
+
+.bx--tooltip--icon__top.bx--tooltip--icon__align-start::after {
+  transform: translate(0, calc(-100% - 12px));
+  top: 0;
+  margin-left: 0;
+}
+
+.bx--tooltip--icon__top.bx--tooltip--icon__align-end::before {
+  transform: translate(0, calc(-100% - 9px)) rotate(180deg);
+  top: 1px;
+  right: 0;
+  left: auto;
+  margin-right: 4px;
+}
+
+.bx--tooltip--icon__top.bx--tooltip--icon__align-end::after {
+  transform: translate(0, calc(-100% - 12px));
+  top: 0;
+  margin-left: 0;
+  right: 0;
+}
+
+.bx--tooltip--icon__bottom.bx--tooltip--icon__align-start::before {
+  transform: translate(0, 10px) rotate(0);
+  bottom: 0;
+  margin-left: 4px;
+}
+
+.bx--tooltip--icon__bottom.bx--tooltip--icon__align-start::after {
+  transform: translate(0, calc(100% + 10px));
+  bottom: 0;
+  margin-left: 0;
+}
+
+.bx--tooltip--icon__bottom.bx--tooltip--icon__align-end::before {
+  transform: translate(0, 10px) rotate(0);
+  bottom: 0;
+  right: 0;
+  left: auto;
+  margin-right: 4px;
+}
+
+.bx--tooltip--icon__bottom.bx--tooltip--icon__align-end::after {
+  transform: translate(0, calc(100% + 10px));
+  bottom: 0;
+  margin-left: 0;
+  right: 0;
+}
+
+.bx--tooltip--icon .bx--tooltip__trigger svg {
+  margin-left: 0;
+}
+
+/* end legacy tooltip icon */
+.bx--tooltip__trigger:hover svg, .bx--tooltip__trigger:focus svg {
+  fill: var(--cds-icon-02, #525252);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger:hover svg, .bx--tooltip__trigger:focus svg {
+    fill: ButtonText;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--top:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--top:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip--top::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--top::after,
+  .bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip--top:hover::before, .bx--tooltip__trigger.bx--tooltip--top:hover::after, .bx--tooltip__trigger.bx--tooltip--top:focus::before, .bx--tooltip__trigger.bx--tooltip--top:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--top:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--top:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--top:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--top:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--top:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--top:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::before, .bx--tooltip__trigger.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::before {
+  top: -0.5rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top::after,
+.bx--tooltip__trigger.bx--tooltip--top .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top + .bx--assistive-text {
+  top: -0.8125rem;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start::before {
+  top: -0.5rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-start + .bx--assistive-text {
+  top: -0.8125rem;
+  left: 0;
+  transform: translate(0, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center::before {
+  top: -0.5rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-center + .bx--assistive-text {
+  top: -0.8125rem;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end::before {
+  top: -0.5rem;
+  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--top.bx--tooltip--align-end + .bx--assistive-text {
+  top: -0.8125rem;
+  right: 0;
+  left: auto;
+  transform: translate(0, -100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--right:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--right:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--right:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::before, .bx--tooltip__trigger.bx--tooltip--right::after,
+.bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--right::before, .bx--tooltip__trigger.bx--tooltip--right::after,
+  .bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::before, .bx--tooltip__trigger.bx--tooltip--right::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::after,
+.bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--right::after,
+  .bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip--right::after,
+  .bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip--right::after,
+  .bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--right::after,
+  .bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip--right:hover::before, .bx--tooltip__trigger.bx--tooltip--right:hover::after, .bx--tooltip__trigger.bx--tooltip--right:focus::before, .bx--tooltip__trigger.bx--tooltip--right:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--right:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--right:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--right:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--right:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--right:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--right:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::before, .bx--tooltip__trigger.bx--tooltip--right::after,
+.bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+  top: 50%;
+  right: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::before {
+  right: -0.5rem;
+  border-color: transparent var(--cds-inverse-02, #393939) transparent transparent;
+  border-width: 0.25rem 0.3125rem 0.25rem 0;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right::after,
+.bx--tooltip__trigger.bx--tooltip--right .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right + .bx--assistive-text {
+  right: -0.8125rem;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start + .bx--assistive-text {
+  top: 50%;
+  right: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start::before {
+  right: -0.5rem;
+  border-color: transparent var(--cds-inverse-02, #393939) transparent transparent;
+  border-width: 0.25rem 0.3125rem 0.25rem 0;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-start + .bx--assistive-text {
+  right: -0.8125rem;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center + .bx--assistive-text {
+  top: 50%;
+  right: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center::before {
+  right: -0.5rem;
+  border-color: transparent var(--cds-inverse-02, #393939) transparent transparent;
+  border-width: 0.25rem 0.3125rem 0.25rem 0;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-center + .bx--assistive-text {
+  right: -0.8125rem;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end + .bx--assistive-text {
+  top: 50%;
+  right: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end::before {
+  right: -0.5rem;
+  border-color: transparent var(--cds-inverse-02, #393939) transparent transparent;
+  border-width: 0.25rem 0.3125rem 0.25rem 0;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--right.bx--tooltip--align-end + .bx--assistive-text {
+  right: -0.8125rem;
+  transform: translate(100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--bottom:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--bottom:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip--bottom::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--bottom::after,
+  .bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip--bottom:hover::before, .bx--tooltip__trigger.bx--tooltip--bottom:hover::after, .bx--tooltip__trigger.bx--tooltip--bottom:focus::before, .bx--tooltip__trigger.bx--tooltip--bottom:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--bottom:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--bottom:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--bottom:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--bottom:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--bottom:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--bottom:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::before, .bx--tooltip__trigger.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom::after,
+.bx--tooltip__trigger.bx--tooltip--bottom .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-start + .bx--assistive-text {
+  bottom: -0.8125rem;
+  left: 0;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-end + .bx--assistive-text {
+  bottom: -0.8125rem;
+  right: 0;
+  left: auto;
+  transform: translate(0, 100%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--left:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--left:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--left:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::before, .bx--tooltip__trigger.bx--tooltip--left::after,
+.bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--left::before, .bx--tooltip__trigger.bx--tooltip--left::after,
+  .bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::before, .bx--tooltip__trigger.bx--tooltip--left::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::after,
+.bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--tooltip__trigger.bx--tooltip--left::after,
+  .bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--tooltip__trigger.bx--tooltip--left::after,
+  .bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--tooltip__trigger.bx--tooltip--left::after,
+  .bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tooltip__trigger.bx--tooltip--left::after,
+  .bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+  .bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::after {
+  content: attr(aria-label);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible::before, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible::after, .bx--tooltip__trigger.bx--tooltip--left:hover::before, .bx--tooltip__trigger.bx--tooltip--left:hover::after, .bx--tooltip__trigger.bx--tooltip--left:focus::before, .bx--tooltip__trigger.bx--tooltip--left:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--left:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--left:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--left:hover .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left:hover + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--left:hover.bx--tooltip--a11y::before, .bx--tooltip__trigger.bx--tooltip--left:focus .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left:focus + .bx--assistive-text, .bx--tooltip__trigger.bx--tooltip--left:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--hidden .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::before, .bx--tooltip__trigger.bx--tooltip--left::after,
+.bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+  top: 50%;
+  left: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::before {
+  left: -0.5rem;
+  border-color: transparent transparent transparent var(--cds-inverse-02, #393939);
+  border-width: 0.25rem 0 0.25rem 0.3125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left::after,
+.bx--tooltip__trigger.bx--tooltip--left .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left + .bx--assistive-text {
+  left: -0.8125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start::before, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start + .bx--assistive-text {
+  top: 50%;
+  left: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start::before {
+  left: -0.5rem;
+  border-color: transparent transparent transparent var(--cds-inverse-02, #393939);
+  border-width: 0.25rem 0 0.25rem 0.3125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-start + .bx--assistive-text {
+  left: -0.8125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center::before, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center + .bx--assistive-text {
+  top: 50%;
+  left: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center::before {
+  left: -0.5rem;
+  border-color: transparent transparent transparent var(--cds-inverse-02, #393939);
+  border-width: 0.25rem 0 0.25rem 0.3125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-center + .bx--assistive-text {
+  left: -0.8125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end::before, .bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end + .bx--assistive-text {
+  top: 50%;
+  left: 0;
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end::before {
+  left: -0.5rem;
+  border-color: transparent transparent transparent var(--cds-inverse-02, #393939);
+  border-width: 0.25rem 0 0.25rem 0.3125rem;
+  transform: translate(-100%, -50%);
+}
+
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end::after,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end .bx--assistive-text,
+.bx--tooltip__trigger.bx--tooltip--left.bx--tooltip--align-end + .bx--assistive-text {
+  left: -0.8125rem;
+  transform: translate(-100%, -50%);
+}
+
+.exp--action-bar {
+  display: block;
+}
+
+.exp--action-bar--displayed-items {
+  display: inline-flex;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp--action-bar--displayed-items--right {
+  justify-content: flex-end;
+}
+
+.exp--action-bar--overflow-menu {
+  display: inline-block;
+}
+
+.exp--action-bar--overflow-menu-item {
+  padding: 0 var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--action-bar--overflow-menu-item-content {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.exp--action-bar--overflow-menu-item svg {
+  margin: 0 var(--cds-spacing-02, 0.25rem);
+}
+
+.bx--breadcrumb {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: inline;
+}
+
+.bx--breadcrumb *,
+.bx--breadcrumb *::before,
+.bx--breadcrumb *::after {
+  box-sizing: inherit;
+}
+
+@media (min-width: 42rem) {
+  .bx--breadcrumb {
+    display: flex;
+    flex-wrap: wrap;
+  }
+}
+
+.bx--breadcrumb-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-right: 0.5rem;
+}
+
+.bx--breadcrumb-item .bx--link:visited {
+  color: var(--cds-link-01, #0f62fe);
+}
+
+.bx--breadcrumb-item .bx--link:visited:hover {
+  color: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--breadcrumb-item::after {
+  margin-left: 0.5rem;
+  color: var(--cds-text-01, #161616);
+  content: '/';
+}
+
+.bx--breadcrumb--no-trailing-slash
+.bx--breadcrumb-item:last-child::after {
+  content: '';
+}
+
+.bx--breadcrumb-item:last-child,
+.bx--breadcrumb-item:last-child::after {
+  margin-right: 0;
+}
+
+.bx--breadcrumb .bx--link {
+  white-space: nowrap;
+}
+
+.bx--breadcrumb-item [aria-current='page'],
+.bx--breadcrumb-item.bx--breadcrumb-item--current
+.bx--link {
+  color: var(--cds-text-01, #161616);
+  cursor: auto;
+}
+
+.bx--breadcrumb-item [aria-current='page']:hover,
+.bx--breadcrumb-item.bx--breadcrumb-item--current
+.bx--link:hover {
+  text-decoration: none;
+}
+
+.bx--breadcrumb.bx--skeleton .bx--link {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 6.25rem;
+  height: 1rem;
+}
+
+.bx--breadcrumb.bx--skeleton .bx--link:hover, .bx--breadcrumb.bx--skeleton .bx--link:focus, .bx--breadcrumb.bx--skeleton .bx--link:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--breadcrumb.bx--skeleton .bx--link::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--breadcrumb.bx--skeleton .bx--link::before {
+    animation: none;
+  }
+}
+
+.exp-breadcrumb-with-overflow {
+  display: block;
+}
+
+.exp-breadcrumb-with-overflow--space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp-breadcrumb-with-overflow--space--right {
+  text-align: end;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container {
+  display: inline-flex;
+  width: 100%;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container .bx--breadcrumb {
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: -100vw;
+  max-width: 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:hover {
+  background: transparent;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu::after {
+  position: absolute;
+  bottom: 2px;
+  width: 0.75rem;
+  height: 1px;
+  background: var(--cds-hover-primary-text, #0043ce);
+  opacity: 0;
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  content: '';
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:hover::after {
+  opacity: 1;
+}
+
+.bx--breadcrumb-item
+.bx--overflow-menu.bx--overflow-menu--open {
+  background: transparent;
+  box-shadow: none;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu__icon {
+  position: relative;
+  transform: translateY(4px);
+  fill: var(--cds-link-01, #0f62fe);
+}
+
+.bx--breadcrumb-item
+.bx--overflow-menu:hover
+.bx--overflow-menu__icon {
+  fill: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--breadcrumb-menu-options:focus {
+  outline: none;
+}
+
+.bx--breadcrumb-menu-options.bx--overflow-menu-options::after {
+  top: -0.4375rem;
+  left: 0.875rem;
+  width: 0;
+  height: 0;
+  margin: 0 auto;
+  background: transparent;
+  border-right: 0.4375rem solid transparent;
+  border-bottom: 0.4375rem solid var(--cds-field-01, #f4f4f4);
+  border-left: 0.4375rem solid transparent;
+}
+
+.exp-breadcrumb-with-overflow--displayed-breadcrumb {
+  overflow: hidden;
+}
+
+@keyframes hide-feedback {
+  0% {
+    visibility: inherit;
+    opacity: 1;
+  }
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes show-feedback {
+  0% {
+    visibility: hidden;
+    opacity: 0;
+  }
+  100% {
+    visibility: inherit;
+    opacity: 1;
+  }
+}
+
+.bx--snippet {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+}
+
+.bx--snippet *,
+.bx--snippet *::before,
+.bx--snippet *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet--disabled,
+.bx--snippet--disabled
+.bx--btn.bx--snippet-btn--expand {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--snippet--disabled .bx--snippet-btn--expand:hover,
+.bx--snippet--disabled .bx--copy-btn:hover {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+  cursor: not-allowed;
+}
+
+.bx--snippet--disabled .bx--snippet__icon,
+.bx--snippet--disabled
+.bx--snippet-btn--expand
+.bx--icon-chevron--down {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--snippet code {
+  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  line-height: var(--cds-code-01-line-height, 1.34);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+}
+
+.bx--snippet--inline {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+  display: inline;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.bx--snippet--inline *,
+.bx--snippet--inline *::before,
+.bx--snippet--inline *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet--inline:hover {
+  background-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--snippet--inline:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--snippet--inline:focus {
+  border: 2px solid var(--cds-focus, #0f62fe);
+  outline: none;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet--inline:focus {
+    border-style: dotted;
+  }
+}
+
+.bx--snippet--inline::before {
+  position: absolute;
+  z-index: 6000;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+  display: none;
+}
+
+.bx--snippet--inline .bx--copy-btn__feedback {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: none;
+  box-sizing: content-box;
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--snippet--inline::before, .bx--snippet--inline::after,
+.bx--snippet--inline .bx--assistive-text,
+.bx--snippet--inline + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--snippet--inline::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--snippet--inline::after,
+.bx--snippet--inline .bx--assistive-text,
+.bx--snippet--inline + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--snippet--inline.bx--copy-btn--animating::before,
+.bx--snippet--inline.bx--copy-btn--animating
+.bx--copy-btn__feedback {
+  display: block;
+}
+
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out
+.bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
+}
+
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in
+.bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
+}
+
+.bx--snippet--inline code {
+  padding: 0 var(--cds-spacing-03, 0.5rem);
+}
+
+.bx--snippet--inline.bx--snippet--no-copy {
+  display: inline-block;
+}
+
+.bx--snippet--inline.bx--snippet--no-copy:hover {
+  background-color: var(--cds-field-01, #f4f4f4);
+  cursor: auto;
+}
+
+.bx--snippet--light.bx--snippet--inline.bx--snippet--no-copy:hover {
+  background-color: var(--cds-field-02, #ffffff);
+  cursor: auto;
+}
+
+.bx--snippet--single {
+  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  line-height: var(--cds-code-01-line-height, 1.34);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+  position: relative;
+  width: 100%;
+  max-width: 37.5rem;
+  background-color: var(--cds-field-01, #f4f4f4);
+  display: flex;
+  align-items: center;
+  max-width: 47.5rem;
+  height: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--single {
+    outline: 2px solid transparent;
+  }
+}
+
+.bx--snippet--single.bx--snippet--no-copy {
+  padding: 0;
+}
+
+.bx--snippet--single.bx--snippet--no-copy::after {
+  right: 1rem;
+}
+
+.bx--snippet--single .bx--snippet-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-left: 1rem;
+  overflow-x: auto;
+}
+
+.bx--snippet--single .bx--snippet-container:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet--single .bx--snippet-container:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--single pre {
+  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  line-height: var(--cds-code-01-line-height, 1.34);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+  padding-right: var(--cds-spacing-03, 0.5rem);
+}
+
+.bx--snippet--single pre,
+.bx--snippet--inline code {
+  white-space: pre;
+}
+
+.bx--snippet--multi {
+  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
+  font-size: var(--cds-code-01-font-size, 0.75rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  line-height: var(--cds-code-01-line-height, 1.34);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
+  position: relative;
+  width: 100%;
+  max-width: 37.5rem;
+  background-color: var(--cds-field-01, #f4f4f4);
+  display: flex;
+  max-width: 100%;
+  padding: 1rem;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--multi {
+    outline: 2px solid transparent;
+  }
+}
+
+.bx--snippet--multi .bx--snippet-container {
+  position: relative;
+  order: 1;
+  min-height: 3.5rem;
+  max-height: 14.875rem;
+  overflow: hidden;
+  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--snippet--multi.bx--snippet--expand
+.bx--snippet-container {
+  max-height: 100%;
+  padding-bottom: var(--cds-spacing-05, 1rem);
+  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--snippet--multi.bx--snippet--wraptext pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.bx--snippet--multi .bx--snippet-container pre {
+  padding-right: 2.5rem;
+  padding-bottom: 1.5rem;
+  overflow-x: auto;
+}
+
+.bx--snippet--multi.bx--snippet--no-copy
+.bx--snippet-container
+pre {
+  padding-right: 0;
+}
+
+.bx--snippet--multi.bx--snippet--expand
+.bx--snippet-container
+pre {
+  overflow-x: auto;
+}
+
+.bx--snippet--multi .bx--snippet-container pre::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1rem;
+  height: 100%;
+  background-image: linear-gradient(to right, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
+  content: '';
+}
+
+.bx--snippet--multi .bx--snippet-container pre code {
+  overflow: hidden;
+}
+
+.bx--snippet__icon {
+  width: 1rem;
+  height: 1rem;
+  transition: all 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-icon-01, #161616);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet__icon {
+    fill: ButtonText;
+  }
+}
+
+.bx--snippet-button {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  overflow: visible;
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: none;
+  outline: none;
+  cursor: pointer;
+}
+
+.bx--snippet-button *,
+.bx--snippet-button *::before,
+.bx--snippet-button *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  outline-color: var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet-button:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--multi .bx--snippet-button {
+  top: var(--cds-spacing-03, 0.5rem);
+  right: var(--cds-spacing-03, 0.5rem);
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--snippet-button:hover {
+  background: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--snippet-button:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--btn--copy__feedback {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  top: 0.75rem;
+  right: 1.25rem;
+  left: inherit;
+  z-index: 6000;
+  font-weight: 400;
+}
+
+.bx--btn--copy__feedback::before,
+.bx--btn--copy__feedback::after {
+  background: var(--cds-inverse-02, #393939);
+}
+
+.bx--btn--copy__feedback::after {
+  border: none;
+}
+
+.bx--snippet .bx--copy-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.bx--snippet-btn--expand {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: 0;
+}
+
+.bx--snippet-btn--expand .bx--snippet-btn--text {
+  position: relative;
+  top: -0.0625rem;
+}
+
+.bx--snippet-btn--expand--hide.bx--snippet-btn--expand {
+  display: none;
+}
+
+.bx--snippet-btn--expand .bx--icon-chevron--down {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+  transform: rotate(0deg);
+  transition: 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-text-01, #161616);
+}
+
+.bx--snippet-btn--expand:hover {
+  color: var(--cds-text-01, #161616);
+  background: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--snippet-btn--expand:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--snippet-btn--expand:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  border-color: transparent;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet-btn--expand:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--expand
+.bx--snippet-btn--expand
+.bx--icon-chevron--down {
+  transform: rotate(180deg);
+  transition: transform 240ms;
+}
+
+.bx--snippet--light,
+.bx--snippet--light .bx--snippet-button,
+.bx--snippet--light .bx--btn.bx--snippet-btn--expand,
+.bx--snippet--light .bx--copy-btn {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--snippet--light.bx--snippet--inline:hover,
+.bx--snippet--light .bx--snippet-button:hover,
+.bx--snippet--light
+.bx--btn.bx--snippet-btn--expand:hover,
+.bx--snippet--light .bx--copy-btn:hover {
+  background-color: var(--cds-hover-light-ui, #e5e5e5);
+}
+
+.bx--snippet--light.bx--snippet--inline:active,
+.bx--snippet--light .bx--snippet-button:active,
+.bx--snippet--light
+.bx--btn.bx--snippet-btn--expand:active,
+.bx--snippet--light .bx--copy-btn:active {
+  background-color: var(--cds-active-light-ui, #c6c6c6);
+}
+
+.bx--snippet--light.bx--snippet--single::after,
+.bx--snippet--light.bx--snippet--multi
+.bx--snippet-container
+pre::after {
+  background-image: linear-gradient(to right, rgba(var(--cds-field-02, #ffffff), 0), var(--cds-field-02, #ffffff));
+}
+
+.bx--snippet--code.bx--skeleton {
+  height: 6.125rem;
+}
+
+.bx--snippet--terminal.bx--skeleton {
+  height: 3.5rem;
+}
+
+.bx--snippet.bx--skeleton .bx--snippet-container {
+  height: 100%;
+}
+
+.bx--snippet.bx--skeleton code {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  display: block;
+  width: 100%;
+  height: 1rem;
+}
+
+.bx--snippet.bx--skeleton code:hover, .bx--snippet.bx--skeleton code:focus, .bx--snippet.bx--skeleton code:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--snippet.bx--skeleton code::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--snippet.bx--skeleton code::before {
+    animation: none;
+  }
+}
+
+.bx--snippet-button .bx--btn--copy__feedback {
+  top: 3.175rem;
+  right: auto;
+  left: 50%;
+}
+
+.bx--snippet-button .bx--btn--copy__feedback::before {
+  top: 0;
+}
+
+.bx--snippet-button .bx--btn--copy__feedback::after {
+  top: -0.25rem;
+}
+
+.bx--snippet--multi .bx--copy-btn {
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--snippet--multi
+.bx--snippet-button
+.bx--btn--copy__feedback {
+  top: 2.675rem;
+}
+
+.bx--snippet--inline .bx--btn--copy__feedback {
+  top: calc(100% - 0.25rem);
+  right: auto;
+  left: 50%;
+}
+
+.bx--snippet__overflow-indicator--left,
+.bx--snippet__overflow-indicator--right {
+  z-index: 1;
+  flex: 1 0 auto;
+  width: 1rem;
+}
+
+.bx--snippet__overflow-indicator--left {
+  order: 0;
+  margin-right: -1rem;
+  background-image: linear-gradient(to left, transparent, var(--cds-field-01, #f4f4f4));
+}
+
+.bx--snippet__overflow-indicator--right {
+  order: 2;
+  margin-left: -1rem;
+  background-image: linear-gradient(to right, transparent, var(--cds-field-01, #f4f4f4));
+}
+
+.bx--snippet--single .bx--snippet__overflow-indicator--right,
+.bx--snippet--single .bx--snippet__overflow-indicator--left {
+  position: absolute;
+  width: 2rem;
+  height: calc(100% - 0.25rem);
+}
+
+.bx--snippet--single .bx--snippet__overflow-indicator--right {
+  right: 2.5rem;
+}
+
+.bx--snippet--single
+.bx--snippet-container:focus
+~ .bx--snippet__overflow-indicator--right {
+  right: calc(2.5rem + 0.125rem);
+}
+
+.bx--snippet--single
+.bx--snippet-container:focus
++ .bx--snippet__overflow-indicator--left {
+  left: 0.125rem;
+}
+
+.bx--snippet--light .bx--snippet__overflow-indicator--left {
+  background-image: linear-gradient(to left, transparent, var(--cds-field-02, #ffffff));
+}
+
+.bx--snippet--light .bx--snippet__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, var(--cds-field-02, #ffffff));
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .bx--snippet__overflow-indicator--left {
+      background-image: linear-gradient(to left, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
+    }
+    .bx--snippet__overflow-indicator--right {
+      background-image: linear-gradient(to right, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
+    }
+  }
+}
+
+bx--snippet--multi.bx--skeleton {
+  height: 6.125rem;
+}
+
+.bx--snippet--single.bx--skeleton {
+  height: 3.5rem;
+}
+
+.bx--snippet.bx--skeleton span {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  display: block;
+  width: 100%;
+  height: 1rem;
+  margin-top: 0.5rem;
+}
+
+.bx--snippet.bx--skeleton span:hover, .bx--snippet.bx--skeleton span:focus, .bx--snippet.bx--skeleton span:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--snippet.bx--skeleton span::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--snippet.bx--skeleton span::before {
+    animation: none;
+  }
+}
+
+.bx--snippet.bx--skeleton span:first-child {
+  margin: 0;
+}
+
+.bx--snippet.bx--skeleton span:nth-child(2) {
+  width: 85%;
+}
+
+.bx--snippet.bx--skeleton span:nth-child(3) {
+  width: 95%;
+}
+
+.bx--snippet--single.bx--skeleton
+.bx--snippet-container {
+  padding-bottom: 0;
+}
+
+@keyframes hide-feedback {
+  0% {
+    visibility: inherit;
+    opacity: 1;
+  }
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes show-feedback {
+  0% {
+    visibility: hidden;
+    opacity: 0;
+  }
+  100% {
+    visibility: inherit;
+    opacity: 1;
+  }
+}
+
+.bx--btn--copy {
+  position: relative;
+  overflow: visible;
+}
+
+.bx--btn--copy .bx--btn__icon {
+  margin-left: 0.3125rem;
+}
+
+.bx--btn--copy__feedback {
+  position: absolute;
+  top: 1.2rem;
+  left: 50%;
+  display: none;
+}
+
+.bx--btn--copy__feedback:focus {
+  border: 2px solid var(--cds-support-01, #da1e28);
+}
+
+.bx--btn--copy__feedback::before {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  top: 1.1rem;
+  z-index: 2;
+  padding: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: 4px;
+  transform: translateX(-50%);
+  content: attr(data-feedback);
+  pointer-events: none;
+}
+
+.bx--btn--copy__feedback::after {
+  top: 0.85rem;
+  left: -0.3rem;
+  z-index: 1;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 1px solid var(--cds-inverse-02, #393939);
+  border-bottom: 1px solid var(--cds-inverse-02, #393939);
+  transform: rotate(-135deg);
+  content: '';
+}
+
+.bx--btn--copy__feedback::before, .bx--btn--copy__feedback::after {
+  position: absolute;
+  display: block;
+  background: var(--cds-inverse-02, #393939);
+}
+
+.bx--btn--copy__feedback--displayed {
+  display: inline-flex;
+}
+
+.bx--copy-btn {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  border: none;
+  cursor: pointer;
+}
+
+.bx--copy-btn *,
+.bx--copy-btn *::before,
+.bx--copy-btn *::after {
+  box-sizing: inherit;
+}
+
+.bx--copy-btn:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--copy-btn:active {
+  background-color: var(--cds-active-ui, #c6c6c6);
+}
+
+.bx--copy-btn::before {
+  position: absolute;
+  z-index: 6000;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+  display: none;
+}
+
+.bx--copy-btn .bx--copy-btn__feedback {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  z-index: 3;
+  display: none;
+  box-sizing: content-box;
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--copy-btn::before, .bx--copy-btn::after,
+.bx--copy-btn .bx--assistive-text,
+.bx--copy-btn + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--copy-btn::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--copy-btn::after,
+.bx--copy-btn .bx--assistive-text,
+.bx--copy-btn + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--copy-btn:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  outline-color: var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--copy-btn:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--copy-btn.bx--copy-btn--animating::before,
+.bx--copy-btn.bx--copy-btn--animating .bx--copy-btn__feedback {
+  display: block;
+}
+
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out .bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
+}
+
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in .bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
+}
+
+.bx--copy {
+  font-size: 0;
+}
+
+.exp--empty-state .exp--empty-state__header,
+.exp--empty-state .exp--empty-state__subtext,
+.exp--empty-state p {
+  margin: 0;
+  padding-bottom: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--empty-state__illustration.exp--empty-state__illustration--lg {
+  min-width: 5rem;
+  max-width: 5rem;
+}
+
+.exp--empty-state__illustration.exp--empty-state__illustration--sm {
+  min-width: 4rem;
+  max-width: 4rem;
+}
+
+.exp--empty-state__action-button,
+.exp--empty-state__link {
+  display: block;
+  margin-top: var(--cds-spacing-06, 1.5rem);
+}
+
+.exp--example-component {
+  display: flex;
+  justify-content: flex-end;
+  --exp-border-color: transparent;
+}
+
+.exp--example-component.exp--example-component--boxed-set {
+  border: 10px solid var(--exp-border-color);
+}
+
+.exp--example-component.exp--example-component--shadow-set {
+  margin: var(--cds-spacing-04, 0.75rem);
+  box-shadow: 0 0 10px var(--exp-border-color);
+}
+
+.exp--http-errors.exp--http-errors-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+  transform: translate(-50%, -150%);
+}
+
+@media (min-width: 42rem) {
+  .exp--http-errors.exp--http-errors-content {
+    transform: translate(-50%, -50%);
+  }
+}
+
+.exp--http-errors .exp--http-errors-error-code-label {
+  font-size: var(--cds-productive-heading-02-font-size, 1rem);
+  font-weight: var(--cds-productive-heading-02-font-weight, 600);
+  line-height: var(--cds-productive-heading-02-line-height, 1.375);
+  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--http-errors .exp--http-errors-title {
+  font-size: var(--cds-productive-heading-05-font-size, 2rem);
+  font-weight: var(--cds-productive-heading-05-font-weight, 400);
+  line-height: var(--cds-productive-heading-05-line-height, 1.25);
+  letter-spacing: var(--cds-productive-heading-05-letter-spacing, 0);
+  margin-bottom: var(--cds-spacing-04, 0.75rem);
+}
+
+.exp--http-errors .exp--http-errors-description {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  margin-bottom: var(--cds-spacing-06, 1.5rem);
+}
+
+.exp--http-errors .exp--http-errors-link {
+  display: block;
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--http-errors .exp--http-errors__image {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  transform: translate(-50%, -40%);
+}
+
+@media (min-width: 42rem) {
+  .exp--http-errors .exp--http-errors__image {
+    transform: translate(-50%, -50%);
+  }
+}
+
+.bx--fieldset {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  margin-bottom: 2rem;
+}
+
+.bx--fieldset *,
+.bx--fieldset *::before,
+.bx--fieldset *::after {
+  box-sizing: inherit;
+}
+
+.bx--form-item {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.bx--label {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  color: var(--cds-text-02, #525252);
+  font-weight: 400;
+  line-height: 1rem;
+  vertical-align: baseline;
+}
+
+.bx--label *,
+.bx--label *::before,
+.bx--label *::after {
+  box-sizing: inherit;
+}
+
+.bx--label .bx--tooltip__trigger {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.bx--label.bx--skeleton {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 4.6875rem;
+  height: 0.875rem;
+}
+
+.bx--label.bx--skeleton:hover, .bx--label.bx--skeleton:focus, .bx--label.bx--skeleton:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--label.bx--skeleton::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--label.bx--skeleton::before {
+    animation: none;
+  }
+}
+
+input[type='number'] {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+}
+
+input[data-invalid]:not(:focus),
+.bx--number[data-invalid] input[type='number']:not(:focus),
+.bx--text-input__field-wrapper[data-invalid]
+> .bx--text-input--invalid:not(:focus),
+.bx--text-area__wrapper[data-invalid]
+> .bx--text-area--invalid:not(:focus),
+.bx--select-input__wrapper[data-invalid]
+.bx--select-input:not(:focus),
+.bx--list-box[data-invalid]:not(:focus),
+.bx--combo-box[data-invalid] .bx--text-input:not(:focus) {
+  outline: 2px solid var(--cds-support-01, #da1e28);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  input[data-invalid]:not(:focus),
+  .bx--number[data-invalid] input[type='number']:not(:focus),
+  .bx--text-input__field-wrapper[data-invalid]
+> .bx--text-input--invalid:not(:focus),
+  .bx--text-area__wrapper[data-invalid]
+> .bx--text-area--invalid:not(:focus),
+  .bx--select-input__wrapper[data-invalid]
+.bx--select-input:not(:focus),
+  .bx--list-box[data-invalid]:not(:focus),
+  .bx--combo-box[data-invalid] .bx--text-input:not(:focus) {
+    outline-style: dotted;
+  }
+}
+
+input[data-invalid] ~ .bx--form-requirement,
+.bx--number[data-invalid] .bx--number__input-wrapper ~ .bx--form-requirement,
+.bx--number__input-wrapper--warning ~ .bx--form-requirement,
+.bx--date-picker-input__wrapper ~ .bx--form-requirement,
+.bx--date-picker-input__wrapper--warn ~ .bx--form-requirement,
+.bx--date-picker-input__wrapper--invalid ~ .bx--form-requirement,
+.bx--time-picker--invalid ~ .bx--form-requirement,
+.bx--text-input__field-wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--text-input__field-wrapper--warning ~ .bx--form-requirement,
+.bx--text-input__field-wrapper--warning > .bx--text-input ~ .bx--form-requirement,
+.bx--text-area__wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--select-input__wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--time-picker[data-invalid] ~ .bx--form-requirement,
+.bx--list-box[data-invalid] ~ .bx--form-requirement,
+.bx--list-box--warning ~ .bx--form-requirement {
+  display: block;
+  max-height: 12.5rem;
+  overflow: visible;
+  font-weight: 400;
+}
+
+input[data-invalid] ~ .bx--form-requirement,
+.bx--number[data-invalid] .bx--number__input-wrapper ~ .bx--form-requirement,
+.bx--date-picker-input__wrapper ~ .bx--form-requirement,
+.bx--date-picker-input__wrapper--invalid ~ .bx--form-requirement,
+.bx--time-picker--invalid ~ .bx--form-requirement,
+.bx--text-input__field-wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--text-area__wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--select-input__wrapper[data-invalid] ~ .bx--form-requirement,
+.bx--time-picker[data-invalid] ~ .bx--form-requirement,
+.bx--list-box[data-invalid] ~ .bx--form-requirement {
+  color: var(--cds-text-error, #da1e28);
+}
+
+.bx--form--fluid .bx--text-input__field-wrapper[data-invalid],
+.bx--form--fluid .bx--text-input__field-wrapper--warning {
+  display: block;
+}
+
+.bx--form--fluid .bx--fieldset {
+  margin: 0;
+}
+
+.bx--form--fluid input[data-invalid] {
+  outline: none;
+}
+
+.bx--form--fluid .bx--form-requirement {
+  margin: 0;
+  padding: 0.5rem 2.5rem 0.5rem 1rem;
+}
+
+input:not(output):not([data-invalid]):-moz-ui-invalid {
+  box-shadow: none;
+}
+
+.bx--form-requirement {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-caption-01-font-size, 0.75rem);
+  font-weight: var(--cds-caption-01-font-weight, 400);
+  line-height: var(--cds-caption-01-line-height, 1.34);
+  letter-spacing: var(--cds-caption-01-letter-spacing, 0.32px);
+  display: none;
+  max-height: 0;
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+}
+
+.bx--form-requirement *,
+.bx--form-requirement *::before,
+.bx--form-requirement *::after {
+  box-sizing: inherit;
+}
+
+.bx--select--inline .bx--form__helper-text {
+  margin-top: 0;
+}
+
+.bx--form__helper-text {
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  line-height: var(--cds-helper-text-01-line-height, 1.34);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+  z-index: 0;
+  width: 100%;
+  margin-top: 0.25rem;
+  color: var(--cds-text-02, #525252);
+  opacity: 1;
+}
+
+.bx--label--disabled,
+.bx--form__helper-text--disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+.bx--loading {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  animation-name: rotate;
+  animation-duration: 690ms;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-fill-mode: forwards;
+  width: 5.5rem;
+  height: 5.5rem;
+}
+
+.bx--loading *,
+.bx--loading *::before,
+.bx--loading *::after {
+  box-sizing: inherit;
+}
+
+.bx--loading svg circle {
+  animation-name: init-stroke;
+  animation-duration: 10ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--loading__svg {
+  fill: transparent;
+}
+
+.bx--loading__svg circle {
+  stroke-width: 10;
+  stroke-linecap: butt;
+  stroke-dasharray: 240;
+}
+
+.bx--loading__stroke {
+  stroke: var(--cds-interactive-04, #0f62fe);
+  stroke-dashoffset: 16;
+}
+
+.bx--loading--small .bx--loading__stroke {
+  stroke-dashoffset: 110;
+}
+
+.bx--loading--stop {
+  animation: rotate-end-p1 700ms cubic-bezier(0.2, 0, 1, 0.9) forwards, rotate-end-p2 700ms cubic-bezier(0.2, 0, 1, 0.9) 700ms forwards;
+}
+
+.bx--loading--stop svg circle {
+  animation-name: stroke-end;
+  animation-duration: 700ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 1, 0.9);
+  animation-delay: 700ms;
+  animation-fill-mode: forwards;
+}
+
+.bx--loading--small {
+  width: 1rem;
+  height: 1rem;
+}
+
+.bx--loading--small circle {
+  stroke-width: 16;
+}
+
+.bx--loading--small .bx--loading__svg {
+  stroke: var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--loading__background {
+  stroke: var(--cds-ui-03, #e0e0e0);
+  stroke-dashoffset: -22;
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    circle.bx--loading__background {
+      stroke-dashoffset: 0;
+      stroke-dasharray: 265;
+    }
+  }
+}
+
+.bx--loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
+  transition: background-color 720ms cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+
+.bx--loading-overlay--stop {
+  display: none;
+}
+
+.bx--file {
+  width: 100%;
+}
+
+.bx--file--invalid {
+  margin-right: 0.5rem;
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.bx--file--label {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  margin-bottom: 0.5rem;
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--file--label *,
+.bx--file--label *::before,
+.bx--file--label *::after {
+  box-sizing: inherit;
+}
+
+.bx--file--label--disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--file-btn {
+  display: inline-flex;
+  margin: 0;
+  padding-right: 4rem;
+}
+
+.bx--file-browse-btn {
+  display: inline-block;
+  width: 100%;
+  max-width: 20rem;
+  margin-bottom: 0.5rem;
+  color: var(--cds-link-01, #0f62fe);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  cursor: pointer;
+  transition: 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--file-browse-btn:focus, .bx--file-browse-btn:hover {
+  outline: 2px solid var(--cds-interactive-03, #0f62fe);
+}
+
+.bx--file-browse-btn:hover, .bx--file-browse-btn:focus, .bx--file-browse-btn:active, .bx--file-browse-btn:active:visited {
+  text-decoration: underline;
+}
+
+.bx--file-browse-btn:active {
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--file-browse-btn--disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+  text-decoration: none;
+  cursor: no-drop;
+}
+
+.bx--file-browse-btn--disabled:hover, .bx--file-browse-btn--disabled:focus {
+  color: var(--cds-disabled-02, #c6c6c6);
+  text-decoration: none;
+  outline: none;
+}
+
+.bx--file-browse-btn--disabled .bx--file__drop-container {
+  border: 1px dashed var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--label-description {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  margin-bottom: 1rem;
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--label-description *,
+.bx--label-description *::before,
+.bx--label-description *::after {
+  box-sizing: inherit;
+}
+
+.bx--label-description--disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--file-btn ~ .bx--file-container {
+  margin-top: 1.5rem;
+}
+
+.bx--btn ~ .bx--file-container {
+  margin-top: 1rem;
+}
+
+.bx--file .bx--file-container,
+.bx--file ~ .bx--file-container {
+  margin-top: 0.5rem;
+}
+
+.bx--file__selected-file {
+  display: grid;
+  grid-auto-rows: auto;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  max-width: 20rem;
+  min-height: 3rem;
+  margin-bottom: 0.5rem;
+  word-break: break-word;
+  background-color: var(--cds-field-01, #f4f4f4);
+}
+
+.bx--file__selected-file:last-child {
+  margin-bottom: 0;
+}
+
+.bx--file__selected-file .bx--form-requirement {
+  display: block;
+  grid-column: 1 / -1;
+  max-height: none;
+  margin: 0;
+}
+
+.bx--file__selected-file .bx--inline-loading__animation .bx--loading {
+  margin-right: 0;
+}
+
+.bx--file__selected-file .bx--file-filename {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  margin-left: 1rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--file__selected-file {
+    outline: 2px solid transparent;
+  }
+}
+
+.bx--file__selected-file--field {
+  gap: 0.5rem 1rem;
+  min-height: 2.5rem;
+}
+
+.bx--file__selected-file--sm {
+  gap: 0.25rem 1rem;
+  min-height: 2rem;
+}
+
+.bx--file__selected-file--invalid__wrapper {
+  outline: 2px solid var(--cds-support-01, #da1e28);
+  outline-offset: -2px;
+  max-width: 20rem;
+  margin-bottom: 0.5rem;
+  background-color: var(--cds-field-01, #f4f4f4);
+  outline-width: 1px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--file__selected-file--invalid__wrapper {
+    outline-style: dotted;
+  }
+}
+
+.bx--file__selected-file--invalid {
+  outline: 2px solid var(--cds-support-01, #da1e28);
+  outline-offset: -2px;
+  padding: 0.75rem 0;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--file__selected-file--invalid {
+    outline-style: dotted;
+  }
+}
+
+.bx--file__selected-file--invalid.bx--file__selected-file--sm {
+  padding: 0.25rem 0;
+}
+
+.bx--file__selected-file--invalid.bx--file__selected-file--field {
+  padding: 0.5rem 0;
+}
+
+.bx--file__selected-file--invalid .bx--form-requirement {
+  padding-top: 1rem;
+  border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.bx--file__selected-file--invalid.bx--file__selected-file--sm
+.bx--form-requirement {
+  padding-top: 0.4375rem;
+}
+
+.bx--file__selected-file--invalid.bx--file__selected-file--field
+.bx--form-requirement {
+  padding-top: 0.6875rem;
+}
+
+.bx--file__selected-file--invalid
+.bx--form-requirement__title,
+.bx--file__selected-file--invalid
+.bx--form-requirement__supplement {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  padding: 0 1rem;
+}
+
+.bx--file__selected-file--invalid
+.bx--form-requirement__title {
+  color: var(--cds-text-error, #da1e28);
+}
+
+.bx--file__selected-file--invalid
+.bx--form-requirement__supplement {
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--file__selected-file--invalid + .bx--form-requirement {
+  font-size: var(--cds-caption-01-font-size, 0.75rem);
+  font-weight: var(--cds-caption-01-font-weight, 400);
+  line-height: var(--cds-caption-01-line-height, 1.34);
+  letter-spacing: var(--cds-caption-01-letter-spacing, 0.32px);
+  display: block;
+  max-height: 12.5rem;
+  padding: 0.5rem 1rem;
+  overflow: visible;
+  color: var(--cds-text-error, #da1e28);
+  font-weight: 400;
+}
+
+.bx--file__selected-file--invalid
++ .bx--form-requirement
+.bx--form-requirement__supplement {
+  padding-bottom: 0.5rem;
+  color: var(--cds-text-01, #161616);
+}
+
+.bx--file__state-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding-right: 1rem;
+}
+
+.bx--file__state-container .bx--loading__svg {
+  stroke: var(--cds-ui-05, #161616);
+}
+
+.bx--file__state-container .bx--file-complete {
+  cursor: pointer;
+  fill: var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--file__state-container .bx--file-complete:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--file__state-container .bx--file-complete:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--file__state-container .bx--file-complete [data-icon-path='inner-path'] {
+  opacity: 1;
+  fill: var(--cds-icon-03, #ffffff);
+}
+
+.bx--file__state-container .bx--file-invalid {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.bx--file__state-container .bx--file-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--file__state-container .bx--file-close:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--file__state-container .bx--file-close:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--file__state-container .bx--file-close svg path {
+  fill: var(--cds-icon-01, #161616);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--file__state-container .bx--file-close svg path {
+    fill: ButtonText;
+  }
+}
+
+.bx--file__state-container .bx--inline-loading__animation {
+  margin-right: -0.5rem;
+}
+
+.bx--file__drop-container {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  height: 6rem;
+  padding: 1rem;
+  overflow: hidden;
+  border: 1px dashed var(--cds-ui-04, #8d8d8d);
+}
+
+.bx--file__drop-container--drag-over {
+  background: none;
+  outline: 2px solid var(--cds-interactive-03, #0f62fe);
+  outline-offset: -2px;
+}
+
+.bx--text-input {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0 1rem;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: none;
+  border-bottom: 1px solid var(--cds-ui-04, #8d8d8d);
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--text-input *,
+.bx--text-input *::before,
+.bx--text-input *::after {
+  box-sizing: inherit;
+}
+
+.bx--text-input:focus, .bx--text-input:active {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--text-input:focus, .bx--text-input:active {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input-wrapper svg[hidden] {
+  display: none;
+}
+
+.bx--text-input--xl {
+  height: 3rem;
+}
+
+.bx--text-input--sm {
+  height: 2rem;
+}
+
+.bx--password-input {
+  padding-right: 2.5rem;
+}
+
+.bx--text-input::placeholder {
+  color: var(--cds-text-05, #6f6f6f);
+  opacity: 1;
+}
+
+.bx--text-input--light {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--text-input__field-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.bx--text-input__field-wrapper .bx--text-input__invalid-icon {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  transform: translateY(-50%);
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.bx--text-input__field-wrapper .bx--text-input__invalid-icon--warning {
+  fill: var(--cds-support-03, #f1c21b);
+}
+
+.bx--text-input__field-wrapper .bx--text-input__invalid-icon--warning path:first-of-type {
+  opacity: 1;
+  fill: #000000;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:focus svg {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--a11y::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: var(--cds-inverse-01, #ffffff);
+  font-weight: 400;
+  text-align: left;
+  background-color: var(--cds-inverse-02, #393939);
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::after {
+  content: attr(aria-label);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible::after, .bx--text-input__field-wrapper .bx--text-input--password__visibility:hover::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility:hover::after, .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible + .bx--assistive-text, .bx--text-input__field-wrapper .bx--text-input--password__visibility:hover .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:hover + .bx--assistive-text, .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible + .bx--assistive-text, .bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility:hover .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:hover + .bx--assistive-text, .bx--text-input__field-wrapper .bx--text-input--password__visibility:hover.bx--tooltip--a11y::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility:focus + .bx--assistive-text, .bx--text-input__field-wrapper .bx--text-input--password__visibility:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--hidden .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::before, .bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility::after,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility .bx--assistive-text,
+.bx--text-input__field-wrapper .bx--text-input--password__visibility + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility,
+.bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  min-height: auto;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  transition: outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--password__visibility svg,
+.bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger svg {
+  transition: fill 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-icon-02, #525252);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--text-input__field-wrapper .bx--text-input--password__visibility svg,
+  .bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger svg {
+    fill: ButtonText;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger:hover,
+.bx--text-input__field-wrapper .bx--btn.bx--text-input--password__visibility__toggle.bx--tooltip__trigger:focus
+svg {
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--text-input__field-wrapper .bx--text-input--invalid {
+  padding-right: 2.5rem;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--invalid.bx--password-input {
+  padding-right: 4rem;
+}
+
+.bx--text-input__field-wrapper .bx--text-input--invalid
++ .bx--text-input--password__visibility,
+.bx--text-input__field-wrapper .bx--text-input--invalid
++ .bx--text-input--password__visibility__toggle {
+  right: 1rem;
+}
+
+.bx--password-input-wrapper .bx--text-input__invalid-icon {
+  right: 2.5rem;
+}
+
+.bx--text-input:disabled
++ .bx--text-input--password__visibility
+svg,
+.bx--text-input:disabled
++ .bx--text-input--password__visibility__toggle
+svg {
+  cursor: not-allowed;
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--text-input:disabled
++ .bx--text-input--password__visibility
+svg:hover,
+.bx--text-input:disabled
++ .bx--text-input--password__visibility__toggle
+svg:hover {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--text-input:disabled {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+  border-bottom: 1px solid transparent;
+  -webkit-text-fill-color: currentColor;
+  cursor: not-allowed;
+}
+
+.bx--text-input--light:disabled {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
+.bx--text-input:disabled::placeholder {
+  color: var(--cds-disabled-02, #c6c6c6);
+  opacity: 1;
+}
+
+.bx--text-input--invalid {
+  outline: 2px solid var(--cds-support-01, #da1e28);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--text-input--invalid {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input--invalid .bx--text-input--password__visibility,
+.bx--text-input--invalid .bx--text-input--password__visibility__toggle {
+  right: 2.5rem;
+}
+
+.bx--skeleton.bx--text-input {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.bx--skeleton.bx--text-input:hover, .bx--skeleton.bx--text-input:focus, .bx--skeleton.bx--text-input:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--skeleton.bx--text-input::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--skeleton.bx--text-input::before {
+    animation: none;
+  }
+}
+
+.bx--form--fluid .bx--text-input-wrapper {
+  position: relative;
+  background: var(--cds-field-01, #f4f4f4);
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--form--fluid .bx--label {
+  position: absolute;
+  top: 0.8125rem;
+  left: 1rem;
+  z-index: 1;
+  margin: 0;
+}
+
+.bx--form--fluid .bx--form__helper-text {
+  display: none;
+}
+
+.bx--form--fluid .bx--text-input {
+  min-height: 4rem;
+  padding: 2rem 1rem 0.8125rem;
+}
+
+.bx--text-input__divider,
+.bx--form--fluid .bx--text-input__divider {
+  display: none;
+}
+
+.bx--form--fluid .bx--text-input--invalid,
+.bx--form--fluid .bx--text-input--warn {
+  border-bottom: none;
+}
+
+.bx--form--fluid
+.bx--text-input--invalid
++ .bx--text-input__divider,
+.bx--form--fluid
+.bx--text-input--warn
++ .bx--text-input__divider {
+  display: block;
+  margin: 0 1rem;
+  border-color: var(--cds-ui-03, #e0e0e0);
+  border-style: solid;
+  border-bottom: none;
+}
+
+.bx--form--fluid .bx--text-input__invalid-icon {
+  top: 5rem;
+}
+
+.bx--form--fluid .bx--text-input-wrapper--light {
+  background: var(--cds-field-02, #ffffff);
+}
+
+.bx--form--fluid
+.bx--text-input__field-wrapper[data-invalid]
+> .bx--text-input--invalid {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.bx--form--fluid
+.bx--text-input__field-wrapper[data-invalid]:not(:focus) {
+  outline: 2px solid var(--cds-support-01, #da1e28);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--form--fluid
+.bx--text-input__field-wrapper[data-invalid]:not(:focus) {
+    outline-style: dotted;
+  }
+}
+
+.bx--form--fluid
+.bx--text-input__field-wrapper[data-invalid]
+> .bx--text-input--invalid:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--form--fluid
+.bx--text-input__field-wrapper[data-invalid]
+> .bx--text-input--invalid:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--text-input-wrapper--inline {
+  flex-flow: row wrap;
+}
+
+.bx--label--inline {
+  flex: 1;
+  margin: 0.8125rem 0 0 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.bx--label--inline--sm {
+  margin-top: 0.5625rem;
+}
+
+.bx--label--inline--xl {
+  margin-top: 1.0625rem;
+}
+
+.bx--text-input__label-helper-wrapper {
+  flex: 2;
+  flex-direction: column;
+  max-width: 8rem;
+  margin-right: 1.5rem;
+  overflow-wrap: break-word;
+}
+
+.bx--form__helper-text--inline {
+  margin-top: 0.125rem;
+}
+
+.bx--text-input__field-outer-wrapper {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.bx--text-input__field-outer-wrapper--inline {
+  flex: 8;
+  flex-direction: column;
+}
+
+.exp--input-group {
+  display: flex;
+}
+
+.exp--import-button {
+  margin-left: var(--cds-spacing-05, 1rem);
+}
+
+.exp--import-modal-label {
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+}
+
+.exp--import-modal-helper-text {
+  margin-top: var(--cds-spacing-07, 2rem);
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+  font-size: var(--cds-helper-text-01-font-size, 0.75rem);
+  line-height: var(--cds-helper-text-01-line-height, 1.34);
+  letter-spacing: var(--cds-helper-text-01-letter-spacing, 0.32px);
+}
+
+.exp--import-modal-body {
+  margin-bottom: var(--cds-spacing-05, 1rem);
+  padding-right: 20%;
+}
+
+.exp--import-modal .bx--modal-container {
+  background: var(--cds-ui-background, #ffffff);
+}
+
+.exp--import-modal .bx--modal-content {
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+.exp--import-modal .bx--file__selected-file {
+  max-width: none;
+  background: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp--import-modal .bx--text-input {
+  background: var(--cds-ui-01, #f4f4f4);
+}
+
+.modified-tabs .modified-tabs__tab-label {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.modified-tabs .bx--tabs__nav {
+  /* overflow cannot be tweaked to fix tooltip */
+}
+
+.modified-tabs__tab-new,
+.modified-tabs__tab {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+}
+
+.modified-tabs__tab-new-img,
+.modified-tabs__tab-close {
+  position: absolute;
+  top: -var(--cds-spacing-04, 0.75rem);
+  right: -var(--cds-spacing-05, 1rem);
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--cds-spacing-04, 0.75rem);
+  overflow: hidden;
+  background-color: transparent;
+  border: var(--cds-spacing-01, 0.125rem) solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  transition: background-color 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.modified-tabs__tab-new-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--cds-spacing-01, 0.125rem);
+  padding: 0;
+}
+
+.modified-tabs__tab-close:focus {
+  border-color: var(--cds-interactive-01, #0f62fe);
+  outline: none;
+}
+
+.modified-tabs__tab-close:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.modified-tabs__tab-new-img {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.bx--toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--toggle:focus {
+  outline: none;
+}
+
+.bx--toggle__label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 0.5rem 0;
+  cursor: pointer;
+}
+
+.bx--toggle__appearance {
+  position: relative;
+  width: 3rem;
+  height: 1.5rem;
+}
+
+.bx--toggle__appearance::before {
+  position: absolute;
+  top: 0;
+  display: block;
+  box-sizing: border-box;
+  width: 3rem;
+  height: 1.5rem;
+  background-color: var(--cds-ui-04, #8d8d8d);
+  border-radius: 0.9375rem;
+  box-shadow: 0 0 0 1px transparent, 0 0 0 3px transparent;
+  cursor: pointer;
+  transition: box-shadow 70ms cubic-bezier(0.2, 0, 1, 0.9), background-color 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  content: '';
+  will-change: box-shadow;
+}
+
+.bx--toggle__appearance::after {
+  position: absolute;
+  top: 0.1875rem;
+  left: 0.1875rem;
+  display: block;
+  box-sizing: border-box;
+  width: 1.125rem;
+  height: 1.125rem;
+  background-color: var(--cds-icon-03, #ffffff);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  content: '';
+}
+
+.bx--toggle__check {
+  position: absolute;
+  top: 0.375rem;
+  left: 0.375rem;
+  z-index: 1;
+  width: 0.375rem;
+  height: 0.3125rem;
+  transform: scale(0.2);
+  transition: 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  fill: var(--cds-icon-03, #ffffff);
+}
+
+.bx--toggle__text--left,
+.bx--toggle__text--right {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  position: relative;
+  margin-left: 0.5rem;
+}
+
+.bx--toggle__text--left {
+  position: absolute;
+  left: 3rem;
+}
+
+.bx--toggle:checked
++ .bx--toggle__label
+.bx--toggle__text--left,
+.bx--toggle:not(:checked)
++ .bx--toggle__label
+.bx--toggle__text--right {
+  visibility: hidden;
+}
+
+.bx--toggle:checked
++ .bx--toggle__label
+.bx--toggle__text--right,
+.bx--toggle:not(:checked)
++ .bx--toggle__label
+.bx--toggle__text--left {
+  display: inline;
+}
+
+.bx--toggle:checked
++ .bx--toggle__label
+.bx--toggle__appearance::before {
+  background-color: var(--cds-support-02, #24a148);
+}
+
+.bx--toggle:checked
++ .bx--toggle__label
+.bx--toggle__appearance::after {
+  background-color: var(--cds-icon-03, #ffffff);
+  transform: translateX(1.5rem);
+}
+
+.bx--toggle
++ .bx--toggle__label
+.bx--toggle__appearance::before {
+  box-shadow: 0 0 0 1px transparent, 0 0 0 3px transparent;
+}
+
+.bx--toggle:focus + .bx--toggle__label,
+.bx--toggle:active
++ .bx--toggle__label
+.bx--toggle__appearance::before {
+  box-shadow: 0 0 0 1px var(--cds-ui-02, #ffffff), 0 0 0 3px var(--cds-focus, #0f62fe);
+}
+
+.bx--toggle:disabled + .bx--toggle__label {
+  cursor: not-allowed;
+}
+
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__appearance::before {
+  background-color: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__appearance::after {
+  background-color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__appearance::before, .bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__appearance::after {
+  cursor: not-allowed;
+  transition: 70ms cubic-bezier(0.2, 0, 1, 0.9);
+}
+
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__text--left,
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__text--right {
+  color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--toggle:disabled:active
++ .bx--toggle__label
+.bx--toggle__appearance:before {
+  box-shadow: none;
+}
+
+.bx--toggle:disabled
++ .bx--toggle__label
+.bx--toggle__check {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--toggle--small
++ .bx--toggle__label
+.bx--toggle__appearance {
+  width: 2rem;
+  height: 1rem;
+}
+
+.bx--toggle--small
++ .bx--toggle__label
+.bx--toggle__appearance::before {
+  top: 0;
+  box-sizing: border-box;
+  width: 2rem;
+  height: 1rem;
+  border-radius: 0.9375rem;
+}
+
+.bx--toggle--small
++ .bx--toggle__label
+.bx--toggle__appearance::after {
+  top: 0.1875rem;
+  left: 0.1875rem;
+  width: 0.625rem;
+  height: 0.625rem;
+}
+
+.bx--toggle--small:checked
++ .bx--toggle__label
+.bx--toggle__check {
+  transform: scale(1) translateX(1rem);
+  fill: var(--cds-support-02, #24a148);
+}
+
+.bx--toggle--small
++ .bx--toggle__label
+.bx--toggle__text--left {
+  left: 2rem;
+}
+
+.bx--toggle--small:checked
++ .bx--toggle__label
+.bx--toggle__appearance::after {
+  margin-left: 0;
+  transform: translateX(1.0625rem);
+}
+
+.bx--toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--toggle-input:focus {
+  outline: none;
+}
+
+.bx--toggle-input__label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  color: var(--cds-text-02, #525252);
+  cursor: pointer;
+}
+
+.bx--toggle__switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 3rem;
+  height: 1.5rem;
+  cursor: pointer;
+}
+
+.bx--toggle__switch::before {
+  position: absolute;
+  top: 0;
+  display: block;
+  box-sizing: border-box;
+  width: 3rem;
+  height: 1.5rem;
+  background-color: var(--cds-ui-04, #8d8d8d);
+  border-radius: 0.9375rem;
+  box-shadow: 0 0 0 1px transparent, 0 0 0 3px transparent;
+  transition: box-shadow 70ms cubic-bezier(0.2, 0, 1, 0.9), background-color 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  content: '';
+  will-change: box-shadow;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--toggle__switch::before {
+    border: 1px solid ButtonText;
+  }
+}
+
+.bx--toggle__switch::after {
+  position: absolute;
+  top: 0.1875rem;
+  left: 0.1875rem;
+  display: block;
+  box-sizing: border-box;
+  width: 1.125rem;
+  height: 1.125rem;
+  background-color: var(--cds-icon-03, #ffffff);
+  border-radius: 50%;
+  transition: transform 70ms cubic-bezier(0.2, 0, 1, 0.9);
+  content: '';
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--toggle__switch::after {
+    border: 3px solid ButtonText;
+  }
+}
+
+.bx--toggle-input__label .bx--toggle__switch {
+  margin-top: 1rem;
+}
+
+.bx--toggle__text--off,
+.bx--toggle__text--on {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  position: absolute;
+  top: 50%;
+  margin-left: 3.5rem;
+  white-space: nowrap;
+  transform: translateY(-50%);
+  user-select: none;
+}
+
+.bx--toggle-input:checked
++ .bx--toggle-input__label
+> .bx--toggle__switch
+> .bx--toggle__text--off,
+.bx--toggle-input:not(:checked)
++ .bx--toggle-input__label
+> .bx--toggle__switch
+> .bx--toggle__text--on {
+  visibility: hidden;
+}
+
+.bx--toggle-input:checked
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+  background-color: var(--cds-support-02, #24a148);
+}
+
+.bx--toggle-input:checked
++ .bx--toggle-input__label
+> .bx--toggle__switch::after {
+  background-color: var(--cds-icon-03, #ffffff);
+  transform: translateX(1.5rem);
+}
+
+.bx--toggle-input:focus
++ .bx--toggle-input__label
+> .bx--toggle__switch::before,
+.bx--toggle-input:active
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+  box-shadow: 0 0 0 1px var(--cds-ui-02, #ffffff), 0 0 0 3px var(--cds-focus, #0f62fe);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--toggle-input:focus
++ .bx--toggle-input__label
+> .bx--toggle__switch::before,
+  .bx--toggle-input:active
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+    outline: 1px solid ButtonText;
+  }
+}
+
+.bx--toggle-input:disabled + .bx--toggle-input__label {
+  color: var(--cds-disabled-02, #c6c6c6);
+  cursor: not-allowed;
+}
+
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch {
+  cursor: not-allowed;
+}
+
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+  background-color: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::after {
+  background-color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::before, .bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::after {
+  cursor: not-allowed;
+  transition: 70ms cubic-bezier(0.2, 0, 1, 0.9);
+}
+
+.bx--toggle-input:disabled:active
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+  box-shadow: none;
+}
+
+.bx--data-table
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::before {
+  background-color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--data-table
+.bx--toggle-input:disabled
++ .bx--toggle-input__label
+> .bx--toggle__switch::after {
+  background-color: var(--cds-disabled-03, #8d8d8d);
+}
+
+.bx--toggle-input--small + .bx--toggle-input__label > .bx--toggle__switch {
+  width: 2rem;
+  height: 1rem;
+}
+
+.bx--toggle-input--small + .bx--toggle-input__label > .bx--toggle__switch::before {
+  width: 2rem;
+  height: 1rem;
+  border-radius: 0.9375rem;
+}
+
+.bx--toggle-input--small + .bx--toggle-input__label > .bx--toggle__switch::after {
+  width: 0.625rem;
+  height: 0.625rem;
+}
+
+.bx--toggle-input--small + .bx--toggle-input__label .bx--toggle__text--off,
+.bx--toggle-input--small + .bx--toggle-input__label .bx--toggle__text--on {
+  margin-left: 2.5rem;
+}
+
+.bx--toggle-input--small:checked + .bx--toggle-input__label > .bx--toggle__switch::after {
+  transform: translateX(1.0625rem);
+}
+
+.bx--toggle-input--small:checked + .bx--toggle-input__label .bx--toggle__check {
+  transform: scale(1) translateX(1rem);
+  fill: var(--cds-support-02, #24a148);
+}
+
+.bx--toggle-input--small:disabled:checked
++ .bx--toggle-input__label
+.bx--toggle__check {
+  fill: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--toggle__label.bx--skeleton {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.bx--toggle__label.bx--skeleton .bx--toggle__label-text {
+  margin-bottom: 0.5rem;
+}
+
+@keyframes fadeIn {
+  0% {
+    transform: translateY(-38.5rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-38.5rem);
+    opacity: 0;
+  }
+}
+
+.exp--notifications-panel__container {
+  --cds-interactive-01: #0f62fe;
+  --cds-interactive-02: #6f6f6f;
+  --cds-interactive-03: #ffffff;
+  --cds-interactive-04: #4589ff;
+  --cds-ui-background: #161616;
+  --cds-ui-01: #262626;
+  --cds-ui-02: #393939;
+  --cds-ui-03: #393939;
+  --cds-ui-04: #6f6f6f;
+  --cds-ui-05: #f4f4f4;
+  --cds-text-01: #f4f4f4;
+  --cds-text-02: #c6c6c6;
+  --cds-text-03: #6f6f6f;
+  --cds-text-04: #ffffff;
+  --cds-text-05: #8d8d8d;
+  --cds-text-error: #ff8389;
+  --cds-icon-01: #f4f4f4;
+  --cds-icon-02: #c6c6c6;
+  --cds-icon-03: #ffffff;
+  --cds-link-01: #78a9ff;
+  --cds-link-02: #a6c8ff;
+  --cds-inverse-link: #0f62fe;
+  --cds-field-01: #262626;
+  --cds-field-02: #393939;
+  --cds-inverse-01: #161616;
+  --cds-inverse-02: #f4f4f4;
+  --cds-support-01: #fa4d56;
+  --cds-support-02: #42be65;
+  --cds-support-03: #f1c21b;
+  --cds-support-04: #4589ff;
+  --cds-inverse-support-01: #da1e28;
+  --cds-inverse-support-02: #24a148;
+  --cds-inverse-support-03: #f1c21b;
+  --cds-inverse-support-04: #0f62fe;
+  --cds-overlay-01: rgba(22, 22, 22, 0.7);
+  --cds-danger-01: #da1e28;
+  --cds-danger-02: #fa4d56;
+  --cds-focus: #ffffff;
+  --cds-inverse-focus-ui: #0f62fe;
+  --cds-hover-primary: #0353e9;
+  --cds-active-primary: #002d9c;
+  --cds-hover-primary-text: #a6c8ff;
+  --cds-hover-secondary: #606060;
+  --cds-active-secondary: #393939;
+  --cds-hover-tertiary: #f4f4f4;
+  --cds-active-tertiary: #c6c6c6;
+  --cds-hover-ui: #353535;
+  --cds-hover-light-ui: #4c4c4c;
+  --cds-hover-selected-ui: #4c4c4c;
+  --cds-active-ui: #525252;
+  --cds-active-light-ui: #6f6f6f;
+  --cds-selected-ui: #393939;
+  --cds-selected-light-ui: #525252;
+  --cds-inverse-hover-ui: #e5e5e5;
+  --cds-hover-danger: #b81921;
+  --cds-active-danger: #750e13;
+  --cds-hover-row: #353535;
+  --cds-visited-link: #be95ff;
+  --cds-disabled-01: #262626;
+  --cds-disabled-02: #525252;
+  --cds-disabled-03: #8d8d8d;
+  --cds-highlight: #002d9c;
+  --cds-decorative-01: #525252;
+  --cds-button-separator: #161616;
+  --cds-skeleton-01: #353535;
+  --cds-skeleton-02: #525252;
+  --cds-brand-01: #0f62fe;
+  --cds-brand-02: #6f6f6f;
+  --cds-brand-03: #ffffff;
+  --cds-active-01: #525252;
+  --cds-hover-field: #353535;
+  --cds-danger: #da1e28;
+  --cds-caption-01-font-size: 0.75rem;
+  --cds-caption-01-font-weight: 400;
+  --cds-caption-01-line-height: 1.34;
+  --cds-caption-01-letter-spacing: 0.32px;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.34;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.34;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.29;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.43;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.34;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.43;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.29;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.29;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.375;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.29;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.25;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.29;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 600;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-layout-01: 1rem;
+  --cds-layout-02: 1.5rem;
+  --cds-layout-03: 2rem;
+  --cds-layout-04: 3rem;
+  --cds-layout-05: 4rem;
+  --cds-layout-06: 6rem;
+  --cds-layout-07: 10rem;
+  --cds-container-01: 1.5rem;
+  --cds-container-02: 2rem;
+  --cds-container-03: 2.5rem;
+  --cds-container-04: 3rem;
+  --cds-container-05: 4rem;
+  --cds-icon-size-01: 1rem;
+  --cds-icon-size-02: 1.25rem;
+  position: fixed;
+  top: var(--cds-spacing-09, 3rem);
+  right: 0;
+  z-index: 2;
+  min-width: 22.75rem;
+  max-width: 22.75rem;
+  min-height: 38.5rem;
+  max-height: 38.5rem;
+  overflow: auto;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-background, #ffffff);
+  transition: transform 110ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-05, 1rem);
+  background-color: var(--cds-ui-background, #ffffff);
+  border-bottom: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__header-flex {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__do-not-disturb-toggle .bx--toggle__switch {
+  margin-top: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__dismiss-button {
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__header {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  margin: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__time-section-label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  font-weight: 600;
+  position: sticky;
+  top: 4.8125rem;
+  z-index: 2;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+  color: var(--cds-text-02, #525252);
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:hover,
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus {
+  background-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:hover .exp--notifications-panel__dismiss-single-button,
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus .exp--notifications-panel__dismiss-single-button {
+  opacity: 1;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  outline: 0;
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  min-height: 6.25rem;
+  padding: var(--cds-spacing-05, 1rem) var(--cds-spacing-05, 1rem) 1.125rem;
+  text-align: left;
+  background-color: var(--cds-ui-background, #ffffff);
+  border: 0;
+  cursor: pointer;
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-title {
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-text-04, #ffffff);
+  font-weight: 400;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-title.exp--notifications-panel__notification-title-unread {
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-text-04, #ffffff);
+  font-weight: 600;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notifications-link {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon {
+  min-width: 1rem;
+  margin-right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-error {
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-success {
+  fill: var(--cds-support-02, #24a148);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-warning {
+  fill: var(--cds-support-03, #f1c21b);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-informational {
+  fill: var(--cds-support-04, #0043ce);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-time-label {
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-time-label,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  color: var(--cds-text-02, #525252);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description.exp--notifications-panel__notification-short-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description.exp--notifications-panel__notification-long-description {
+  display: block;
+  -webkit-line-clamp: initial;
+  overflow: initial;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  min-width: 5.5rem;
+  padding: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button .bx--btn__icon {
+  transition: transform 240ms ease;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button.exp--notifications-panel__notification-read-more-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button.exp--notifications-panel__notification-read-more-button .bx--btn__icon {
+  transform: rotate(0deg);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button.exp--notifications-panel__notification-read-less-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button.exp--notifications-panel__notification-read-less-button .bx--btn__icon {
+  transform: rotate(180deg);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__dismiss-single-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 2rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+  opacity: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification-today:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-yesterday:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-previous:not(:first-of-type):before {
+  position: absolute;
+  top: 0;
+  width: calc(100% - 2rem);
+  height: 1px;
+  margin: 0 auto;
+  background-color: var(--cds-ui-02, #ffffff);
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+  content: '';
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification-today:hover
++ .exp--notifications-panel__notification-today:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-yesterday:hover
++ .exp--notifications-panel__notification-yesterday:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-previous:hover
++ .exp--notifications-panel__notification-previous:not(:first-of-type):before {
+  background-color: transparent;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__main-section-empty.exp--notifications-panel__main-section {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: initial;
+  margin-top: var(--cds-layout-07, 10rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__main-section-empty.exp--notifications-panel__main-section .exp-subtext {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel-main-section {
+  min-height: 500px;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  background-color: var(--cds-ui-background, #ffffff);
+  border-top: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__view-all-button {
+  width: 100%;
+  max-width: calc(100% - 2.5rem);
+  height: 2.5rem;
+  min-height: 2.5rem;
+  color: var(--cds-text-01, #161616);
+  border-right: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__settings-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__settings-button .bx--btn__icon {
+  margin: 0;
+}
+
+.bx--grid {
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 99rem;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+@media (min-width: 42rem) {
+  .bx--grid {
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
+}
+
+@media (min-width: 99rem) {
+  .bx--grid {
+    padding-right: 2.5rem;
+    padding-left: 2.5rem;
+  }
+}
+
+@media (min-width: 99rem) {
+  .bx--grid--full-width {
+    max-width: 100%;
+  }
+}
+
+.bx--row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -1rem;
+  margin-left: -1rem;
+}
+
+.bx--row-padding [class*='bx--col'],
+.bx--col-padding {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.bx--grid--condensed [class*='bx--col'] {
+  padding-top: 0.03125rem;
+  padding-bottom: 0.03125rem;
+}
+
+.bx--col {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col,
+.bx--grid--condensed .bx--col {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col,
+.bx--grid--narrow .bx--col {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm-0 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm-0,
+.bx--grid--condensed .bx--col-sm-0 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm-0,
+.bx--grid--narrow .bx--col-sm-0 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm-1 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm-1,
+.bx--grid--condensed .bx--col-sm-1 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm-1,
+.bx--grid--narrow .bx--col-sm-1 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm-2 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm-2,
+.bx--grid--condensed .bx--col-sm-2 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm-2,
+.bx--grid--narrow .bx--col-sm-2 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm-3 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm-3,
+.bx--grid--condensed .bx--col-sm-3 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm-3,
+.bx--grid--narrow .bx--col-sm-3 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm-4 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm-4,
+.bx--grid--condensed .bx--col-sm-4 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm-4,
+.bx--grid--narrow .bx--col-sm-4 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-sm,
+.bx--col-sm--auto {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-sm,
+.bx--grid--condensed .bx--col-sm, .bx--row--condensed
+.bx--col-sm--auto,
+.bx--grid--condensed
+.bx--col-sm--auto {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-sm,
+.bx--grid--narrow .bx--col-sm, .bx--row--narrow
+.bx--col-sm--auto,
+.bx--grid--narrow
+.bx--col-sm--auto {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col,
+.bx--col-sm {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%;
+}
+
+.bx--col--auto,
+.bx--col-sm--auto {
+  flex: 1 0 0%;
+  width: auto;
+  max-width: 100%;
+}
+
+.bx--col-sm-0 {
+  display: none;
+}
+
+.bx--col-sm-1 {
+  display: block;
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.bx--col-sm-2 {
+  display: block;
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+.bx--col-sm-3 {
+  display: block;
+  flex: 0 0 75%;
+  max-width: 75%;
+}
+
+.bx--col-sm-4 {
+  display: block;
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+.bx--offset-sm-0 {
+  margin-left: 0;
+}
+
+.bx--offset-sm-1 {
+  margin-left: 25%;
+}
+
+.bx--offset-sm-2 {
+  margin-left: 50%;
+}
+
+.bx--offset-sm-3 {
+  margin-left: 75%;
+}
+
+.bx--col-md-0 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-0,
+.bx--grid--condensed .bx--col-md-0 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-0,
+.bx--grid--narrow .bx--col-md-0 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-1 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-1,
+.bx--grid--condensed .bx--col-md-1 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-1,
+.bx--grid--narrow .bx--col-md-1 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-2 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-2,
+.bx--grid--condensed .bx--col-md-2 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-2,
+.bx--grid--narrow .bx--col-md-2 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-3 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-3,
+.bx--grid--condensed .bx--col-md-3 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-3,
+.bx--grid--narrow .bx--col-md-3 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-4 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-4,
+.bx--grid--condensed .bx--col-md-4 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-4,
+.bx--grid--narrow .bx--col-md-4 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-5 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-5,
+.bx--grid--condensed .bx--col-md-5 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-5,
+.bx--grid--narrow .bx--col-md-5 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-6 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-6,
+.bx--grid--condensed .bx--col-md-6 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-6,
+.bx--grid--narrow .bx--col-md-6 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-7 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-7,
+.bx--grid--condensed .bx--col-md-7 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-7,
+.bx--grid--narrow .bx--col-md-7 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md-8 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md-8,
+.bx--grid--condensed .bx--col-md-8 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md-8,
+.bx--grid--narrow .bx--col-md-8 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-md,
+.bx--col-md--auto {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-md,
+.bx--grid--condensed .bx--col-md, .bx--row--condensed
+.bx--col-md--auto,
+.bx--grid--condensed
+.bx--col-md--auto {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-md,
+.bx--grid--narrow .bx--col-md, .bx--row--narrow
+.bx--col-md--auto,
+.bx--grid--narrow
+.bx--col-md--auto {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+@media (min-width: 42rem) {
+  .bx--col,
+  .bx--col-md {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .bx--col--auto,
+  .bx--col-md--auto {
+    flex: 1 0 0%;
+    width: auto;
+    max-width: 100%;
+  }
+  .bx--col-md-0 {
+    display: none;
+  }
+  .bx--col-md-1 {
+    display: block;
+    flex: 0 0 12.5%;
+    max-width: 12.5%;
+  }
+  .bx--col-md-2 {
+    display: block;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .bx--col-md-3 {
+    display: block;
+    flex: 0 0 37.5%;
+    max-width: 37.5%;
+  }
+  .bx--col-md-4 {
+    display: block;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .bx--col-md-5 {
+    display: block;
+    flex: 0 0 62.5%;
+    max-width: 62.5%;
+  }
+  .bx--col-md-6 {
+    display: block;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .bx--col-md-7 {
+    display: block;
+    flex: 0 0 87.5%;
+    max-width: 87.5%;
+  }
+  .bx--col-md-8 {
+    display: block;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .bx--offset-md-0 {
+    margin-left: 0;
+  }
+  .bx--offset-md-1 {
+    margin-left: 12.5%;
+  }
+  .bx--offset-md-2 {
+    margin-left: 25%;
+  }
+  .bx--offset-md-3 {
+    margin-left: 37.5%;
+  }
+  .bx--offset-md-4 {
+    margin-left: 50%;
+  }
+  .bx--offset-md-5 {
+    margin-left: 62.5%;
+  }
+  .bx--offset-md-6 {
+    margin-left: 75%;
+  }
+  .bx--offset-md-7 {
+    margin-left: 87.5%;
+  }
+}
+
+.bx--col-lg-0 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-0,
+.bx--grid--condensed .bx--col-lg-0 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-0,
+.bx--grid--narrow .bx--col-lg-0 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-1 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-1,
+.bx--grid--condensed .bx--col-lg-1 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-1,
+.bx--grid--narrow .bx--col-lg-1 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-2 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-2,
+.bx--grid--condensed .bx--col-lg-2 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-2,
+.bx--grid--narrow .bx--col-lg-2 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-3 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-3,
+.bx--grid--condensed .bx--col-lg-3 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-3,
+.bx--grid--narrow .bx--col-lg-3 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-4 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-4,
+.bx--grid--condensed .bx--col-lg-4 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-4,
+.bx--grid--narrow .bx--col-lg-4 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-5 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-5,
+.bx--grid--condensed .bx--col-lg-5 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-5,
+.bx--grid--narrow .bx--col-lg-5 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-6 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-6,
+.bx--grid--condensed .bx--col-lg-6 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-6,
+.bx--grid--narrow .bx--col-lg-6 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-7 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-7,
+.bx--grid--condensed .bx--col-lg-7 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-7,
+.bx--grid--narrow .bx--col-lg-7 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-8 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-8,
+.bx--grid--condensed .bx--col-lg-8 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-8,
+.bx--grid--narrow .bx--col-lg-8 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-9 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-9,
+.bx--grid--condensed .bx--col-lg-9 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-9,
+.bx--grid--narrow .bx--col-lg-9 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-10 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-10,
+.bx--grid--condensed .bx--col-lg-10 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-10,
+.bx--grid--narrow .bx--col-lg-10 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-11 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-11,
+.bx--grid--condensed .bx--col-lg-11 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-11,
+.bx--grid--narrow .bx--col-lg-11 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-12 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-12,
+.bx--grid--condensed .bx--col-lg-12 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-12,
+.bx--grid--narrow .bx--col-lg-12 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-13 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-13,
+.bx--grid--condensed .bx--col-lg-13 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-13,
+.bx--grid--narrow .bx--col-lg-13 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-14 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-14,
+.bx--grid--condensed .bx--col-lg-14 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-14,
+.bx--grid--narrow .bx--col-lg-14 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-15 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-15,
+.bx--grid--condensed .bx--col-lg-15 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-15,
+.bx--grid--narrow .bx--col-lg-15 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg-16 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg-16,
+.bx--grid--condensed .bx--col-lg-16 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg-16,
+.bx--grid--narrow .bx--col-lg-16 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-lg,
+.bx--col-lg--auto {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-lg,
+.bx--grid--condensed .bx--col-lg, .bx--row--condensed
+.bx--col-lg--auto,
+.bx--grid--condensed
+.bx--col-lg--auto {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-lg,
+.bx--grid--narrow .bx--col-lg, .bx--row--narrow
+.bx--col-lg--auto,
+.bx--grid--narrow
+.bx--col-lg--auto {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+@media (min-width: 66rem) {
+  .bx--col,
+  .bx--col-lg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .bx--col--auto,
+  .bx--col-lg--auto {
+    flex: 1 0 0%;
+    width: auto;
+    max-width: 100%;
+  }
+  .bx--col-lg-0 {
+    display: none;
+  }
+  .bx--col-lg-1 {
+    display: block;
+    flex: 0 0 6.25%;
+    max-width: 6.25%;
+  }
+  .bx--col-lg-2 {
+    display: block;
+    flex: 0 0 12.5%;
+    max-width: 12.5%;
+  }
+  .bx--col-lg-3 {
+    display: block;
+    flex: 0 0 18.75%;
+    max-width: 18.75%;
+  }
+  .bx--col-lg-4 {
+    display: block;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .bx--col-lg-5 {
+    display: block;
+    flex: 0 0 31.25%;
+    max-width: 31.25%;
+  }
+  .bx--col-lg-6 {
+    display: block;
+    flex: 0 0 37.5%;
+    max-width: 37.5%;
+  }
+  .bx--col-lg-7 {
+    display: block;
+    flex: 0 0 43.75%;
+    max-width: 43.75%;
+  }
+  .bx--col-lg-8 {
+    display: block;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .bx--col-lg-9 {
+    display: block;
+    flex: 0 0 56.25%;
+    max-width: 56.25%;
+  }
+  .bx--col-lg-10 {
+    display: block;
+    flex: 0 0 62.5%;
+    max-width: 62.5%;
+  }
+  .bx--col-lg-11 {
+    display: block;
+    flex: 0 0 68.75%;
+    max-width: 68.75%;
+  }
+  .bx--col-lg-12 {
+    display: block;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .bx--col-lg-13 {
+    display: block;
+    flex: 0 0 81.25%;
+    max-width: 81.25%;
+  }
+  .bx--col-lg-14 {
+    display: block;
+    flex: 0 0 87.5%;
+    max-width: 87.5%;
+  }
+  .bx--col-lg-15 {
+    display: block;
+    flex: 0 0 93.75%;
+    max-width: 93.75%;
+  }
+  .bx--col-lg-16 {
+    display: block;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .bx--offset-lg-0 {
+    margin-left: 0;
+  }
+  .bx--offset-lg-1 {
+    margin-left: 6.25%;
+  }
+  .bx--offset-lg-2 {
+    margin-left: 12.5%;
+  }
+  .bx--offset-lg-3 {
+    margin-left: 18.75%;
+  }
+  .bx--offset-lg-4 {
+    margin-left: 25%;
+  }
+  .bx--offset-lg-5 {
+    margin-left: 31.25%;
+  }
+  .bx--offset-lg-6 {
+    margin-left: 37.5%;
+  }
+  .bx--offset-lg-7 {
+    margin-left: 43.75%;
+  }
+  .bx--offset-lg-8 {
+    margin-left: 50%;
+  }
+  .bx--offset-lg-9 {
+    margin-left: 56.25%;
+  }
+  .bx--offset-lg-10 {
+    margin-left: 62.5%;
+  }
+  .bx--offset-lg-11 {
+    margin-left: 68.75%;
+  }
+  .bx--offset-lg-12 {
+    margin-left: 75%;
+  }
+  .bx--offset-lg-13 {
+    margin-left: 81.25%;
+  }
+  .bx--offset-lg-14 {
+    margin-left: 87.5%;
+  }
+  .bx--offset-lg-15 {
+    margin-left: 93.75%;
+  }
+}
+
+.bx--col-xlg-0 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-0,
+.bx--grid--condensed .bx--col-xlg-0 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-0,
+.bx--grid--narrow .bx--col-xlg-0 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-1 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-1,
+.bx--grid--condensed .bx--col-xlg-1 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-1,
+.bx--grid--narrow .bx--col-xlg-1 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-2 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-2,
+.bx--grid--condensed .bx--col-xlg-2 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-2,
+.bx--grid--narrow .bx--col-xlg-2 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-3 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-3,
+.bx--grid--condensed .bx--col-xlg-3 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-3,
+.bx--grid--narrow .bx--col-xlg-3 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-4 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-4,
+.bx--grid--condensed .bx--col-xlg-4 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-4,
+.bx--grid--narrow .bx--col-xlg-4 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-5 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-5,
+.bx--grid--condensed .bx--col-xlg-5 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-5,
+.bx--grid--narrow .bx--col-xlg-5 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-6 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-6,
+.bx--grid--condensed .bx--col-xlg-6 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-6,
+.bx--grid--narrow .bx--col-xlg-6 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-7 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-7,
+.bx--grid--condensed .bx--col-xlg-7 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-7,
+.bx--grid--narrow .bx--col-xlg-7 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-8 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-8,
+.bx--grid--condensed .bx--col-xlg-8 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-8,
+.bx--grid--narrow .bx--col-xlg-8 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-9 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-9,
+.bx--grid--condensed .bx--col-xlg-9 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-9,
+.bx--grid--narrow .bx--col-xlg-9 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-10 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-10,
+.bx--grid--condensed .bx--col-xlg-10 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-10,
+.bx--grid--narrow .bx--col-xlg-10 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-11 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-11,
+.bx--grid--condensed .bx--col-xlg-11 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-11,
+.bx--grid--narrow .bx--col-xlg-11 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-12 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-12,
+.bx--grid--condensed .bx--col-xlg-12 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-12,
+.bx--grid--narrow .bx--col-xlg-12 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-13 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-13,
+.bx--grid--condensed .bx--col-xlg-13 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-13,
+.bx--grid--narrow .bx--col-xlg-13 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-14 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-14,
+.bx--grid--condensed .bx--col-xlg-14 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-14,
+.bx--grid--narrow .bx--col-xlg-14 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-15 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-15,
+.bx--grid--condensed .bx--col-xlg-15 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-15,
+.bx--grid--narrow .bx--col-xlg-15 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg-16 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg-16,
+.bx--grid--condensed .bx--col-xlg-16 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg-16,
+.bx--grid--narrow .bx--col-xlg-16 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-xlg,
+.bx--col-xlg--auto {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-xlg,
+.bx--grid--condensed .bx--col-xlg, .bx--row--condensed
+.bx--col-xlg--auto,
+.bx--grid--condensed
+.bx--col-xlg--auto {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-xlg,
+.bx--grid--narrow .bx--col-xlg, .bx--row--narrow
+.bx--col-xlg--auto,
+.bx--grid--narrow
+.bx--col-xlg--auto {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+@media (min-width: 82rem) {
+  .bx--col,
+  .bx--col-xlg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .bx--col--auto,
+  .bx--col-xlg--auto {
+    flex: 1 0 0%;
+    width: auto;
+    max-width: 100%;
+  }
+  .bx--col-xlg-0 {
+    display: none;
+  }
+  .bx--col-xlg-1 {
+    display: block;
+    flex: 0 0 6.25%;
+    max-width: 6.25%;
+  }
+  .bx--col-xlg-2 {
+    display: block;
+    flex: 0 0 12.5%;
+    max-width: 12.5%;
+  }
+  .bx--col-xlg-3 {
+    display: block;
+    flex: 0 0 18.75%;
+    max-width: 18.75%;
+  }
+  .bx--col-xlg-4 {
+    display: block;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .bx--col-xlg-5 {
+    display: block;
+    flex: 0 0 31.25%;
+    max-width: 31.25%;
+  }
+  .bx--col-xlg-6 {
+    display: block;
+    flex: 0 0 37.5%;
+    max-width: 37.5%;
+  }
+  .bx--col-xlg-7 {
+    display: block;
+    flex: 0 0 43.75%;
+    max-width: 43.75%;
+  }
+  .bx--col-xlg-8 {
+    display: block;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .bx--col-xlg-9 {
+    display: block;
+    flex: 0 0 56.25%;
+    max-width: 56.25%;
+  }
+  .bx--col-xlg-10 {
+    display: block;
+    flex: 0 0 62.5%;
+    max-width: 62.5%;
+  }
+  .bx--col-xlg-11 {
+    display: block;
+    flex: 0 0 68.75%;
+    max-width: 68.75%;
+  }
+  .bx--col-xlg-12 {
+    display: block;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .bx--col-xlg-13 {
+    display: block;
+    flex: 0 0 81.25%;
+    max-width: 81.25%;
+  }
+  .bx--col-xlg-14 {
+    display: block;
+    flex: 0 0 87.5%;
+    max-width: 87.5%;
+  }
+  .bx--col-xlg-15 {
+    display: block;
+    flex: 0 0 93.75%;
+    max-width: 93.75%;
+  }
+  .bx--col-xlg-16 {
+    display: block;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .bx--offset-xlg-0 {
+    margin-left: 0;
+  }
+  .bx--offset-xlg-1 {
+    margin-left: 6.25%;
+  }
+  .bx--offset-xlg-2 {
+    margin-left: 12.5%;
+  }
+  .bx--offset-xlg-3 {
+    margin-left: 18.75%;
+  }
+  .bx--offset-xlg-4 {
+    margin-left: 25%;
+  }
+  .bx--offset-xlg-5 {
+    margin-left: 31.25%;
+  }
+  .bx--offset-xlg-6 {
+    margin-left: 37.5%;
+  }
+  .bx--offset-xlg-7 {
+    margin-left: 43.75%;
+  }
+  .bx--offset-xlg-8 {
+    margin-left: 50%;
+  }
+  .bx--offset-xlg-9 {
+    margin-left: 56.25%;
+  }
+  .bx--offset-xlg-10 {
+    margin-left: 62.5%;
+  }
+  .bx--offset-xlg-11 {
+    margin-left: 68.75%;
+  }
+  .bx--offset-xlg-12 {
+    margin-left: 75%;
+  }
+  .bx--offset-xlg-13 {
+    margin-left: 81.25%;
+  }
+  .bx--offset-xlg-14 {
+    margin-left: 87.5%;
+  }
+  .bx--offset-xlg-15 {
+    margin-left: 93.75%;
+  }
+}
+
+.bx--col-max-0 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-0,
+.bx--grid--condensed .bx--col-max-0 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-0,
+.bx--grid--narrow .bx--col-max-0 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-1 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-1,
+.bx--grid--condensed .bx--col-max-1 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-1,
+.bx--grid--narrow .bx--col-max-1 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-2 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-2,
+.bx--grid--condensed .bx--col-max-2 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-2,
+.bx--grid--narrow .bx--col-max-2 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-3 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-3,
+.bx--grid--condensed .bx--col-max-3 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-3,
+.bx--grid--narrow .bx--col-max-3 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-4 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-4,
+.bx--grid--condensed .bx--col-max-4 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-4,
+.bx--grid--narrow .bx--col-max-4 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-5 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-5,
+.bx--grid--condensed .bx--col-max-5 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-5,
+.bx--grid--narrow .bx--col-max-5 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-6 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-6,
+.bx--grid--condensed .bx--col-max-6 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-6,
+.bx--grid--narrow .bx--col-max-6 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-7 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-7,
+.bx--grid--condensed .bx--col-max-7 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-7,
+.bx--grid--narrow .bx--col-max-7 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-8 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-8,
+.bx--grid--condensed .bx--col-max-8 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-8,
+.bx--grid--narrow .bx--col-max-8 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-9 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-9,
+.bx--grid--condensed .bx--col-max-9 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-9,
+.bx--grid--narrow .bx--col-max-9 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-10 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-10,
+.bx--grid--condensed .bx--col-max-10 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-10,
+.bx--grid--narrow .bx--col-max-10 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-11 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-11,
+.bx--grid--condensed .bx--col-max-11 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-11,
+.bx--grid--narrow .bx--col-max-11 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-12 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-12,
+.bx--grid--condensed .bx--col-max-12 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-12,
+.bx--grid--narrow .bx--col-max-12 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-13 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-13,
+.bx--grid--condensed .bx--col-max-13 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-13,
+.bx--grid--narrow .bx--col-max-13 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-14 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-14,
+.bx--grid--condensed .bx--col-max-14 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-14,
+.bx--grid--narrow .bx--col-max-14 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-15 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-15,
+.bx--grid--condensed .bx--col-max-15 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-15,
+.bx--grid--narrow .bx--col-max-15 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max-16 {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max-16,
+.bx--grid--condensed .bx--col-max-16 {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max-16,
+.bx--grid--narrow .bx--col-max-16 {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+.bx--col-max,
+.bx--col-max--auto {
+  width: 100%;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+.bx--row--condensed .bx--col-max,
+.bx--grid--condensed .bx--col-max, .bx--row--condensed
+.bx--col-max--auto,
+.bx--grid--condensed
+.bx--col-max--auto {
+  padding-right: 0.03125rem;
+  padding-left: 0.03125rem;
+}
+
+.bx--row--narrow .bx--col-max,
+.bx--grid--narrow .bx--col-max, .bx--row--narrow
+.bx--col-max--auto,
+.bx--grid--narrow
+.bx--col-max--auto {
+  padding-right: 1rem;
+  padding-left: 0;
+}
+
+@media (min-width: 99rem) {
+  .bx--col,
+  .bx--col-max {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+  .bx--col--auto,
+  .bx--col-max--auto {
+    flex: 1 0 0%;
+    width: auto;
+    max-width: 100%;
+  }
+  .bx--col-max-0 {
+    display: none;
+  }
+  .bx--col-max-1 {
+    display: block;
+    flex: 0 0 6.25%;
+    max-width: 6.25%;
+  }
+  .bx--col-max-2 {
+    display: block;
+    flex: 0 0 12.5%;
+    max-width: 12.5%;
+  }
+  .bx--col-max-3 {
+    display: block;
+    flex: 0 0 18.75%;
+    max-width: 18.75%;
+  }
+  .bx--col-max-4 {
+    display: block;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .bx--col-max-5 {
+    display: block;
+    flex: 0 0 31.25%;
+    max-width: 31.25%;
+  }
+  .bx--col-max-6 {
+    display: block;
+    flex: 0 0 37.5%;
+    max-width: 37.5%;
+  }
+  .bx--col-max-7 {
+    display: block;
+    flex: 0 0 43.75%;
+    max-width: 43.75%;
+  }
+  .bx--col-max-8 {
+    display: block;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .bx--col-max-9 {
+    display: block;
+    flex: 0 0 56.25%;
+    max-width: 56.25%;
+  }
+  .bx--col-max-10 {
+    display: block;
+    flex: 0 0 62.5%;
+    max-width: 62.5%;
+  }
+  .bx--col-max-11 {
+    display: block;
+    flex: 0 0 68.75%;
+    max-width: 68.75%;
+  }
+  .bx--col-max-12 {
+    display: block;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .bx--col-max-13 {
+    display: block;
+    flex: 0 0 81.25%;
+    max-width: 81.25%;
+  }
+  .bx--col-max-14 {
+    display: block;
+    flex: 0 0 87.5%;
+    max-width: 87.5%;
+  }
+  .bx--col-max-15 {
+    display: block;
+    flex: 0 0 93.75%;
+    max-width: 93.75%;
+  }
+  .bx--col-max-16 {
+    display: block;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .bx--offset-max-0 {
+    margin-left: 0;
+  }
+  .bx--offset-max-1 {
+    margin-left: 6.25%;
+  }
+  .bx--offset-max-2 {
+    margin-left: 12.5%;
+  }
+  .bx--offset-max-3 {
+    margin-left: 18.75%;
+  }
+  .bx--offset-max-4 {
+    margin-left: 25%;
+  }
+  .bx--offset-max-5 {
+    margin-left: 31.25%;
+  }
+  .bx--offset-max-6 {
+    margin-left: 37.5%;
+  }
+  .bx--offset-max-7 {
+    margin-left: 43.75%;
+  }
+  .bx--offset-max-8 {
+    margin-left: 50%;
+  }
+  .bx--offset-max-9 {
+    margin-left: 56.25%;
+  }
+  .bx--offset-max-10 {
+    margin-left: 62.5%;
+  }
+  .bx--offset-max-11 {
+    margin-left: 68.75%;
+  }
+  .bx--offset-max-12 {
+    margin-left: 75%;
+  }
+  .bx--offset-max-13 {
+    margin-left: 81.25%;
+  }
+  .bx--offset-max-14 {
+    margin-left: 87.5%;
+  }
+  .bx--offset-max-15 {
+    margin-left: 93.75%;
+  }
+}
+
+.bx--no-gutter,
+.bx--row.bx--no-gutter [class*='bx--col'] {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.bx--no-gutter--start,
+.bx--row.bx--no-gutter--start [class*='bx--col'] {
+  padding-left: 0;
+}
+
+.bx--no-gutter--end,
+.bx--row.bx--no-gutter--end [class*='bx--col'] {
+  padding-right: 0;
+}
+
+.bx--no-gutter--left,
+.bx--row.bx--no-gutter--left [class*='bx--col'] {
+  padding-left: 0;
+}
+
+.bx--no-gutter--right,
+.bx--row.bx--no-gutter--right [class*='bx--col'] {
+  padding-right: 0;
+}
+
+.bx--hang--start {
+  padding-left: 1rem;
+}
+
+.bx--hang--end {
+  padding-right: 1rem;
+}
+
+.bx--hang--left {
+  padding-left: 1rem;
+}
+
+.bx--hang--right {
+  padding-right: 1rem;
+}
+
+.bx--aspect-ratio {
+  position: relative;
+}
+
+.bx--aspect-ratio::before {
+  float: left;
+  width: 1px;
+  height: 0;
+  margin-left: -1px;
+  content: '';
+}
+
+.bx--aspect-ratio::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+
+.bx--aspect-ratio--16x9::before {
+  padding-top: 56.25%;
+}
+
+.bx--aspect-ratio--9x16::before {
+  padding-top: 177.77778%;
+}
+
+.bx--aspect-ratio--2x1::before {
+  padding-top: 50%;
+}
+
+.bx--aspect-ratio--1x2::before {
+  padding-top: 200%;
+}
+
+.bx--aspect-ratio--4x3::before {
+  padding-top: 75%;
+}
+
+.bx--aspect-ratio--3x4::before {
+  padding-top: 133.33333%;
+}
+
+.bx--aspect-ratio--1x1::before {
+  padding-top: 100%;
+}
+
+.bx--aspect-ratio--object {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+.bx--inline-loading {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 2rem;
+}
+
+.bx--inline-loading .bx--loading__svg circle {
+  stroke-width: 12;
+}
+
+.bx--inline-loading .bx--loading__stroke {
+  stroke-dashoffset: 110;
+}
+
+.bx--inline-loading__text {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--inline-loading__animation {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--inline-loading__checkmark-container {
+  fill: var(--cds-support-02, #24a148);
+}
+
+.bx--inline-loading__checkmark-container.bx--inline-loading__svg {
+  position: absolute;
+  top: 0.75rem;
+  width: 0.75rem;
+}
+
+.bx--inline-loading__checkmark-container[hidden] {
+  display: none;
+}
+
+.bx--inline-loading__checkmark {
+  transform-origin: 50% 50%;
+  animation-name: stroke;
+  animation-duration: 250ms;
+  animation-fill-mode: forwards;
+  fill: none;
+  stroke: var(--cds-interactive-04, #0f62fe);
+  stroke-width: 1.8;
+  stroke-dasharray: 12;
+  stroke-dashoffset: 12;
+}
+
+.bx--inline-loading--error {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.bx--inline-loading--error[hidden] {
+  display: none;
+}
+
+.bx--loading--small .bx--inline-loading__svg {
+  stroke: var(--cds-interactive-04, #0f62fe);
+}
+
+/* If IE11 Don't show check animation */
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  .bx--inline-loading__checkmark-container {
+    top: 1px;
+    right: 0.5rem;
+  }
+  .bx--inline-loading__checkmark {
+    animation: none;
+    stroke-dashoffset: 0;
+    stroke-dasharray: 0;
+  }
+}
+
+@keyframes sidePanelExitLeft {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-30rem);
+    opacity: 0;
+  }
+}
+
+@keyframes sidePanelExitRight {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(30rem);
+    opacity: 0;
+  }
+}
+
+.exp-side-panel-container {
+  position: fixed;
+  top: var(--cds-spacing-09, 3rem);
+  z-index: 3;
+  box-sizing: border-box;
+  min-width: 30rem;
+  max-width: 30rem;
+  height: calc(100% - 3rem);
+  overflow: auto;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-01, #f4f4f4);
+  transition: transform 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp-side-panel-container.exp-side-panel-container-light {
+  --cds-interactive-01: #0f62fe;
+  --cds-interactive-02: #393939;
+  --cds-interactive-03: #0f62fe;
+  --cds-interactive-04: #0f62fe;
+  --cds-ui-background: #f4f4f4;
+  --cds-ui-01: #ffffff;
+  --cds-ui-02: #f4f4f4;
+  --cds-ui-03: #e0e0e0;
+  --cds-ui-04: #8d8d8d;
+  --cds-ui-05: #161616;
+  --cds-text-01: #161616;
+  --cds-text-02: #525252;
+  --cds-text-03: #a8a8a8;
+  --cds-text-04: #ffffff;
+  --cds-text-05: #6f6f6f;
+  --cds-text-error: #da1e28;
+  --cds-icon-01: #161616;
+  --cds-icon-02: #525252;
+  --cds-icon-03: #ffffff;
+  --cds-link-01: #0f62fe;
+  --cds-link-02: #0043ce;
+  --cds-inverse-link: #78a9ff;
+  --cds-field-01: #ffffff;
+  --cds-field-02: #f4f4f4;
+  --cds-inverse-01: #ffffff;
+  --cds-inverse-02: #393939;
+  --cds-support-01: #da1e28;
+  --cds-support-02: #24a148;
+  --cds-support-03: #f1c21b;
+  --cds-support-04: #0043ce;
+  --cds-inverse-support-01: #fa4d56;
+  --cds-inverse-support-02: #42be65;
+  --cds-inverse-support-03: #f1c21b;
+  --cds-inverse-support-04: #4589ff;
+  --cds-overlay-01: rgba(22, 22, 22, 0.5);
+  --cds-danger-01: #da1e28;
+  --cds-danger-02: #da1e28;
+  --cds-focus: #0f62fe;
+  --cds-inverse-focus-ui: #ffffff;
+  --cds-hover-primary: #0353e9;
+  --cds-active-primary: #002d9c;
+  --cds-hover-primary-text: #0043ce;
+  --cds-hover-secondary: #4c4c4c;
+  --cds-active-secondary: #6f6f6f;
+  --cds-hover-tertiary: #0353e9;
+  --cds-active-tertiary: #002d9c;
+  --cds-hover-ui: #e5e5e5;
+  --cds-hover-light-ui: #e5e5e5;
+  --cds-hover-selected-ui: #cacaca;
+  --cds-active-ui: #c6c6c6;
+  --cds-active-light-ui: #c6c6c6;
+  --cds-selected-ui: #e0e0e0;
+  --cds-selected-light-ui: #e0e0e0;
+  --cds-inverse-hover-ui: #4c4c4c;
+  --cds-hover-danger: #b81921;
+  --cds-active-danger: #750e13;
+  --cds-hover-row: #e5e5e5;
+  --cds-visited-link: #8a3ffc;
+  --cds-disabled-01: #ffffff;
+  --cds-disabled-02: #c6c6c6;
+  --cds-disabled-03: #8d8d8d;
+  --cds-highlight: #edf5ff;
+  --cds-decorative-01: #e0e0e0;
+  --cds-button-separator: #e0e0e0;
+  --cds-skeleton-01: #e5e5e5;
+  --cds-skeleton-02: #c6c6c6;
+  --cds-brand-01: #0f62fe;
+  --cds-brand-02: #393939;
+  --cds-brand-03: #0f62fe;
+  --cds-active-01: #c6c6c6;
+  --cds-hover-field: #e5e5e5;
+  --cds-danger: #da1e28;
+  --cds-caption-01-font-size: 0.75rem;
+  --cds-caption-01-font-weight: 400;
+  --cds-caption-01-line-height: 1.34;
+  --cds-caption-01-letter-spacing: 0.32px;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.34;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.34;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.29;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.43;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.34;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.43;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.29;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.29;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.375;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.29;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.25;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.29;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 600;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-layout-01: 1rem;
+  --cds-layout-02: 1.5rem;
+  --cds-layout-03: 2rem;
+  --cds-layout-04: 3rem;
+  --cds-layout-05: 4rem;
+  --cds-layout-06: 6rem;
+  --cds-layout-07: 10rem;
+  --cds-container-01: 1.5rem;
+  --cds-container-02: 2rem;
+  --cds-container-03: 2.5rem;
+  --cds-container-04: 3rem;
+  --cds-container-05: 4rem;
+  --cds-icon-size-01: 1rem;
+  --cds-icon-size-02: 1.25rem;
+}
+
+.exp-side-panel-container.exp-side-panel-container-dark,
+.exp-side-panel-container.exp-side-panel-container-dark .exp-side-panel-body-content {
+  --cds-interactive-01: #0f62fe;
+  --cds-interactive-02: #6f6f6f;
+  --cds-interactive-03: #ffffff;
+  --cds-interactive-04: #4589ff;
+  --cds-ui-background: #161616;
+  --cds-ui-01: #262626;
+  --cds-ui-02: #393939;
+  --cds-ui-03: #393939;
+  --cds-ui-04: #6f6f6f;
+  --cds-ui-05: #f4f4f4;
+  --cds-text-01: #f4f4f4;
+  --cds-text-02: #c6c6c6;
+  --cds-text-03: #6f6f6f;
+  --cds-text-04: #ffffff;
+  --cds-text-05: #8d8d8d;
+  --cds-text-error: #ff8389;
+  --cds-icon-01: #f4f4f4;
+  --cds-icon-02: #c6c6c6;
+  --cds-icon-03: #ffffff;
+  --cds-link-01: #78a9ff;
+  --cds-link-02: #a6c8ff;
+  --cds-inverse-link: #0f62fe;
+  --cds-field-01: #262626;
+  --cds-field-02: #393939;
+  --cds-inverse-01: #161616;
+  --cds-inverse-02: #f4f4f4;
+  --cds-support-01: #fa4d56;
+  --cds-support-02: #42be65;
+  --cds-support-03: #f1c21b;
+  --cds-support-04: #4589ff;
+  --cds-inverse-support-01: #da1e28;
+  --cds-inverse-support-02: #24a148;
+  --cds-inverse-support-03: #f1c21b;
+  --cds-inverse-support-04: #0f62fe;
+  --cds-overlay-01: rgba(22, 22, 22, 0.7);
+  --cds-danger-01: #da1e28;
+  --cds-danger-02: #fa4d56;
+  --cds-focus: #ffffff;
+  --cds-inverse-focus-ui: #0f62fe;
+  --cds-hover-primary: #0353e9;
+  --cds-active-primary: #002d9c;
+  --cds-hover-primary-text: #a6c8ff;
+  --cds-hover-secondary: #606060;
+  --cds-active-secondary: #393939;
+  --cds-hover-tertiary: #f4f4f4;
+  --cds-active-tertiary: #c6c6c6;
+  --cds-hover-ui: #353535;
+  --cds-hover-light-ui: #4c4c4c;
+  --cds-hover-selected-ui: #4c4c4c;
+  --cds-active-ui: #525252;
+  --cds-active-light-ui: #6f6f6f;
+  --cds-selected-ui: #393939;
+  --cds-selected-light-ui: #525252;
+  --cds-inverse-hover-ui: #e5e5e5;
+  --cds-hover-danger: #b81921;
+  --cds-active-danger: #750e13;
+  --cds-hover-row: #353535;
+  --cds-visited-link: #be95ff;
+  --cds-disabled-01: #262626;
+  --cds-disabled-02: #525252;
+  --cds-disabled-03: #8d8d8d;
+  --cds-highlight: #002d9c;
+  --cds-decorative-01: #525252;
+  --cds-button-separator: #161616;
+  --cds-skeleton-01: #353535;
+  --cds-skeleton-02: #525252;
+  --cds-brand-01: #0f62fe;
+  --cds-brand-02: #6f6f6f;
+  --cds-brand-03: #ffffff;
+  --cds-active-01: #525252;
+  --cds-hover-field: #353535;
+  --cds-danger: #da1e28;
+  --cds-caption-01-font-size: 0.75rem;
+  --cds-caption-01-font-weight: 400;
+  --cds-caption-01-line-height: 1.34;
+  --cds-caption-01-letter-spacing: 0.32px;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.34;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.34;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.29;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.43;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.34;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.43;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.29;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.29;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.375;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.29;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.25;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.29;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 600;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-layout-01: 1rem;
+  --cds-layout-02: 1.5rem;
+  --cds-layout-03: 2rem;
+  --cds-layout-04: 3rem;
+  --cds-layout-05: 4rem;
+  --cds-layout-06: 6rem;
+  --cds-layout-07: 10rem;
+  --cds-container-01: 1.5rem;
+  --cds-container-02: 2rem;
+  --cds-container-03: 2.5rem;
+  --cds-container-04: 3rem;
+  --cds-container-05: 4rem;
+  --cds-icon-size-01: 1rem;
+  --cds-icon-size-02: 1.25rem;
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement {
+  right: 0;
+  border-left: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--extra-small {
+  min-width: 16rem;
+  max-width: 16rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(16rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--small {
+  min-width: 20rem;
+  max-width: 20rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(20rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--medium {
+  min-width: 30rem;
+  max-width: 30rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(30rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--large {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(40rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--max {
+  min-width: 75%;
+  max-width: 75%;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(75%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement {
+  left: 0;
+  border-right: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--extra-small {
+  min-width: 16rem;
+  max-width: 16rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-16rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--small {
+  min-width: 20rem;
+  max-width: 20rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-20rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--medium {
+  min-width: 30rem;
+  max-width: 30rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-30rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--large {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-40rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--max {
+  min-width: 75%;
+  max-width: 75%;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-75%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp-side-panel-container.exp-side-panel-with-condensed-header .exp-side-panel-title-text {
+  font-size: var(--cds-productive-heading-02-font-size, 1rem);
+  font-weight: var(--cds-productive-heading-02-font-weight, 600);
+  line-height: var(--cds-productive-heading-02-line-height, 1.375);
+  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
+}
+
+.exp-side-panel-container.exp-side-panel-with-condensed-header .exp-side-panel-header {
+  border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp-side-panel-container .exp-side-panel-title-text {
+  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-productive-heading-03-font-weight, 400);
+  line-height: var(--cds-productive-heading-03-line-height, 1.4);
+  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+  display: -webkit-box;
+  margin-right: var(--cds-spacing-07, 2rem);
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+  overflow: hidden;
+  transition: font-size 150ms, font-weight 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.exp-side-panel-container .exp-side-panel-subtitle-text {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  margin-bottom: var(--cds-spacing-05, 1rem);
+  overflow: hidden;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.exp-side-panel-container .exp-side-panel-label-text {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.exp-side-panel-container .exp-side-panel-action-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button {
+  min-width: 2rem;
+}
+
+.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-icon-only-button {
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-icon-only-button svg {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-leading-button {
+  margin-right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-side-panel-container .bx--btn.exp-side-panel-navigation-back-button,
+.exp-side-panel-container .bx--btn.exp-side-panel-close-button {
+  min-width: 2rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp-side-panel-container .bx--btn.exp-side-panel-close-button {
+  position: absolute;
+  top: var(--cds-spacing-03, 0.5rem);
+  right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-side-panel-container .exp-side-panel-body-content {
+  padding: var(--cds-spacing-05, 1rem);
+  padding-top: 0;
+  padding-bottom: var(--cds-layout-07, 10rem);
+}
+
+.exp-side-panel-container .exp-side-panel-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: var(--cds-spacing-05, 1rem);
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 100%;
+  height: var(--cds-layout-05, 4rem);
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small {
+  min-width: 16rem;
+  max-width: 16rem;
+  flex-direction: column;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button,
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small.exp-side-panel-actions-container--multi-action .exp-side-panel-primary-action-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small {
+  min-width: 20rem;
+  max-width: 20rem;
+  flex-direction: column;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button,
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small.exp-side-panel-actions-container--multi-action .exp-side-panel-primary-action-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium {
+  min-width: 30rem;
+  max-width: 30rem;
+  flex-direction: row;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium.exp-side-panel-actions-container--multi-action-3-buttons-or-more {
+  flex-direction: column;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button {
+  width: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large.exp-side-panel-actions-container--single-action .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max.exp-side-panel-actions-container--single-action .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container-condensed {
+  height: var(--cds-layout-04, 3rem);
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container .exp-side-panel-primary-action-button {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action
+.exp-side-panel-primary-action-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--single-action.exp-side-panel-actions--large
+.exp-side-panel-primary-action-button,
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action.exp-side-panel-actions--large
+.exp-side-panel-primary-action-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action-3-buttons-or-more.exp-side-panel-actions--large
+.exp-side-panel-primary-action-button,
+.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max
+.exp-side-panel-primary-action-button {
+  width: 25%;
+  max-width: 25%;
+}
+
+.exp-side-panel-primary-action-button .bx--inline-loading {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: var(--cds-spacing-07, 2rem);
+}
+
+@keyframes sidePanelOverlayEntrance {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes sidePanelOverlayExit {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.exp-side-panel--visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.exp-side-panel-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--content-switcher {
+  display: flex;
+  justify-content: space-evenly;
+  width: 100%;
+  height: 2.5rem;
+}
+
+.bx--content-switcher--sm {
+  height: 2rem;
+}
+
+.bx--content-switcher--xl {
+  height: 3rem;
+}
+
+.bx--content-switcher--disabled {
+  cursor: not-allowed;
+}
+
+.bx--content-switcher-btn {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  overflow: hidden;
+  color: var(--cds-text-02, #525252);
+  white-space: nowrap;
+  text-align: left;
+  text-decoration: none;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  border: none;
+  transition: all 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--content-switcher-btn *,
+.bx--content-switcher-btn *::before,
+.bx--content-switcher-btn *::after {
+  box-sizing: inherit;
+}
+
+.bx--content-switcher-btn:focus {
+  z-index: 3;
+  border-color: var(--cds-focus, #0f62fe);
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe), inset 0 0 0 3px var(--cds-ui-01, #f4f4f4);
+}
+
+.bx--content-switcher-btn:hover {
+  cursor: pointer;
+}
+
+.bx--content-switcher-btn:hover, .bx--content-switcher-btn:active {
+  z-index: 3;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.bx--content-switcher-btn:disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+  pointer-events: none;
+}
+
+.bx--content-switcher-btn:disabled:hover {
+  cursor: not-allowed;
+}
+
+.bx--content-switcher--light .bx--content-switcher-btn {
+  background-color: var(--cds-ui-02, #ffffff);
+}
+
+.bx--content-switcher--light .bx--content-switcher-btn:hover {
+  background-color: var(--cds-hover-light-ui, #e5e5e5);
+}
+
+.bx--content-switcher-btn:first-child {
+  border-top-left-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.bx--content-switcher-btn:last-child {
+  border-top-right-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.bx--content-switcher-btn::before {
+  position: absolute;
+  left: 0;
+  z-index: 2;
+  display: block;
+  width: 0.0625rem;
+  height: 1rem;
+  background-color: var(--cds-ui-03, #e0e0e0);
+  content: '';
+}
+
+.bx--content-switcher-btn:first-of-type::before {
+  display: none;
+}
+
+.bx--content-switcher--light
+.bx--content-switcher-btn::before {
+  background-color: var(--cds-decorative-01, #e0e0e0);
+}
+
+.bx--content-switcher--light
+.bx--content-switcher-btn:focus::before,
+.bx--content-switcher--light
+.bx--content-switcher-btn:focus
++ .bx--content-switcher-btn::before,
+.bx--content-switcher--light
+.bx--content-switcher-btn:hover::before,
+.bx--content-switcher--light
+.bx--content-switcher-btn:hover
++ .bx--content-switcher-btn::before,
+.bx--content-switcher--light
+.bx--content-switcher--selected::before,
+.bx--content-switcher--light
+.bx--content-switcher--selected
++ .bx--content-switcher-btn::before,
+.bx--content-switcher-btn:focus::before,
+.bx--content-switcher-btn:focus
++ .bx--content-switcher-btn::before,
+.bx--content-switcher-btn:hover::before,
+.bx--content-switcher-btn:hover
++ .bx--content-switcher-btn::before,
+.bx--content-switcher--selected::before,
+.bx--content-switcher--selected
++ .bx--content-switcher-btn::before {
+  background-color: transparent;
+}
+
+.bx--content-switcher__icon {
+  transition: fill 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-text-02, #525252);
+}
+
+.bx--content-switcher__icon + span {
+  margin-left: 0.5rem;
+}
+
+.bx--content-switcher__label {
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--content-switcher-btn:hover .bx--content-switcher__icon,
+.bx--content-switcher-btn:focus .bx--content-switcher__icon {
+  fill: var(--cds-text-01, #161616);
+}
+
+.bx--content-switcher--light
+.bx--content-switcher-btn.bx--content-switcher--selected,
+.bx--content-switcher-btn.bx--content-switcher--selected {
+  z-index: 3;
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-ui-05, #161616);
+}
+
+.bx--content-switcher--light
+.bx--content-switcher-btn.bx--content-switcher--selected:disabled,
+.bx--content-switcher-btn.bx--content-switcher--selected:disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-03, #8d8d8d);
+}
+
+.bx--content-switcher-btn.bx--content-switcher--selected
+.bx--content-switcher__icon {
+  fill: var(--cds-inverse-01, #ffffff);
+}
+
+.exp-button-set-with-overflow {
+  display: block;
+}
+
+.exp-button-set-with-overflow--space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp-button-set-with-overflow--space--right {
+  text-align: end;
+}
+
+.exp-button-set-with-overflow--button-container {
+  display: inline-flex;
+}
+
+.exp-button-set-with-overflow--button-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: calc(-100vw - 100%);
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.bx--search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.bx--search .bx--label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--search-input {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  order: 1;
+  width: 100%;
+  padding: 0 2.5rem;
+  color: var(--cds-text-01, #161616);
+  text-overflow: ellipsis;
+  background-color: var(--cds-field-01, #f4f4f4);
+  border: none;
+  border-bottom: 1px solid var(--cds-ui-04, #8d8d8d);
+  transition: background-color 110ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  appearance: none;
+}
+
+.bx--search-input *,
+.bx--search-input *::before,
+.bx--search-input *::after {
+  box-sizing: inherit;
+}
+
+.bx--search-input:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--search-input:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--search-input::placeholder {
+  color: var(--cds-text-05, #6f6f6f);
+  opacity: 1;
+}
+
+.bx--search-input::-ms-clear {
+  display: none;
+}
+
+.bx--search-input[disabled] {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+  border-bottom: 1px solid transparent;
+  cursor: not-allowed;
+}
+
+.bx--search-input[disabled]::placeholder {
+  color: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--search--light .bx--search-input {
+  background: var(--cds-field-02, #ffffff);
+}
+
+.bx--search--sm .bx--search-input {
+  height: 2rem;
+  padding: 0 var(--cds-spacing-07, 2rem);
+}
+
+.bx--search--sm .bx--search-magnifier {
+  left: 0.5rem;
+}
+
+.bx--search--lg .bx--search-input {
+  height: 2.5rem;
+  padding: 0 var(--cds-spacing-08, 2.5rem);
+}
+
+.bx--search--lg .bx--search-magnifier {
+  left: 0.75rem;
+}
+
+.bx--search--xl .bx--search-input {
+  height: 3rem;
+  padding: 0 var(--cds-spacing-09, 3rem);
+}
+
+.bx--search-magnifier {
+  position: absolute;
+  top: 50%;
+  left: var(--cds-spacing-05, 1rem);
+  z-index: 2;
+  width: 1rem;
+  height: 1rem;
+  transform: translateY(-50%);
+  pointer-events: none;
+  fill: var(--cds-icon-02, #525252);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--search-magnifier {
+    fill: ButtonText;
+  }
+}
+
+.bx--search-close {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.bx--search-close *,
+.bx--search-close *::before,
+.bx--search-close *::after {
+  box-sizing: inherit;
+}
+
+.bx--search-close::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--search-close::before {
+  position: absolute;
+  top: 0.0625rem;
+  left: 0;
+  display: block;
+  width: 2px;
+  height: calc(100% - 2px);
+  background-color: var(--cds-field-01, #f4f4f4);
+  transition: background-color 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  content: '';
+}
+
+.bx--search-close:hover {
+  border-bottom: 1px solid var(--cds-ui-04, #8d8d8d);
+}
+
+.bx--search-close:hover::before {
+  background-color: var(--cds-hover-field, #e5e5e5);
+}
+
+.bx--search-button {
+  flex-shrink: 0;
+  margin-left: 0.125rem;
+  background-color: var(--cds-field-01, #f4f4f4);
+}
+
+.bx--search-button svg {
+  vertical-align: middle;
+  fill: currentColor;
+}
+
+.bx--search-close svg {
+  fill: inherit;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--search-close svg {
+    fill: ButtonText;
+  }
+}
+
+.bx--search-close,
+.bx--search-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px 0;
+  visibility: inherit;
+  cursor: pointer;
+  opacity: 1;
+  transition: opacity 110ms cubic-bezier(0.2, 0, 0.38, 0.9), background-color 110ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 110ms cubic-bezier(0.2, 0, 0.38, 0.9), border 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: var(--cds-icon-01, #161616);
+}
+
+.bx--search-close:hover,
+.bx--search-button:hover {
+  background-color: var(--cds-hover-field, #e5e5e5);
+}
+
+.bx--search-close:focus,
+.bx--search-button:focus {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--search-close:focus,
+  .bx--search-button:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--search-close:active,
+.bx--search-button:active {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+  background-color: var(--cds-selected-ui, #e0e0e0);
+}
+
+@media screen and (prefers-contrast) {
+  .bx--search-close:active,
+  .bx--search-button:active {
+    outline-style: dotted;
+  }
+}
+
+.bx--search--disabled .bx--search-close {
+  outline: none;
+  cursor: not-allowed;
+}
+
+.bx--search--disabled .bx--search-close:hover {
+  background-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.bx--search--disabled .bx--search-close:hover::before {
+  background-color: transparent;
+}
+
+.bx--search--disabled svg {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--search-close:focus::before,
+.bx--search-close:active::before {
+  background-color: var(--cds-focus, #0f62fe);
+}
+
+.bx--search-input:focus ~ .bx--search-close:hover {
+  outline: 2px solid var(--cds-focus, #0f62fe);
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--search-input:focus ~ .bx--search-close:hover {
+    outline-style: dotted;
+  }
+}
+
+.bx--search--sm .bx--search-close,
+.bx--search--sm ~ .bx--search-button {
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--search--lg .bx--search-close,
+.bx--search--lg ~ .bx--search-button {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.bx--search--xl .bx--search-close,
+.bx--search--xl ~ .bx--search-button {
+  width: 3rem;
+  height: 3rem;
+}
+
+.bx--search-close--hidden {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.bx--search--xl.bx--skeleton .bx--search-input,
+.bx--search--lg.bx--skeleton .bx--search-input,
+.bx--search--sm.bx--skeleton .bx--search-input {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 100%;
+}
+
+.bx--search--xl.bx--skeleton .bx--search-input:hover, .bx--search--xl.bx--skeleton .bx--search-input:focus, .bx--search--xl.bx--skeleton .bx--search-input:active,
+.bx--search--lg.bx--skeleton .bx--search-input:hover,
+.bx--search--lg.bx--skeleton .bx--search-input:focus,
+.bx--search--lg.bx--skeleton .bx--search-input:active,
+.bx--search--sm.bx--skeleton .bx--search-input:hover,
+.bx--search--sm.bx--skeleton .bx--search-input:focus,
+.bx--search--sm.bx--skeleton .bx--search-input:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--search--xl.bx--skeleton .bx--search-input::before,
+.bx--search--lg.bx--skeleton .bx--search-input::before,
+.bx--search--sm.bx--skeleton .bx--search-input::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--search--xl.bx--skeleton .bx--search-input::before,
+  .bx--search--lg.bx--skeleton .bx--search-input::before,
+  .bx--search--sm.bx--skeleton .bx--search-input::before {
+    animation: none;
+  }
+}
+
+.bx--search--xl.bx--skeleton .bx--search-input::placeholder,
+.bx--search--lg.bx--skeleton .bx--search-input::placeholder,
+.bx--search--sm.bx--skeleton .bx--search-input::placeholder {
+  color: transparent;
+}
+
+.bx--tag {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  display: inline-block;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  appearance: none;
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  color: var(--cds-tag-color-gray, #393939);
+  background-color: var(--cds-tag-background-gray, #e0e0e0);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  max-width: 100%;
+  min-height: 1.5rem;
+  margin: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  vertical-align: middle;
+  word-break: break-word;
+  border-radius: 0.9375rem;
+  cursor: default;
+}
+
+.bx--tag *,
+.bx--tag *::before,
+.bx--tag *::after {
+  box-sizing: inherit;
+}
+
+.bx--tag::-moz-focus-inner {
+  border: 0;
+}
+
+.bx--tag.bx--tag--interactive:hover,
+.bx--tag .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-gray, #c6c6c6);
+}
+
+.bx--tag:not(:first-child) {
+  margin-left: 0;
+}
+
+.bx--tag--red {
+  color: var(--cds-tag-color-red, #750e13);
+  background-color: var(--cds-tag-background-red, #ffd7d9);
+}
+
+.bx--tag--red.bx--tag--interactive:hover,
+.bx--tag--red .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-red, #ffb3b8);
+}
+
+.bx--tag--magenta {
+  color: var(--cds-tag-color-magenta, #740937);
+  background-color: var(--cds-tag-background-magenta, #ffd6e8);
+}
+
+.bx--tag--magenta.bx--tag--interactive:hover,
+.bx--tag--magenta .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-magenta, #ffafd2);
+}
+
+.bx--tag--purple {
+  color: var(--cds-tag-color-purple, #491d8b);
+  background-color: var(--cds-tag-background-purple, #e8daff);
+}
+
+.bx--tag--purple.bx--tag--interactive:hover,
+.bx--tag--purple .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-purple, #d4bbff);
+}
+
+.bx--tag--blue {
+  color: var(--cds-tag-color-blue, #002d9c);
+  background-color: var(--cds-tag-background-blue, #d0e2ff);
+}
+
+.bx--tag--blue.bx--tag--interactive:hover,
+.bx--tag--blue .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-blue, #a6c8ff);
+}
+
+.bx--tag--cyan {
+  color: var(--cds-tag-color-cyan, #003a6d);
+  background-color: var(--cds-tag-background-cyan, #bae6ff);
+}
+
+.bx--tag--cyan.bx--tag--interactive:hover,
+.bx--tag--cyan .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-cyan, #82cfff);
+}
+
+.bx--tag--teal {
+  color: var(--cds-tag-color-teal, #004144);
+  background-color: var(--cds-tag-background-teal, #9ef0f0);
+}
+
+.bx--tag--teal.bx--tag--interactive:hover,
+.bx--tag--teal .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-teal, #3ddbd9);
+}
+
+.bx--tag--green {
+  color: var(--cds-tag-color-green, #044317);
+  background-color: var(--cds-tag-background-green, #a7f0ba);
+}
+
+.bx--tag--green.bx--tag--interactive:hover,
+.bx--tag--green .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-green, #6fdc8c);
+}
+
+.bx--tag--gray {
+  color: var(--cds-tag-color-gray, #393939);
+  background-color: var(--cds-tag-background-gray, #e0e0e0);
+}
+
+.bx--tag--gray.bx--tag--interactive:hover,
+.bx--tag--gray .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-gray, #c6c6c6);
+}
+
+.bx--tag--cool-gray {
+  color: var(--cds-tag-color-cool-gray, #343a3f);
+  background-color: var(--cds-tag-background-cool-gray, #dde1e6);
+}
+
+.bx--tag--cool-gray.bx--tag--interactive:hover,
+.bx--tag--cool-gray .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-cool-gray, #c1c7cd);
+}
+
+.bx--tag--warm-gray {
+  color: var(--cds-tag-color-warm-gray, #3c3838);
+  background-color: var(--cds-tag-background-warm-gray, #e5e0df);
+}
+
+.bx--tag--warm-gray.bx--tag--interactive:hover,
+.bx--tag--warm-gray .bx--tag__close-icon:hover {
+  background-color: var(--cds-tag-hover-warm-gray, #cac5c4);
+}
+
+.bx--tag--high-contrast {
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-inverse-02, #393939);
+}
+
+.bx--tag--high-contrast.bx--tag--interactive:hover,
+.bx--tag--high-contrast .bx--tag__close-icon:hover {
+  background-color: var(--cds-inverse-hover-ui, #4c4c4c);
+}
+
+.bx--tag--disabled,
+.bx--tag--filter.bx--tag--disabled,
+.bx--tag--interactive.bx--tag--disabled {
+  color: var(--cds-disabled-02, #c6c6c6);
+  background-color: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--tag--disabled.bx--tag--interactive:hover,
+.bx--tag--disabled .bx--tag__close-icon:hover,
+.bx--tag--filter.bx--tag--disabled.bx--tag--interactive:hover,
+.bx--tag--filter.bx--tag--disabled .bx--tag__close-icon:hover,
+.bx--tag--interactive.bx--tag--disabled.bx--tag--interactive:hover,
+.bx--tag--interactive.bx--tag--disabled .bx--tag__close-icon:hover {
+  background-color: var(--cds-disabled-01, #f4f4f4);
+}
+
+.bx--tag--disabled:hover,
+.bx--tag--filter.bx--tag--disabled:hover,
+.bx--tag--interactive.bx--tag--disabled:hover {
+  cursor: not-allowed;
+}
+
+.bx--tag__label {
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--tag--interactive:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe);
+}
+
+.bx--tag--interactive:hover {
+  cursor: pointer;
+}
+
+.bx--tag--filter {
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  cursor: pointer;
+}
+
+.bx--tag--filter:hover {
+  outline: none;
+}
+
+.bx--tag--interactive {
+  transition: background-color 70ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--tag__close-icon {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: 0 0 0 0.125rem;
+  padding: 0;
+  color: currentColor;
+  background-color: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 70ms cubic-bezier(0.2, 0, 0.38, 0.9), box-shadow 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--tag__close-icon svg {
+  fill: currentColor;
+}
+
+.bx--tag__custom-icon {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  margin-right: var(--cds-spacing-02, 0.25rem);
+  padding: 0;
+  color: currentColor;
+  background-color: transparent;
+  border: 0;
+  outline: none;
+}
+
+.bx--tag__custom-icon svg {
+  fill: currentColor;
+}
+
+.bx--tag--disabled .bx--tag__close-icon {
+  cursor: not-allowed;
+}
+
+.bx--tag__close-icon:focus {
+  border-radius: 50%;
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe);
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--tag__close-icon:focus {
+    outline: 1px solid ButtonText;
+  }
+}
+
+.bx--tag--high-contrast .bx--tag__close-icon:focus {
+  box-shadow: inset 0 0 0 1px var(--cds-inverse-focus-ui, #ffffff);
+}
+
+.bx--tag--filter.bx--tag--disabled
+.bx--tag__close-icon:hover {
+  background-color: transparent;
+}
+
+.bx--tag--filter.bx--tag--disabled svg {
+  fill: var(--cds-disabled-02, #c6c6c6);
+}
+
+.bx--tag--sm {
+  min-height: 1.125rem;
+  padding: 0 0.5rem;
+}
+
+.bx--tag--sm.bx--tag--filter {
+  padding-right: 0;
+}
+
+.bx--tag--sm .bx--tag__close-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  margin-left: 0.3125rem;
+}
+
+.bx--tag.bx--skeleton {
+  position: relative;
+  padding: 0;
+  background: var(--cds-skeleton-01, #e5e5e5);
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-skeleton-01, #e5e5e5);
+  width: 3.75rem;
+  overflow: hidden;
+}
+
+.bx--tag.bx--skeleton:hover, .bx--tag.bx--skeleton:focus, .bx--tag.bx--skeleton:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--tag.bx--skeleton::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: var(--cds-skeleton-02, #c6c6c6);
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--tag.bx--skeleton::before {
+    animation: none;
+  }
+}
+
+.bx--tag.bx--skeleton.bx--tag--interactive:hover,
+.bx--tag.bx--skeleton .bx--tag__close-icon:hover {
+  background-color: var(--cds-skeleton-01, #e5e5e5);
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .bx--tag.bx--skeleton {
+      transform: translateZ(0);
+    }
+  }
+}
+
+.exp-tag-set {
+  display: block;
+  width: 100%;
+}
+
+.exp-tag-set--space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp-tag-set--space--right {
+  text-align: end;
+}
+
+.exp-tag-set--tag-container {
+  display: inline-flex;
+  white-space: nowrap;
+}
+
+.exp-tag-set--tag-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: -100vw;
+  width: 100%;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.exp-tag-set--overflow {
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.exp-tag-set--overflow--hidden {
+  max-width: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.exp-tag-set--overflow-tag-item {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  white-space: nowrap;
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon {
+  padding: 0;
+}
+
+.exp-tag-set--overflow-tag .bx--tag--high-contrast {
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon:focus {
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe);
+}
+
+.exp-tag-set--show-all-tags-link {
+  display: block;
+  margin: var(--cds-spacing-02, 0.25rem);
+  margin-left: 0;
+}
+
+.exp-tag-set--show-all-tags-search {
+  margin-bottom: var(--cds-layout-01, 1rem);
+}
+
+.exp-tag-set--tooltip {
+  min-width: initial;
+}
+
+.exp-breadcrumb-with-overflow {
+  display: block;
+}
+
+.exp-breadcrumb-with-overflow--space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp-breadcrumb-with-overflow--space--right {
+  text-align: end;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container {
+  display: inline-flex;
+  width: 100%;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container .bx--breadcrumb {
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.exp-breadcrumb-with-overflow--breadcrumb-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: -100vw;
+  max-width: 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu {
+  position: relative;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:focus {
+  outline: 1px solid var(--cds-focus, #0f62fe);
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:hover {
+  background: transparent;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu::after {
+  position: absolute;
+  bottom: 2px;
+  width: 0.75rem;
+  height: 1px;
+  background: var(--cds-hover-primary-text, #0043ce);
+  opacity: 0;
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  content: '';
+}
+
+.bx--breadcrumb-item .bx--overflow-menu:hover::after {
+  opacity: 1;
+}
+
+.bx--breadcrumb-item
+.bx--overflow-menu.bx--overflow-menu--open {
+  background: transparent;
+  box-shadow: none;
+}
+
+.bx--breadcrumb-item .bx--overflow-menu__icon {
+  position: relative;
+  transform: translateY(4px);
+  fill: var(--cds-link-01, #0f62fe);
+}
+
+.bx--breadcrumb-item
+.bx--overflow-menu:hover
+.bx--overflow-menu__icon {
+  fill: var(--cds-hover-primary-text, #0043ce);
+}
+
+.bx--breadcrumb-menu-options:focus {
+  outline: none;
+}
+
+.bx--breadcrumb-menu-options.bx--overflow-menu-options::after {
+  top: -0.4375rem;
+  left: 0.875rem;
+  width: 0;
+  height: 0;
+  margin: 0 auto;
+  background: transparent;
+  border-right: 0.4375rem solid transparent;
+  border-bottom: 0.4375rem solid var(--cds-field-01, #f4f4f4);
+  border-left: 0.4375rem solid transparent;
+}
+
+.exp-breadcrumb-with-overflow--displayed-breadcrumb {
+  overflow: hidden;
+}
+
+.exp-temp-combo-button {
+  justify-content: flex-start;
+  min-width: 160px;
+}
+
+.exp-temp-combo-button--trigger {
+  width: 100%;
+  padding: 0 var(--cds-spacing-05, 1rem);
+}
+
+.exp-temp-combo-button--options::after {
+  content: initial;
+}
+
+.exp-page-header {
+  /* Bleed class for the background */
+  position: sticky;
+  top: var(--exp-page-header--header-top);
+  display: inline-block;
+  /* cause top/bottom margin to reserve space */
+  width: 100%;
+  background-color: var(--cds-ui-background, #ffffff);
+  /* custom props */
+  --exp-page-header--breadcrumb-min-height: var(--cds-spacing-08, 2.5rem);
+  --exp-page-header--breadcrumb-title-visibility: hidden;
+  --exp-page-header--breadcrumb-title-opacity: 1;
+  --exp-page-header--breadcrumb-top: 0;
+  --exp-page-header--background-opacity: 1;
+  --exp-page-header--breadcrumb-title-top: initial;
+  --exp-page-header--button-set-in-breadcrumb-width-px: initial;
+}
+
+.exp-page-header--background::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  opacity: var(--exp-page-header--background-opacity);
+  content: '';
+  z-index: -1;
+  box-shadow: 0 1px 0 var(--cds-ui-03, #e0e0e0);
+}
+
+.exp-page-header--breadcrumb-row {
+  position: sticky;
+  top: var(--exp-page-header--breadcrumb-top);
+  z-index: 99;
+  min-height: var(--exp-page-header--breadcrumb-min-height);
+}
+
+.exp-page-header--breadcrumb-row + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp-page-header--breadcrumb-row--container {
+  display: flex;
+  flex-wrap: nowrap;
+  min-width: calc( 100% + ( var(--exp-page-header--width-px) - var(--exp-page-header--breadcrumb-row-width-px) ) / 2);
+}
+
+.exp-page-header--breadcrumb-row--with-actions + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-layout-02, 1.5rem);
+}
+
+.exp-page-header--breadcrumb-row::after {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  display: block;
+  width: 50vw;
+  height: 1px;
+  /* creates a full width box shadow without causing scroll */
+  box-shadow: 0 1px 0 0 var(--cds-ui-03, #e0e0e0), 0 1px 0 0 var(--cds-ui-03, #e0e0e0);
+  transform: translateX(-50%) scaleX(1);
+  opacity: 0;
+  transition: all 150ms ease-out;
+  content: '';
+}
+
+.exp-page-header--breadcrumb-row--next-to-tabs::after,
+.exp-page-header--breadcrumb-row--with-actions::after {
+  /* creates a full width box shadow without causing scroll */
+  box-shadow: 25vw 1px 0 0 var(--cds-ui-03, #e0e0e0), -25vw 1px 0 0 var(--cds-ui-03, #e0e0e0);
+  opacity: 1;
+}
+
+.exp-page-header--breadcrumb-container {
+  width: 100%;
+}
+
+.exp-page-header--breadcrumb-row--has-breadcrumbs .exp-page-header--action-bar-column {
+  flex: 1 0 40%;
+  max-width: 40%;
+}
+
+.exp-page-header--action-bar-column-content {
+  display: flex;
+  justify-content: flex-end;
+  white-space: nowrap;
+}
+
+@media (min-width: 66rem) {
+  .exp-page-header--action-bar-column-content {
+    flex-wrap: nowrap;
+    /* assume enough space */
+  }
+}
+
+.exp-page-header--breadcrumb-row .exp-page-header--page-actions {
+  display: inline-block;
+  flex: 1 1 var(--exp-page-header--button-set-in-breadcrumb-width-px);
+  width: 100%;
+  max-width: var(--exp-page-header--button-set-in-breadcrumb-width-px);
+  white-space: nowrap;
+  visibility: hidden;
+  opacity: 0;
+  transition: all 240ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.exp-page-header--breadcrumb-row .exp-page-header--page-actions--in-breadcrumb {
+  visibility: visible;
+  opacity: 1;
+}
+
+.exp-page-header--breadcrumb-column {
+  flex: 0 0 100%;
+  max-width: 100%;
+  overflow: hidden;
+  /* required for ellipsis in title */
+}
+
+.exp-page-header--breadcrumb-row--has-action-bar .exp-page-header--breadcrumb-column {
+  flex: 0 1 60%;
+  max-width: 60%;
+}
+
+.exp-page-header--breadcrumb-column--background,
+.exp-page-header--action-bar-column--background {
+  position: relative;
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp-page-header--background
+.exp-page-header--breadcrumb-column--background::before,
+.exp-page-header--background
+.exp-page-header--action-bar-column--background::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-ui-01, #f4f4f4);
+  opacity: var(--exp-page-header--background-opacity);
+  content: '';
+}
+
+.exp-page-header--breadcrumb {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  padding-top: var(--cds-spacing-04, 0.75rem);
+}
+
+.exp-page-header--breadcrumb .bx--breadcrumb-item {
+  margin-right: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp-page-header--breadcrumb .bx--breadcrumb-item::after {
+  margin-left: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp-page-header--breadcrumb .bx--breadcrumb-item,
+.exp-page-header--breadcrumb
+.bx--breadcrumb-item
+.bx--link {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.exp-page-header--breadcrumb-title {
+  position: relative;
+}
+
+.exp-page-header--breadcrumb-title:not(.exp-page-header--breadcrumb-title--pre-collapsed) {
+  transform: translateY(var(--exp-page-header--breadcrumb-title-top));
+  /* token linter does not support this form */
+  visibility: var(--exp-page-header--breadcrumb-title-visibility);
+  opacity: var(--exp-page-header--breadcrumb-title-opacity);
+}
+
+.exp-page-header--breadcrumb-container
+.exp-page-header--breadcrumb-title.bx--breadcrumb-item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.exp-page-header--breadcrumb-container--hidden
+.exp-page-header--breadcrumb-title.exp-page-header--breadcrumb-title {
+  overflow: initial;
+}
+
+.exp-page-header--breadcrumb-title.bx--breadcrumb-item
+.bx--link {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.exp-page-header--action-bar {
+  flex: 1 1 var(--exp-page-header--max-action-bar-width-px);
+  width: 100%;
+  max-width: var(--exp-page-header--max-action-bar-width-px);
+  margin-top: calc(-1 * var(--cds-spacing-04, 0.75rem));
+  /* align with breadcrumb */
+  padding-top: var(--cds-spacing-04, 0.75rem);
+  white-space: nowrap;
+  vertical-align: top;
+}
+
+.exp-page-header--title-row {
+  z-index: 100;
+  margin-top: var(--cds-spacing-02, 0.25rem);
+  margin-bottom: 0;
+}
+
+@media (min-width: 42rem) {
+  .exp-page-header--title-row {
+    flex-wrap: nowrap;
+    /* assume enough space */
+  }
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--under-action-bar {
+  margin-top: var(--cds-spacing-06, 1.5rem);
+}
+
+.exp-page-header--title-row + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-layout-03, 2rem);
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--spacing-below-03 {
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--spacing-below-05 + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-spacing-05, 1rem);
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--spacing-below-06 {
+  margin-bottom: var(--cds-layout-02, 1.5rem);
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--no-breadcrumb-row {
+  margin-top: var(--cds-layout-03, 2rem);
+}
+
+.exp-page-header--title-row.exp-page-header--title-row--sticky {
+  position: sticky;
+  top: var(--exp-page-header--breadcrumb-top);
+}
+
+.exp-page-header--title-column {
+  flex: 0 0 100%;
+  overflow: hidden;
+  /* required for ellipsis in title */
+}
+
+@media (min-width: 42rem) {
+  .exp-page-header--title-column {
+    flex: 0 1 60%;
+  }
+}
+
+.exp-page-header--title {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.exp-page-header--title--fades {
+  opacity: calc(1 - var(--exp-page-header--breadcrumb-title-opacity));
+}
+
+.exp-page-header--title-icon {
+  margin-right: var(--cds-spacing-04, 0.75rem);
+}
+
+.exp-page-header--page-actions {
+  flex: 0 0 100%;
+  margin-top: var(--cds-spacing-05, 1rem);
+  white-space: nowrap;
+}
+
+@media (min-width: 42rem) {
+  .exp-page-header--page-actions {
+    flex: 1 1 40%;
+    margin-top: 0;
+  }
+}
+
+.exp-page-header--page-actions-container {
+  justify-content: flex-end;
+}
+
+.exp-page-header--title-row .exp-page-header--page-actions {
+  visibility: visible;
+  opacity: 1;
+  transition: all 110ms cubic-bezier(0, 0, 0.38, 0.9);
+  transition-property: opacity, visibility;
+}
+
+.exp-page-header--title-row .exp-page-header--page-actions--in-breadcrumb {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.exp-page-header--subtitle-row {
+  margin-top: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-page-header--subtitle-row + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-layout-01, 1rem);
+}
+
+.exp-page-header--subtitle {
+  font-size: var(--cds-body-long-02-font-size, 1rem);
+  font-weight: var(--cds-body-long-02-font-weight, 400);
+  line-height: var(--cds-body-long-02-line-height, 1.5);
+  letter-spacing: var(--cds-body-long-02-letter-spacing, 0);
+}
+
+.exp-page-header--available-row {
+  margin-top: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp-page-header--available-row + .exp-page-header--last-row-buffer--active {
+  height: var(--cds-layout-03, 2rem);
+}
+
+.exp-page-header--navigation-row {
+  flex-wrap: wrap-reverse;
+  margin-top: var(--cds-spacing-04, 0.75rem);
+}
+
+.exp-page-header--navigation-row .bx--content-switcher {
+  box-sizing: content-box;
+  padding-bottom: var(--cds-layout-01, 1rem);
+}
+
+.exp-page-header--last-row-buffer--active + .exp-page-header--navigation-row {
+  margin-top: 0;
+}
+
+.exp-page-header--navigation-row--spacing-above-06 {
+  margin-top: var(--cds-layout-02, 1.5rem);
+}
+
+.exp-page-header--navigation-row .bx--tab-content {
+  display: none;
+  /* need to figure out how to handle the tab content */
+}
+
+.exp-page-header--navigation-tabs {
+  margin-left: calc(-1 * var(--cds-spacing-04, 0.75rem));
+}
+
+.exp-page-header--navigation-row--has-tags .exp-page-header--navigation-tabs {
+  flex: 0 1 75%;
+  max-width: 75%;
+}
+
+.exp-page-header--navigation-tags {
+  display: flex;
+  flex: 1 0 25%;
+  align-items: center;
+  justify-content: flex-end;
+  max-width: 25%;
+  padding-bottom: var(--cds-spacing-02, 0.25rem);
+  /* design says 3 from bottom of tag, which has $spacing-02 already. 2 * $spacing-02 = $spacing-3 */
+  white-space: nowrap;
+  text-align: right;
+}
+
+.exp-page-header--navigation-tags--tags-only {
+  justify-content: flex-start;
+  margin-left: calc(-1 * var(--cds-spacing-02, 0.25rem));
+  padding-bottom: var(--cds-spacing-04, 0.75rem);
+  text-align: initial;
+}
+
+.exp-page-header--navigation-row .bx--content-switcher-btn {
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp-page-header
+.bx--btn.bx--btn--icon-only.exp-page-header__collapse-expand-toggle {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+}
+
+.exp-page-header
+.exp-page-header__collapse-expand-toggle
+.bx--btn__icon {
+  transition: all 400ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp-page-header
+.exp-page-header__collapse-expand-toggle--collapsed
+.bx--btn__icon {
+  transform: scaleY(-1);
+}
+
+.exp-page-header--background .exp-page-header--navigation-tags {
+  padding-right: var(--cds-spacing-07, 2rem);
+}
+
+@media (min-width: 42rem) {
+  .exp-page-header--background .exp-page-header--navigation-tags {
+    padding-right: var(--cds-spacing-05, 1rem);
+  }
+}
+
+.exp-remove-delete-modal .bx--modal-container {
+  background: var(--cds-ui-03, #e0e0e0);
+}
+
+.exp-remove-delete-modal-body {
+  margin-bottom: var(--cds-spacing-05, 1rem);
+}
+
+.exp-tag-set {
+  display: block;
+  width: 100%;
+}
+
+.exp-tag-set--space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp-tag-set--space--right {
+  text-align: end;
+}
+
+.exp-tag-set--tag-container {
+  display: inline-flex;
+  white-space: nowrap;
+}
+
+.exp-tag-set--tag-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: -100vw;
+  width: 100%;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.exp-tag-set--overflow {
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.exp-tag-set--overflow--hidden {
+  max-width: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.exp-tag-set--overflow-tag-item {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  white-space: nowrap;
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon {
+  padding: 0;
+}
+
+.exp-tag-set--overflow-tag .bx--tag--high-contrast {
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon:hover {
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.exp-tag-set--overflow-tag .bx--tag__close-icon:focus {
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe);
+}
+
+.exp-tag-set--show-all-tags-link {
+  display: block;
+  margin: var(--cds-spacing-02, 0.25rem);
+  margin-left: 0;
+}
+
+.exp-tag-set--show-all-tags-search {
+  margin-bottom: var(--cds-layout-01, 1rem);
+}
+
+.exp-tag-set--tooltip {
+  min-width: initial;
+}
+
+.exp--tearsheet {
+  align-items: flex-end;
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-1-of-2 {
+  z-index: 8999;
+  background-color: rgba(22, 22, 22, 0.33);
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-1-of-3 {
+  z-index: 8998;
+  background-color: rgba(22, 22, 22, 0.11);
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-2-of-3 {
+  z-index: 8999;
+  background-color: rgba(22, 22, 22, 0.25);
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-2-of-2,
+.exp--tearsheet.exp--tearsheet--stacked-3-of-3 {
+  background-color: rgba(22, 22, 22, 0.25);
+}
+
+.exp--tearsheet[class*='exp--tearsheet--stacked'] {
+  transition: visibility 0s linear, z-index 240ms;
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-closed {
+  transition: visibility 0s linear 240ms, opacity 240ms cubic-bezier(0.4, 0.14, 1, 1);
+}
+
+.exp--tearsheet .exp--tearsheet__container {
+  top: auto;
+  height: 100%;
+  max-height: calc(100% - var(--cds-spacing-09, 3rem));
+  transform: translate3d(0, 500px, 0);
+}
+
+.exp--tearsheet.exp--tearsheet .exp--tearsheet__container {
+  transition: width 240ms cubic-bezier(0.4, 0.14, 0.3, 1), transform 240ms cubic-bezier(0, 0, 0.3, 1);
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-2-of-2 .exp--tearsheet__container,
+.exp--tearsheet.exp--tearsheet--stacked-2-of-3 .exp--tearsheet__container {
+  max-height: calc(100% - (var(--cds-spacing-09, 3rem) + var(--cds-spacing-05, 1rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-3-of-3 .exp--tearsheet__container {
+  max-height: calc(100% - (var(--cds-spacing-09, 3rem) + (2 * var(--cds-spacing-05, 1rem))));
+}
+
+.exp--tearsheet .exp--tearsheet__container--lower {
+  max-height: calc(100% - (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-2-of-2
+.exp--tearsheet__container--lower,
+.exp--tearsheet.exp--tearsheet--stacked-2-of-3
+.exp--tearsheet__container--lower {
+  max-height: calc(100% - (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem) + var(--cds-spacing-05, 1rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-3-of-3
+.exp--tearsheet__container--lower {
+  max-height: calc( 100% - (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem) + (2 * var(--cds-spacing-05, 1rem))));
+}
+
+@media (min-width: 42rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-2:not(.exp--tearsheet--wide)
+.exp--tearsheet__container,
+  .exp--tearsheet.exp--tearsheet--stacked-2-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(60% - (2 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+@media (min-width: 66rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-2:not(.exp--tearsheet--wide)
+.exp--tearsheet__container,
+  .exp--tearsheet.exp--tearsheet--stacked-2-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(42% - (2 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+@media (min-width: 82rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-2:not(.exp--tearsheet--wide)
+.exp--tearsheet__container,
+  .exp--tearsheet.exp--tearsheet--stacked-2-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(36% - (2 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+@media (min-width: 42rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(60% - (4 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+@media (min-width: 66rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(42% - (4 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+@media (min-width: 82rem) {
+  .exp--tearsheet.exp--tearsheet--stacked-1-of-3:not(.exp--tearsheet--wide)
+.exp--tearsheet__container {
+    width: calc(36% - (4 * var(--cds-spacing-05, 1rem)));
+  }
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__container {
+  width: calc(100% - (2 * var(--cds-spacing-07, 2rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-1-of-2.exp--tearsheet--wide
+.exp--tearsheet__container,
+.exp--tearsheet.exp--tearsheet--stacked-2-of-3.exp--tearsheet--wide
+.exp--tearsheet__container {
+  width: calc(100% - (2 * var(--cds-spacing-07, 2rem)) - (2 * var(--cds-spacing-05, 1rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--stacked-1-of-3.exp--tearsheet--wide
+.exp--tearsheet__container {
+  width: calc(100% - (2 * var(--cds-spacing-07, 2rem)) - (4 * var(--cds-spacing-05, 1rem)));
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header {
+  margin: 0;
+  padding: var(--cds-spacing-06, 1.5rem);
+  border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--tearsheet .exp--tearsheet__header--no-close-icon {
+  display: none;
+}
+
+.exp--tearsheet.exp--tearsheet--wide
+.bx--modal-header__heading {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+}
+
+.exp--tearsheet .exp--tearsheet__header-description {
+  margin-top: var(--cds-spacing-05, 1rem);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header-description {
+  margin-top: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--tearsheet .exp--tearsheet__header-navigation {
+  margin: var(--cds-spacing-04, 0.75rem) 0 0;
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header-navigation {
+  margin: var(--cds-spacing-04, 0.75rem) 0 calc(-1 * var(--cds-spacing-06, 1.5rem));
+}
+
+.exp--tearsheet .exp--tearsheet__body {
+  display: flex;
+  flex-grow: 1;
+  margin: 0;
+  padding: 0;
+}
+
+.exp--tearsheet .exp--tearsheet__influencer {
+  width: 256px;
+  min-width: 256px;
+  border-right: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--tearsheet .exp--tearsheet__influencer--right {
+  order: 1;
+}
+
+.exp--tearsheet .exp--tearsheet__influencer--wide {
+  width: 320px;
+  min-width: 320px;
+}
+
+.exp--tearsheet .exp--tearsheet__right {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.exp--tearsheet .exp--tearsheet__main {
+  flex-grow: 1;
+  overflow: auto;
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main {
+  background: var(--cds-ui-02, #ffffff);
+}
+
+.exp--tearsheet .exp--tearsheet__buttons {
+  border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__buttons {
+  background: var(--cds-ui-02, #ffffff);
+}
+
+@keyframes webTerminalEntrance {
+  0% {
+    transform: translateX(36.5rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes webTerminalExit {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(36.5rem);
+    opacity: 0;
+  }
+}
+
+/*
+  The reason for not using theme tokens in the web terminal
+  component is because we want these colors to always be the same
+  despite of which carbon theme the user has.
+*/
+.exp-web-terminal {
+  --cds-interactive-01: #0f62fe;
+  --cds-interactive-02: #6f6f6f;
+  --cds-interactive-03: #ffffff;
+  --cds-interactive-04: #4589ff;
+  --cds-ui-background: #262626;
+  --cds-ui-01: #393939;
+  --cds-ui-02: #525252;
+  --cds-ui-03: #525252;
+  --cds-ui-04: #8d8d8d;
+  --cds-ui-05: #f4f4f4;
+  --cds-text-01: #f4f4f4;
+  --cds-text-02: #c6c6c6;
+  --cds-text-03: #6f6f6f;
+  --cds-text-04: #ffffff;
+  --cds-text-05: #8d8d8d;
+  --cds-text-error: #ffb3b8;
+  --cds-icon-01: #f4f4f4;
+  --cds-icon-02: #c6c6c6;
+  --cds-icon-03: #ffffff;
+  --cds-link-01: #78a9ff;
+  --cds-link-02: #a6c8ff;
+  --cds-inverse-link: #0f62fe;
+  --cds-field-01: #393939;
+  --cds-field-02: #525252;
+  --cds-inverse-01: #161616;
+  --cds-inverse-02: #f4f4f4;
+  --cds-support-01: #ff8389;
+  --cds-support-02: #42be65;
+  --cds-support-03: #f1c21b;
+  --cds-support-04: #4589ff;
+  --cds-inverse-support-01: #da1e28;
+  --cds-inverse-support-02: #24a148;
+  --cds-inverse-support-03: #f1c21b;
+  --cds-inverse-support-04: #0f62fe;
+  --cds-overlay-01: rgba(22, 22, 22, 0.7);
+  --cds-danger-01: #da1e28;
+  --cds-danger-02: #ff8389;
+  --cds-focus: #ffffff;
+  --cds-inverse-focus-ui: #0f62fe;
+  --cds-hover-primary: #0353e9;
+  --cds-active-primary: #002d9c;
+  --cds-hover-primary-text: #a6c8ff;
+  --cds-hover-secondary: #606060;
+  --cds-active-secondary: #393939;
+  --cds-hover-tertiary: #f4f4f4;
+  --cds-active-tertiary: #c6c6c6;
+  --cds-hover-ui: #4c4c4c;
+  --cds-hover-light-ui: #656565;
+  --cds-hover-selected-ui: #656565;
+  --cds-active-ui: #6f6f6f;
+  --cds-active-light-ui: #8d8d8d;
+  --cds-selected-ui: #525252;
+  --cds-selected-light-ui: #6f6f6f;
+  --cds-inverse-hover-ui: #e5e5e5;
+  --cds-hover-danger: #b81921;
+  --cds-active-danger: #750e13;
+  --cds-hover-row: #4c4c4c;
+  --cds-visited-link: #be95ff;
+  --cds-disabled-01: #393939;
+  --cds-disabled-02: #6f6f6f;
+  --cds-disabled-03: #a8a8a8;
+  --cds-highlight: #0043ce;
+  --cds-decorative-01: #6f6f6f;
+  --cds-button-separator: #161616;
+  --cds-skeleton-01: #353535;
+  --cds-skeleton-02: #525252;
+  --cds-brand-01: #0f62fe;
+  --cds-brand-02: #6f6f6f;
+  --cds-brand-03: #ffffff;
+  --cds-active-01: #6f6f6f;
+  --cds-hover-field: #4c4c4c;
+  --cds-danger: #da1e28;
+  --cds-caption-01-font-size: 0.75rem;
+  --cds-caption-01-font-weight: 400;
+  --cds-caption-01-line-height: 1.34;
+  --cds-caption-01-letter-spacing: 0.32px;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.34;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.34;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.29;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.43;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.34;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.43;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.29;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.29;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.375;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.29;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.25;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.29;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 600;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-layout-01: 1rem;
+  --cds-layout-02: 1.5rem;
+  --cds-layout-03: 2rem;
+  --cds-layout-04: 3rem;
+  --cds-layout-05: 4rem;
+  --cds-layout-06: 6rem;
+  --cds-layout-07: 10rem;
+  --cds-container-01: 1.5rem;
+  --cds-container-02: 2rem;
+  --cds-container-03: 2.5rem;
+  --cds-container-04: 3rem;
+  --cds-container-05: 4rem;
+  --cds-icon-size-01: 1rem;
+  --cds-icon-size-02: 1.25rem;
+  position: fixed;
+  top: var(--cds-spacing-09, 3rem);
+  right: 0;
+  width: 36.5rem;
+  height: calc(100vh - var(--cds-spacing-09, 3rem));
+  background-color: #161616;
+  /* stylelint-disable-line  */
+}
+
+.exp-web-terminal__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 3rem;
+  background-color: var(--cds-ui-background, #ffffff);
+}
+
+.exp-web-terminal__bar-icon {
+  cursor: pointer;
+  fill: var(--cds-text-01, #161616);
+}
+
+.exp-web-terminal__bar-icon-container {
+  position: relative;
+  padding: var(--cds-spacing-04, 0.75rem);
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.exp-web-terminal__bar-icon-dropdown {
+  position: absolute;
+  top: 2.8125rem;
+  /* stylelint-disable-line */
+  left: 0;
+  width: 10rem;
+  background-color: var(--cds-field-01, #f4f4f4);
+  /* stylelint-disable-next-line  */
+  transform: translateY(calc(-1 * var(--cds-spacing-04, 0.75rem)));
+  visibility: hidden;
+  opacity: 0;
+  transition: all cubic-bezier(0.2, 0, 0.38, 0.9) 110ms;
+}
+
+.exp-web-terminal__bar-icon-container:hover
+.exp-web-terminal__bar-icon-dropdown,
+.exp-web-terminal__bar-icon-container:focus
+.exp-web-terminal__bar-icon-dropdown {
+  transform: translateY(0);
+  visibility: visible;
+  opacity: 1;
+}
+
+.exp-web-terminal__bar-icon-dropdown-link {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2.125rem;
+  padding-left: var(--cds-spacing-04, 0.75rem);
+  color: var(--cds-text-02, #525252);
+  text-decoration: none;
+  cursor: pointer;
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  transition: all cubic-bezier(0.2, 0, 0.38, 0.9) 110ms;
+}
+
+.exp-web-terminal__bar-icon-dropdown-link:hover {
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-hover-ui, #e5e5e5);
+}
+
+.exp-web-terminal__close-container {
+  padding: var(--cds-spacing-04, 0.75rem);
+  cursor: pointer;
+}
+
+.exp-web-terminal__body {
+  height: 100%;
+}
+
+.security--combo-button {
+  position: relative;
+  display: inline-flex;
+}
+
+.security--combo-button__action {
+  display: block;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.security--combo-button__overflow-menu {
+  width: 3rem;
+  height: auto;
+  background-color: var(--cds-interactive-01, #0f62fe);
+  border-left: 0.0625rem solid var(--cds-ui-03, #e0e0e0);
+}
+
+.security--combo-button__overflow-menu.bx--overflow-menu:hover,
+.security--combo-button__overflow-menu.bx--overflow-menu--open {
+  background-color: var(--cds-hover-primary, #0353e9);
+}
+
+.security--combo-button__overflow-menu.bx--overflow-menu:active {
+  background-color: var(--cds-active-primary, #002d9c);
+}
+
+.security--combo-button__overflow-menu__icon {
+  pointer-events: none;
+  fill: var(--cds-icon-03, #ffffff);
+}
+
+.security--combo-button__overflow-menu__list {
+  width: 100%;
+}
+
+.security--combo-button__overflow-menu__list:after {
+  display: none;
+}
+
+.security--combo-button__overflow-menu__item {
+  max-width: none;
+}
+
+.security--combo-button__overflow-menu__item__icon {
+  margin-left: auto;
+}
+"
+`;

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -187,52 +187,52 @@ strong {
 }
 
 h1 {
-  font-size: var(--cds-productive-heading-06-font-size, 2.625rem);
-  font-weight: var(--cds-productive-heading-06-font-weight, 300);
-  line-height: var(--cds-productive-heading-06-line-height, 1.199);
-  letter-spacing: var(--cds-productive-heading-06-letter-spacing, 0);
+  font-size: 2.625rem;
+  font-weight: 300;
+  line-height: 1.199;
+  letter-spacing: 0;
 }
 
 h2 {
-  font-size: var(--cds-productive-heading-05-font-size, 2rem);
-  font-weight: var(--cds-productive-heading-05-font-weight, 400);
-  line-height: var(--cds-productive-heading-05-line-height, 1.25);
-  letter-spacing: var(--cds-productive-heading-05-letter-spacing, 0);
+  font-size: 2rem;
+  font-weight: 400;
+  line-height: 1.25;
+  letter-spacing: 0;
 }
 
 h3 {
-  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
-  font-weight: var(--cds-productive-heading-04-font-weight, 400);
-  line-height: var(--cds-productive-heading-04-line-height, 1.29);
-  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+  font-size: 1.75rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0;
 }
 
 h4 {
-  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
-  font-weight: var(--cds-productive-heading-03-font-weight, 400);
-  line-height: var(--cds-productive-heading-03-line-height, 1.4);
-  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.4;
+  letter-spacing: 0;
 }
 
 h5 {
-  font-size: var(--cds-productive-heading-02-font-size, 1rem);
-  font-weight: var(--cds-productive-heading-02-font-weight, 600);
-  line-height: var(--cds-productive-heading-02-line-height, 1.375);
-  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.375;
+  letter-spacing: 0;
 }
 
 h6 {
-  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
-  font-weight: var(--cds-productive-heading-01-font-weight, 600);
-  line-height: var(--cds-productive-heading-01-line-height, 1.29);
-  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
 }
 
 p {
-  font-size: var(--cds-body-long-02-font-size, 1rem);
-  font-weight: var(--cds-body-long-02-font-weight, 400);
-  line-height: var(--cds-body-long-02-line-height, 1.5);
-  letter-spacing: var(--cds-body-long-02-letter-spacing, 0);
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0;
 }
 
 a {
@@ -283,6 +283,2060 @@ em {
     transform-origin: left;
     opacity: 0.3;
   }
+}
+
+.bx--assistive-text,
+.bx--visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--body {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  color: #161616;
+  line-height: 1;
+  background-color: #ffffff;
+}
+
+.bx--body *,
+.bx--body *::before,
+.bx--body *::after {
+  box-sizing: inherit;
+}
+
+.bx--text-truncate--end {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.bx--text-truncate--front {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  direction: rtl;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@keyframes hide-feedback {
+  0% {
+    visibility: inherit;
+    opacity: 1;
+  }
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes show-feedback {
+  0% {
+    visibility: hidden;
+    opacity: 0;
+  }
+  100% {
+    visibility: inherit;
+    opacity: 1;
+  }
+}
+
+.bx--snippet {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+}
+
+.bx--snippet *,
+.bx--snippet *::before,
+.bx--snippet *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet--disabled,
+.bx--snippet--disabled
+.bx--btn.bx--snippet-btn--expand {
+  color: #c6c6c6;
+  background-color: #f4f4f4;
+}
+
+.bx--snippet--disabled .bx--snippet-btn--expand:hover,
+.bx--snippet--disabled .bx--copy-btn:hover {
+  color: #c6c6c6;
+  background-color: #f4f4f4;
+  cursor: not-allowed;
+}
+
+.bx--snippet--disabled .bx--snippet__icon,
+.bx--snippet--disabled
+.bx--snippet-btn--expand
+.bx--icon-chevron--down {
+  fill: #c6c6c6;
+}
+
+.bx--snippet code {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.34;
+  letter-spacing: 0.32px;
+}
+
+.bx--snippet--inline {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+  display: inline;
+  padding: 0;
+  color: #161616;
+  background-color: #f4f4f4;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.bx--snippet--inline *,
+.bx--snippet--inline *::before,
+.bx--snippet--inline *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet--inline:hover {
+  background-color: #e0e0e0;
+}
+
+.bx--snippet--inline:active {
+  background-color: #c6c6c6;
+}
+
+.bx--snippet--inline:focus {
+  border: 2px solid #0f62fe;
+  outline: none;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet--inline:focus {
+    border-style: dotted;
+  }
+}
+
+.bx--snippet--inline::before {
+  position: absolute;
+  z-index: 6000;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+  display: none;
+}
+
+.bx--snippet--inline .bx--copy-btn__feedback {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: #ffffff;
+  font-weight: 400;
+  text-align: left;
+  background-color: #393939;
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  display: none;
+  box-sizing: content-box;
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--inline .bx--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--snippet--inline::before, .bx--snippet--inline::after,
+.bx--snippet--inline .bx--assistive-text,
+.bx--snippet--inline + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--snippet--inline::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent #393939 transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--snippet--inline::after,
+.bx--snippet--inline .bx--assistive-text,
+.bx--snippet--inline + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--snippet--inline.bx--copy-btn--animating::before,
+.bx--snippet--inline.bx--copy-btn--animating
+.bx--copy-btn__feedback {
+  display: block;
+}
+
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out
+.bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
+}
+
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
+.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in
+.bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
+}
+
+.bx--snippet--inline code {
+  padding: 0 0.5rem;
+}
+
+.bx--snippet--inline.bx--snippet--no-copy {
+  display: inline-block;
+}
+
+.bx--snippet--inline.bx--snippet--no-copy:hover {
+  background-color: #f4f4f4;
+  cursor: auto;
+}
+
+.bx--snippet--light.bx--snippet--inline.bx--snippet--no-copy:hover {
+  background-color: #ffffff;
+  cursor: auto;
+}
+
+.bx--snippet--single {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.34;
+  letter-spacing: 0.32px;
+  position: relative;
+  width: 100%;
+  max-width: 37.5rem;
+  background-color: #f4f4f4;
+  display: flex;
+  align-items: center;
+  max-width: 47.5rem;
+  height: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--single {
+    outline: 2px solid transparent;
+  }
+}
+
+.bx--snippet--single.bx--snippet--no-copy {
+  padding: 0;
+}
+
+.bx--snippet--single.bx--snippet--no-copy::after {
+  right: 1rem;
+}
+
+.bx--snippet--single .bx--snippet-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-left: 1rem;
+  overflow-x: auto;
+}
+
+.bx--snippet--single .bx--snippet-container:focus {
+  outline: 2px solid #0f62fe;
+  outline-offset: -2px;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet--single .bx--snippet-container:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--single pre {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.34;
+  letter-spacing: 0.32px;
+  padding-right: 0.5rem;
+}
+
+.bx--snippet--single pre,
+.bx--snippet--inline code {
+  white-space: pre;
+}
+
+.bx--snippet--multi {
+  font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.34;
+  letter-spacing: 0.32px;
+  position: relative;
+  width: 100%;
+  max-width: 37.5rem;
+  background-color: #f4f4f4;
+  display: flex;
+  max-width: 100%;
+  padding: 1rem;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet--multi {
+    outline: 2px solid transparent;
+  }
+}
+
+.bx--snippet--multi .bx--snippet-container {
+  position: relative;
+  order: 1;
+  min-height: 3.5rem;
+  max-height: 14.875rem;
+  overflow: hidden;
+  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--snippet--multi.bx--snippet--expand
+.bx--snippet-container {
+  max-height: 100%;
+  padding-bottom: 1rem;
+  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--snippet--multi.bx--snippet--wraptext pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.bx--snippet--multi .bx--snippet-container pre {
+  padding-right: 2.5rem;
+  padding-bottom: 1.5rem;
+  overflow-x: auto;
+}
+
+.bx--snippet--multi.bx--snippet--no-copy
+.bx--snippet-container
+pre {
+  padding-right: 0;
+}
+
+.bx--snippet--multi.bx--snippet--expand
+.bx--snippet-container
+pre {
+  overflow-x: auto;
+}
+
+.bx--snippet--multi .bx--snippet-container pre::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1rem;
+  height: 100%;
+  background-image: linear-gradient(to right, rgba(244, 244, 244, 0), #f4f4f4);
+  content: '';
+}
+
+.bx--snippet--multi .bx--snippet-container pre code {
+  overflow: hidden;
+}
+
+.bx--snippet__icon {
+  width: 1rem;
+  height: 1rem;
+  transition: all 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: #161616;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--snippet__icon {
+    fill: ButtonText;
+  }
+}
+
+.bx--snippet-button {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  overflow: visible;
+  background-color: #f4f4f4;
+  border: none;
+  outline: none;
+  cursor: pointer;
+}
+
+.bx--snippet-button *,
+.bx--snippet-button *::before,
+.bx--snippet-button *::after {
+  box-sizing: inherit;
+}
+
+.bx--snippet-button:focus {
+  outline: 2px solid #0f62fe;
+  outline-offset: -2px;
+  outline-color: #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet-button:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--multi .bx--snippet-button {
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--snippet-button:hover {
+  background: #e5e5e5;
+}
+
+.bx--snippet-button:active {
+  background-color: #c6c6c6;
+}
+
+.bx--btn--copy__feedback {
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  top: 0.75rem;
+  right: 1.25rem;
+  left: inherit;
+  z-index: 6000;
+  font-weight: 400;
+}
+
+.bx--btn--copy__feedback::before,
+.bx--btn--copy__feedback::after {
+  background: #393939;
+}
+
+.bx--btn--copy__feedback::after {
+  border: none;
+}
+
+.bx--snippet .bx--copy-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.bx--snippet-btn--expand {
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  color: #161616;
+  background-color: #f4f4f4;
+  border: 0;
+}
+
+.bx--snippet-btn--expand .bx--snippet-btn--text {
+  position: relative;
+  top: -0.0625rem;
+}
+
+.bx--snippet-btn--expand--hide.bx--snippet-btn--expand {
+  display: none;
+}
+
+.bx--snippet-btn--expand .bx--icon-chevron--down {
+  margin-left: 0.5rem;
+  transform: rotate(0deg);
+  transition: 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
+  fill: #161616;
+}
+
+.bx--snippet-btn--expand:hover {
+  color: #161616;
+  background: #e5e5e5;
+}
+
+.bx--snippet-btn--expand:active {
+  background-color: #c6c6c6;
+}
+
+.bx--snippet-btn--expand:focus {
+  outline: 2px solid #0f62fe;
+  outline-offset: -2px;
+  border-color: transparent;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--snippet-btn--expand:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--snippet--expand
+.bx--snippet-btn--expand
+.bx--icon-chevron--down {
+  transform: rotate(180deg);
+  transition: transform 240ms;
+}
+
+.bx--snippet--light,
+.bx--snippet--light .bx--snippet-button,
+.bx--snippet--light .bx--btn.bx--snippet-btn--expand,
+.bx--snippet--light .bx--copy-btn {
+  background-color: #ffffff;
+}
+
+.bx--snippet--light.bx--snippet--inline:hover,
+.bx--snippet--light .bx--snippet-button:hover,
+.bx--snippet--light
+.bx--btn.bx--snippet-btn--expand:hover,
+.bx--snippet--light .bx--copy-btn:hover {
+  background-color: #e5e5e5;
+}
+
+.bx--snippet--light.bx--snippet--inline:active,
+.bx--snippet--light .bx--snippet-button:active,
+.bx--snippet--light
+.bx--btn.bx--snippet-btn--expand:active,
+.bx--snippet--light .bx--copy-btn:active {
+  background-color: #c6c6c6;
+}
+
+.bx--snippet--light.bx--snippet--single::after,
+.bx--snippet--light.bx--snippet--multi
+.bx--snippet-container
+pre::after {
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff);
+}
+
+.bx--snippet--code.bx--skeleton {
+  height: 6.125rem;
+}
+
+.bx--snippet--terminal.bx--skeleton {
+  height: 3.5rem;
+}
+
+.bx--snippet.bx--skeleton .bx--snippet-container {
+  height: 100%;
+}
+
+.bx--snippet.bx--skeleton code {
+  position: relative;
+  padding: 0;
+  background: #e5e5e5;
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  display: block;
+  width: 100%;
+  height: 1rem;
+}
+
+.bx--snippet.bx--skeleton code:hover, .bx--snippet.bx--skeleton code:focus, .bx--snippet.bx--skeleton code:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--snippet.bx--skeleton code::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: #c6c6c6;
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--snippet.bx--skeleton code::before {
+    animation: none;
+  }
+}
+
+.bx--snippet-button .bx--btn--copy__feedback {
+  top: 3.175rem;
+  right: auto;
+  left: 50%;
+}
+
+.bx--snippet-button .bx--btn--copy__feedback::before {
+  top: 0;
+}
+
+.bx--snippet-button .bx--btn--copy__feedback::after {
+  top: -0.25rem;
+}
+
+.bx--snippet--multi .bx--copy-btn {
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--snippet--multi
+.bx--snippet-button
+.bx--btn--copy__feedback {
+  top: 2.675rem;
+}
+
+.bx--snippet--inline .bx--btn--copy__feedback {
+  top: calc(100% - 0.25rem);
+  right: auto;
+  left: 50%;
+}
+
+.bx--snippet__overflow-indicator--left,
+.bx--snippet__overflow-indicator--right {
+  z-index: 1;
+  flex: 1 0 auto;
+  width: 1rem;
+}
+
+.bx--snippet__overflow-indicator--left {
+  order: 0;
+  margin-right: -1rem;
+  background-image: linear-gradient(to left, transparent, #f4f4f4);
+}
+
+.bx--snippet__overflow-indicator--right {
+  order: 2;
+  margin-left: -1rem;
+  background-image: linear-gradient(to right, transparent, #f4f4f4);
+}
+
+.bx--snippet--single .bx--snippet__overflow-indicator--right,
+.bx--snippet--single .bx--snippet__overflow-indicator--left {
+  position: absolute;
+  width: 2rem;
+  height: calc(100% - 0.25rem);
+}
+
+.bx--snippet--single .bx--snippet__overflow-indicator--right {
+  right: 2.5rem;
+}
+
+.bx--snippet--single
+.bx--snippet-container:focus
+~ .bx--snippet__overflow-indicator--right {
+  right: calc(2.5rem + 0.125rem);
+}
+
+.bx--snippet--single
+.bx--snippet-container:focus
++ .bx--snippet__overflow-indicator--left {
+  left: 0.125rem;
+}
+
+.bx--snippet--light .bx--snippet__overflow-indicator--left {
+  background-image: linear-gradient(to left, transparent, #ffffff);
+}
+
+.bx--snippet--light .bx--snippet__overflow-indicator--right {
+  background-image: linear-gradient(to right, transparent, #ffffff);
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    .bx--snippet__overflow-indicator--left {
+      background-image: linear-gradient(to left, rgba(244, 244, 244, 0), #f4f4f4);
+    }
+    .bx--snippet__overflow-indicator--right {
+      background-image: linear-gradient(to right, rgba(244, 244, 244, 0), #f4f4f4);
+    }
+  }
+}
+
+bx--snippet--multi.bx--skeleton {
+  height: 6.125rem;
+}
+
+.bx--snippet--single.bx--skeleton {
+  height: 3.5rem;
+}
+
+.bx--snippet.bx--skeleton span {
+  position: relative;
+  padding: 0;
+  background: #e5e5e5;
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  display: block;
+  width: 100%;
+  height: 1rem;
+  margin-top: 0.5rem;
+}
+
+.bx--snippet.bx--skeleton span:hover, .bx--snippet.bx--skeleton span:focus, .bx--snippet.bx--skeleton span:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--snippet.bx--skeleton span::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: #c6c6c6;
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--snippet.bx--skeleton span::before {
+    animation: none;
+  }
+}
+
+.bx--snippet.bx--skeleton span:first-child {
+  margin: 0;
+}
+
+.bx--snippet.bx--skeleton span:nth-child(2) {
+  width: 85%;
+}
+
+.bx--snippet.bx--skeleton span:nth-child(3) {
+  width: 95%;
+}
+
+.bx--snippet--single.bx--skeleton
+.bx--snippet-container {
+  padding-bottom: 0;
+}
+
+.bx--btn {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 20rem;
+  min-height: 3rem;
+  margin: 0;
+  padding: calc(0.875rem - 3px) 63px calc(0.875rem - 3px) 15px;
+  text-align: left;
+  text-decoration: none;
+  vertical-align: top;
+  border-radius: 0;
+  outline: none;
+  cursor: pointer;
+  transition: background 70ms cubic-bezier(0, 0, 0.38, 0.9), box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9), border-color 70ms cubic-bezier(0, 0, 0.38, 0.9), outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
+}
+
+.bx--btn *,
+.bx--btn *::before,
+.bx--btn *::after {
+  box-sizing: inherit;
+}
+
+.bx--btn:disabled, .bx--btn:hover:disabled, .bx--btn:focus:disabled, .bx--btn.bx--btn--disabled, .bx--btn.bx--btn--disabled:hover, .bx--btn.bx--btn--disabled:focus {
+  color: #8d8d8d;
+  background: #c6c6c6;
+  border-color: #c6c6c6;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.bx--btn .bx--btn__icon {
+  position: absolute;
+  right: 1rem;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.bx--btn::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.bx--btn--primary {
+  color: #ffffff;
+  background-color: #0f62fe;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--primary:hover {
+  background-color: #0353e9;
+}
+
+.bx--btn--primary:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--primary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--primary:active {
+  background-color: #002d9c;
+}
+
+.bx--btn--primary .bx--btn__icon,
+.bx--btn--primary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--primary:hover {
+  color: #ffffff;
+}
+
+.bx--btn--secondary {
+  color: #ffffff;
+  background-color: #393939;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--secondary:hover {
+  background-color: #4c4c4c;
+}
+
+.bx--btn--secondary:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--secondary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--secondary:active {
+  background-color: #6f6f6f;
+}
+
+.bx--btn--secondary .bx--btn__icon,
+.bx--btn--secondary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--secondary:hover, .bx--btn--secondary:focus {
+  color: #ffffff;
+}
+
+.bx--btn--tertiary {
+  color: #0f62fe;
+  background-color: transparent;
+  border-color: #0f62fe;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--tertiary:hover {
+  background-color: #0353e9;
+}
+
+.bx--btn--tertiary:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--tertiary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--tertiary:active {
+  background-color: #002d9c;
+}
+
+.bx--btn--tertiary .bx--btn__icon,
+.bx--btn--tertiary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--tertiary:hover {
+  color: #ffffff;
+}
+
+.bx--btn--tertiary:focus {
+  color: #ffffff;
+  background-color: #0f62fe;
+}
+
+.bx--btn--tertiary:active {
+  color: #ffffff;
+  background-color: #002d9c;
+  border-color: transparent;
+}
+
+.bx--btn--tertiary:disabled, .bx--btn--tertiary:hover:disabled, .bx--btn--tertiary:focus:disabled, .bx--btn--tertiary.bx--btn--disabled, .bx--btn--tertiary.bx--btn--disabled:hover, .bx--btn--tertiary.bx--btn--disabled:focus {
+  color: #8d8d8d;
+  background: transparent;
+  outline: none;
+}
+
+.bx--btn--ghost {
+  color: #0f62fe;
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  padding: calc(0.875rem - 3px) 16px;
+}
+
+.bx--btn--ghost:hover {
+  background-color: #e5e5e5;
+}
+
+.bx--btn--ghost:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--ghost:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--ghost:active {
+  background-color: #c6c6c6;
+}
+
+.bx--btn--ghost .bx--btn__icon,
+.bx--btn--ghost .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--ghost .bx--btn__icon {
+  position: static;
+  margin-left: 0.5rem;
+}
+
+.bx--btn--ghost:hover, .bx--btn--ghost:active {
+  color: #0043ce;
+}
+
+.bx--btn--ghost:active {
+  background-color: #c6c6c6;
+}
+
+.bx--btn--ghost:disabled, .bx--btn--ghost:hover:disabled, .bx--btn--ghost:focus:disabled, .bx--btn--ghost.bx--btn--disabled, .bx--btn--ghost.bx--btn--disabled:hover, .bx--btn--ghost.bx--btn--disabled:focus {
+  color: #8d8d8d;
+  background: transparent;
+  border-color: transparent;
+  outline: none;
+}
+
+.bx--btn--ghost.bx--btn--sm {
+  padding: calc(0.375rem - 3px) 16px;
+}
+
+.bx--btn--ghost.bx--btn--field {
+  padding: calc(0.675rem - 3px) 16px;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  outline: 1px solid #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+  outline: 1px solid #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: #ffffff;
+  font-weight: 400;
+  text-align: left;
+  background-color: #393939;
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
+  content: attr(aria-label);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden .bx--assistive-text,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger svg,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover svg,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
+  fill: currentColor;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::after,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  opacity: 0;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+  border-color: #0f62fe;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:active:not([disabled]) {
+  border-color: transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus
+svg {
+  outline-color: transparent;
+}
+
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:hover,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:focus,
+.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:active {
+  cursor: not-allowed;
+  fill: #8d8d8d;
+}
+
+.bx--btn--icon-only--top {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.bx--btn--icon-only--top:focus {
+  outline: 1px solid #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn--icon-only--top:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn--icon-only--top:focus {
+  outline: 1px solid transparent;
+}
+
+.bx--btn--icon-only--top:focus svg {
+  outline: 1px solid #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--btn--icon-only--top:focus svg {
+    outline-style: dotted;
+  }
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  position: absolute;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    display: inline-block;
+  }
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after {
+  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--a11y::before, .bx--btn--icon-only--top.bx--tooltip--a11y::after {
+  transition: none;
+}
+
+.bx--btn--icon-only--top::before {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+}
+
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  box-sizing: content-box;
+  color: inherit;
+  white-space: normal;
+  word-break: break-word;
+  opacity: 1;
+}
+
+.bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: #ffffff;
+  font-weight: 400;
+  text-align: left;
+  background-color: #393939;
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--icon-only--top::after,
+  .bx--btn--icon-only--top .bx--assistive-text,
+  .bx--btn--icon-only--top + .bx--assistive-text {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--btn--icon-only--top::after {
+  content: attr(aria-label);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--a11y::after {
+  content: none;
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible::before, .bx--btn--icon-only--top.bx--tooltip--visible::after, .bx--btn--icon-only--top:hover::before, .bx--btn--icon-only--top:hover::after, .bx--btn--icon-only--top:focus::before, .bx--btn--icon-only--top:focus::after {
+  opacity: 1;
+}
+
+@keyframes tooltip-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top:hover .bx--assistive-text,
+.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:focus .bx--assistive-text,
+.bx--btn--icon-only--top:focus + .bx--assistive-text {
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn--icon-only--top:hover .bx--assistive-text,
+.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:hover.bx--tooltip--a11y::before, .bx--btn--icon-only--top:focus .bx--assistive-text,
+.bx--btn--icon-only--top:focus + .bx--assistive-text, .bx--btn--icon-only--top:focus.bx--tooltip--a11y::before {
+  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--hidden .bx--assistive-text,
+.bx--btn--icon-only--top.bx--tooltip--hidden + .bx--assistive-text {
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.bx--btn--icon-only--top.bx--tooltip--hidden.bx--tooltip--a11y::before {
+  opacity: 0;
+  animation: none;
+}
+
+.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  top: 0;
+  left: 50%;
+}
+
+.bx--btn--icon-only--top::before {
+  top: -0.5rem;
+  border-color: #393939 transparent transparent transparent;
+  border-width: 0.3125rem 0.25rem 0 0.25rem;
+  transform: translate(-50%, -100%);
+}
+
+.bx--btn--icon-only--top::after,
+.bx--btn--icon-only--top .bx--assistive-text,
+.bx--btn--icon-only--top + .bx--assistive-text {
+  top: -0.8125rem;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+
+.bx--btn--icon-only--bottom::before, .bx--btn--icon-only--bottom::after,
+.bx--btn--icon-only--bottom .bx--assistive-text,
+.bx--btn--icon-only--bottom + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--btn--icon-only--bottom::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent #393939 transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--btn--icon-only--bottom::after,
+.bx--btn--icon-only--bottom .bx--assistive-text,
+.bx--btn--icon-only--bottom + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--btn--icon-only {
+  padding-right: 0.9375rem;
+  padding-left: 0.9375rem;
+}
+
+.bx--btn--icon-only .bx--btn__icon {
+  position: static;
+}
+
+.bx--btn--icon-only.bx--btn--ghost .bx--btn__icon,
+.bx--btn--icon-only.bx--btn--danger--ghost .bx--btn__icon {
+  margin: 0;
+}
+
+.bx--btn--icon-only.bx--btn--selected {
+  background: #e0e0e0;
+}
+
+.bx--btn path[data-icon-path='inner-path'] {
+  fill: none;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost
+.bx--btn__icon path,
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost:hover
+.bx--btn__icon path {
+    fill: ButtonText;
+  }
+}
+
+.bx--btn--ghost.bx--btn--icon-only
+.bx--btn__icon
+path:not([data-icon-path]),
+.bx--btn--ghost.bx--btn--icon-only .bx--btn__icon {
+  fill: #161616;
+}
+
+.bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon
+path,
+.bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon,
+.bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
+.bx--btn__icon {
+  fill: #8d8d8d;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon
+path path,
+  .bx--btn--ghost.bx--btn--icon-only[disabled]
+.bx--btn__icon path,
+  .bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
+.bx--btn__icon path {
+    fill: GrayText;
+  }
+}
+
+.bx--btn--ghost.bx--btn--icon-only[disabled] {
+  cursor: not-allowed;
+}
+
+.bx--btn--field.bx--btn--icon-only {
+  padding-right: 0.6875rem;
+  padding-left: 0.6875rem;
+}
+
+.bx--btn--sm.bx--btn--icon-only {
+  padding-right: 0.4375rem;
+  padding-left: 0.4375rem;
+}
+
+.bx--btn--danger {
+  color: #ffffff;
+  background-color: #da1e28;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--danger:hover {
+  background-color: #b81921;
+}
+
+.bx--btn--danger:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger:active {
+  background-color: #750e13;
+}
+
+.bx--btn--danger .bx--btn__icon,
+.bx--btn--danger .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger:hover {
+  color: #ffffff;
+}
+
+.bx--btn--danger-tertiary, .bx--btn--danger--tertiary {
+  color: #da1e28;
+  background-color: transparent;
+  border-color: #da1e28;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
+  background-color: #b81921;
+}
+
+.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
+  background-color: #750e13;
+}
+
+.bx--btn--danger-tertiary .bx--btn__icon,
+.bx--btn--danger-tertiary .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--tertiary .bx--btn__icon,
+.bx--btn--danger--tertiary .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
+  color: #ffffff;
+  border-color: #b81921;
+}
+
+.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
+  color: #ffffff;
+  background-color: #da1e28;
+}
+
+.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
+  color: #ffffff;
+  border-color: #750e13;
+}
+
+.bx--btn--danger-tertiary:disabled, .bx--btn--danger-tertiary:hover:disabled, .bx--btn--danger-tertiary:focus:disabled, .bx--btn--danger-tertiary.bx--btn--disabled, .bx--btn--danger-tertiary.bx--btn--disabled:hover, .bx--btn--danger-tertiary.bx--btn--disabled:focus, .bx--btn--danger--tertiary:disabled, .bx--btn--danger--tertiary:hover:disabled, .bx--btn--danger--tertiary:focus:disabled, .bx--btn--danger--tertiary.bx--btn--disabled, .bx--btn--danger--tertiary.bx--btn--disabled:hover, .bx--btn--danger--tertiary.bx--btn--disabled:focus {
+  color: #8d8d8d;
+  background: transparent;
+  outline: none;
+}
+
+.bx--btn--danger-ghost, .bx--btn--danger--ghost {
+  color: #da1e28;
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 1px;
+  padding: calc(0.875rem - 3px) 16px;
+}
+
+.bx--btn--danger-ghost:hover, .bx--btn--danger--ghost:hover {
+  background-color: #b81921;
+}
+
+.bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
+  border-color: #0f62fe;
+  box-shadow: inset 0 0 0 1px #0f62fe, inset 0 0 0 2px #ffffff;
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
+    outline: 3px solid transparent;
+    outline-offset: -3px;
+  }
+}
+
+.bx--btn--danger-ghost:active, .bx--btn--danger--ghost:active {
+  background-color: #750e13;
+}
+
+.bx--btn--danger-ghost .bx--btn__icon,
+.bx--btn--danger-ghost .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--ghost .bx--btn__icon,
+.bx--btn--danger--ghost .bx--btn__icon path:not([data-icon-path]) {
+  fill: currentColor;
+}
+
+.bx--btn--danger-ghost .bx--btn__icon, .bx--btn--danger--ghost .bx--btn__icon {
+  position: static;
+  margin-left: 0.5rem;
+}
+
+.bx--btn--danger-ghost:hover, .bx--btn--danger-ghost:active, .bx--btn--danger--ghost:hover, .bx--btn--danger--ghost:active {
+  color: #ffffff;
+}
+
+.bx--btn--danger-ghost:disabled, .bx--btn--danger-ghost:hover:disabled, .bx--btn--danger-ghost:focus:disabled, .bx--btn--danger-ghost.bx--btn--disabled, .bx--btn--danger-ghost.bx--btn--disabled:hover, .bx--btn--danger-ghost.bx--btn--disabled:focus, .bx--btn--danger--ghost:disabled, .bx--btn--danger--ghost:hover:disabled, .bx--btn--danger--ghost:focus:disabled, .bx--btn--danger--ghost.bx--btn--disabled, .bx--btn--danger--ghost.bx--btn--disabled:hover, .bx--btn--danger--ghost.bx--btn--disabled:focus {
+  color: #c6c6c6;
+  background: transparent;
+  border-color: transparent;
+  outline: none;
+}
+
+.bx--btn--danger-ghost.bx--btn--sm, .bx--btn--danger--ghost.bx--btn--sm {
+  padding: calc(0.375rem - 3px) 16px;
+}
+
+.bx--btn--danger-ghost.bx--btn--field, .bx--btn--danger--ghost.bx--btn--field {
+  padding: calc(0.675rem - 3px) 16px;
+}
+
+.bx--btn--sm {
+  min-height: 2rem;
+  padding: calc(0.375rem - 3px) 60px calc(0.375rem - 3px) 12px;
+}
+
+.bx--btn--xl:not(.bx--btn--icon-only) {
+  align-items: baseline;
+  padding-top: 1rem;
+  padding-right: 4rem;
+  padding-left: 1rem;
+  min-height: 5rem;
+}
+
+.bx--btn--lg:not(.bx--btn--icon-only) {
+  align-items: baseline;
+  padding-top: 1rem;
+  padding-right: 4rem;
+  padding-left: 1rem;
+  min-height: 4rem;
+}
+
+.bx--btn--field {
+  min-height: 2.5rem;
+  padding: calc(0.675rem - 3px) 60px calc(0.675rem - 3px) 12px;
+}
+
+.bx--btn.bx--skeleton {
+  position: relative;
+  padding: 0;
+  background: #e5e5e5;
+  border: none;
+  box-shadow: none;
+  pointer-events: none;
+  width: 9.375rem;
+}
+
+.bx--btn.bx--skeleton:hover, .bx--btn.bx--skeleton:focus, .bx--btn.bx--skeleton:active {
+  border: none;
+  outline: none;
+  cursor: default;
+}
+
+.bx--btn.bx--skeleton::before {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: #c6c6c6;
+  animation: 3000ms ease-in-out skeleton infinite;
+  content: '';
+  will-change: transform-origin, transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bx--btn.bx--skeleton::before {
+    animation: none;
+  }
+}
+
+.bx--btn-set {
+  display: flex;
+}
+
+.bx--btn-set--stacked {
+  flex-direction: column;
+}
+
+.bx--btn-set .bx--btn {
+  width: 100%;
+  max-width: 12.25rem;
+}
+
+.bx--btn-set .bx--btn:not(:focus) {
+  box-shadow: -0.0625rem 0 0 0 #e0e0e0;
+}
+
+.bx--btn-set .bx--btn:first-of-type:not(:focus) {
+  box-shadow: inherit;
+}
+
+.bx--btn-set .bx--btn:focus + .bx--btn {
+  box-shadow: inherit;
+}
+
+.bx--btn-set--stacked .bx--btn:not(:focus) {
+  box-shadow: 0 -0.0625rem 0 0 #e0e0e0;
+}
+
+.bx--btn-set--stacked .bx--btn:first-of-type:not(:focus) {
+  box-shadow: inherit;
+}
+
+.bx--btn-set .bx--btn.bx--btn--disabled {
+  box-shadow: -0.0625rem 0 0 0 #8d8d8d;
+}
+
+.bx--btn-set .bx--btn.bx--btn--disabled:first-of-type {
+  box-shadow: none;
+}
+
+.bx--btn-set--stacked .bx--btn.bx--btn--disabled {
+  box-shadow: 0 -0.0625rem 0 0 #8d8d8d;
+}
+
+.bx--btn-set--stacked .bx--btn.bx--btn--disabled:first-of-type {
+  box-shadow: none;
+}
+
+@keyframes hide-feedback {
+  0% {
+    visibility: inherit;
+    opacity: 1;
+  }
+  100% {
+    visibility: hidden;
+    opacity: 0;
+  }
+}
+
+@keyframes show-feedback {
+  0% {
+    visibility: hidden;
+    opacity: 0;
+  }
+  100% {
+    visibility: inherit;
+    opacity: 1;
+  }
+}
+
+.bx--btn--copy {
+  position: relative;
+  overflow: visible;
+}
+
+.bx--btn--copy .bx--btn__icon {
+  margin-left: 0.3125rem;
+}
+
+.bx--btn--copy__feedback {
+  position: absolute;
+  top: 1.2rem;
+  left: 50%;
+  display: none;
+}
+
+.bx--btn--copy__feedback:focus {
+  border: 2px solid #da1e28;
+}
+
+.bx--btn--copy__feedback::before {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  top: 1.1rem;
+  z-index: 2;
+  padding: 0.25rem;
+  color: #ffffff;
+  font-weight: 400;
+  white-space: nowrap;
+  border-radius: 4px;
+  transform: translateX(-50%);
+  content: attr(data-feedback);
+  pointer-events: none;
+}
+
+.bx--btn--copy__feedback::after {
+  top: 0.85rem;
+  left: -0.3rem;
+  z-index: 1;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-right: 1px solid #393939;
+  border-bottom: 1px solid #393939;
+  transform: rotate(-135deg);
+  content: '';
+}
+
+.bx--btn--copy__feedback::before, .bx--btn--copy__feedback::after {
+  position: absolute;
+  display: block;
+  background: #393939;
+}
+
+.bx--btn--copy__feedback--displayed {
+  display: inline-flex;
+}
+
+.bx--copy-btn {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background-color: #f4f4f4;
+  border: none;
+  cursor: pointer;
+}
+
+.bx--copy-btn *,
+.bx--copy-btn *::before,
+.bx--copy-btn *::after {
+  box-sizing: inherit;
+}
+
+.bx--copy-btn:hover {
+  background-color: #e5e5e5;
+}
+
+.bx--copy-btn:active {
+  background-color: #c6c6c6;
+}
+
+.bx--copy-btn::before {
+  position: absolute;
+  z-index: 6000;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  content: '';
+  display: none;
+}
+
+.bx--copy-btn .bx--copy-btn__feedback {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  width: max-content;
+  min-width: 1.5rem;
+  max-width: 13rem;
+  height: auto;
+  padding: 0.1875rem 1rem;
+  color: #ffffff;
+  font-weight: 400;
+  text-align: left;
+  background-color: #393939;
+  border-radius: 0.125rem;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.29;
+  letter-spacing: 0.16px;
+  z-index: 3;
+  display: none;
+  box-sizing: content-box;
+  margin: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-accelerator: true) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    width: auto;
+  }
+}
+
+@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
+  .bx--copy-btn .bx--copy-btn__feedback {
+    border: 1px solid transparent;
+  }
+}
+
+.bx--copy-btn::before, .bx--copy-btn::after,
+.bx--copy-btn .bx--assistive-text,
+.bx--copy-btn + .bx--assistive-text {
+  bottom: 0;
+  left: 50%;
+}
+
+.bx--copy-btn::before {
+  bottom: -0.5rem;
+  border-color: transparent transparent #393939 transparent;
+  border-width: 0 0.25rem 0.3125rem 0.25rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--copy-btn::after,
+.bx--copy-btn .bx--assistive-text,
+.bx--copy-btn + .bx--assistive-text {
+  bottom: -0.8125rem;
+  transform: translate(-50%, 100%);
+}
+
+.bx--copy-btn:focus {
+  outline: 2px solid #0f62fe;
+  outline-offset: -2px;
+  outline-color: #0f62fe;
+}
+
+@media screen and (prefers-contrast) {
+  .bx--copy-btn:focus {
+    outline-style: dotted;
+  }
+}
+
+.bx--copy-btn.bx--copy-btn--animating::before,
+.bx--copy-btn.bx--copy-btn--animating .bx--copy-btn__feedback {
+  display: block;
+}
+
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out .bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
+}
+
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
+.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in .bx--copy-btn__feedback {
+  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
+}
+
+.bx--copy {
+  font-size: 0;
 }
 
 .bx--link {
@@ -397,1077 +2451,6 @@ em {
   font-weight: var(--cds-body-short-02-font-weight, 400);
   line-height: var(--cds-body-short-02-line-height, 1.375);
   letter-spacing: var(--cds-body-short-02-letter-spacing, 0);
-}
-
-.bx--text-truncate--end {
-  display: inline-block;
-  width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.bx--text-truncate--front {
-  display: inline-block;
-  width: 100%;
-  overflow: hidden;
-  direction: rtl;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.bx--assistive-text,
-.bx--visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  border: 0;
-  visibility: inherit;
-  clip: rect(0, 0, 0, 0);
-}
-
-.bx--body {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  color: var(--cds-text-01, #161616);
-  line-height: 1;
-  background-color: var(--cds-ui-background, #ffffff);
-}
-
-.bx--body *,
-.bx--body *::before,
-.bx--body *::after {
-  box-sizing: inherit;
-}
-
-.bx--btn {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  position: relative;
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 20rem;
-  min-height: 3rem;
-  margin: 0;
-  padding: calc(0.875rem - 3px) 63px calc(0.875rem - 3px) 15px;
-  text-align: left;
-  text-decoration: none;
-  vertical-align: top;
-  border-radius: 0;
-  outline: none;
-  cursor: pointer;
-  transition: background 70ms cubic-bezier(0, 0, 0.38, 0.9), box-shadow 70ms cubic-bezier(0, 0, 0.38, 0.9), border-color 70ms cubic-bezier(0, 0, 0.38, 0.9), outline 70ms cubic-bezier(0, 0, 0.38, 0.9);
-}
-
-.bx--btn *,
-.bx--btn *::before,
-.bx--btn *::after {
-  box-sizing: inherit;
-}
-
-.bx--btn:disabled, .bx--btn:hover:disabled, .bx--btn:focus:disabled, .bx--btn.bx--btn--disabled, .bx--btn.bx--btn--disabled:hover, .bx--btn.bx--btn--disabled:focus {
-  color: var(--cds-disabled-03, #8d8d8d);
-  background: var(--cds-disabled-02, #c6c6c6);
-  border-color: var(--cds-disabled-02, #c6c6c6);
-  box-shadow: none;
-  cursor: not-allowed;
-}
-
-.bx--btn .bx--btn__icon {
-  position: absolute;
-  right: 1rem;
-  flex-shrink: 0;
-  width: 1rem;
-  height: 1rem;
-}
-
-.bx--btn::-moz-focus-inner {
-  padding: 0;
-  border: 0;
-}
-
-.bx--btn--primary {
-  color: var(--cds-text-04, #ffffff);
-  background-color: var(--cds-interactive-01, #0f62fe);
-  border-color: transparent;
-  border-style: solid;
-  border-width: 1px;
-}
-
-.bx--btn--primary:hover {
-  background-color: var(--cds-hover-primary, #0353e9);
-}
-
-.bx--btn--primary:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--primary:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--primary:active {
-  background-color: var(--cds-active-primary, #002d9c);
-}
-
-.bx--btn--primary .bx--btn__icon,
-.bx--btn--primary .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--primary:hover {
-  color: var(--cds-text-04, #ffffff);
-}
-
-.bx--btn--secondary {
-  color: var(--cds-text-04, #ffffff);
-  background-color: var(--cds-interactive-02, #393939);
-  border-color: transparent;
-  border-style: solid;
-  border-width: 1px;
-}
-
-.bx--btn--secondary:hover {
-  background-color: var(--cds-hover-secondary, #4c4c4c);
-}
-
-.bx--btn--secondary:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--secondary:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--secondary:active {
-  background-color: var(--cds-active-secondary, #6f6f6f);
-}
-
-.bx--btn--secondary .bx--btn__icon,
-.bx--btn--secondary .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--secondary:hover, .bx--btn--secondary:focus {
-  color: var(--cds-text-04, #ffffff);
-}
-
-.bx--btn--tertiary {
-  color: var(--cds-interactive-03, #0f62fe);
-  background-color: transparent;
-  border-color: var(--cds-interactive-03, #0f62fe);
-  border-style: solid;
-  border-width: 1px;
-}
-
-.bx--btn--tertiary:hover {
-  background-color: var(--cds-hover-tertiary, #0353e9);
-}
-
-.bx--btn--tertiary:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--tertiary:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--tertiary:active {
-  background-color: var(--cds-active-tertiary, #002d9c);
-}
-
-.bx--btn--tertiary .bx--btn__icon,
-.bx--btn--tertiary .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--tertiary:hover {
-  color: var(--cds-inverse-01, #ffffff);
-}
-
-.bx--btn--tertiary:focus {
-  color: var(--cds-inverse-01, #ffffff);
-  background-color: var(--cds-interactive-03, #0f62fe);
-}
-
-.bx--btn--tertiary:active {
-  color: var(--cds-inverse-01, #ffffff);
-  background-color: var(--cds-active-tertiary, #002d9c);
-  border-color: transparent;
-}
-
-.bx--btn--tertiary:disabled, .bx--btn--tertiary:hover:disabled, .bx--btn--tertiary:focus:disabled, .bx--btn--tertiary.bx--btn--disabled, .bx--btn--tertiary.bx--btn--disabled:hover, .bx--btn--tertiary.bx--btn--disabled:focus {
-  color: var(--cds-disabled-03, #8d8d8d);
-  background: transparent;
-  outline: none;
-}
-
-.bx--btn--ghost {
-  color: var(--cds-link-01, #0f62fe);
-  background-color: transparent;
-  border-color: transparent;
-  border-style: solid;
-  border-width: 1px;
-  padding: calc(0.875rem - 3px) 16px;
-}
-
-.bx--btn--ghost:hover {
-  background-color: var(--cds-hover-ui, #e5e5e5);
-}
-
-.bx--btn--ghost:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--ghost:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--ghost:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--btn--ghost .bx--btn__icon,
-.bx--btn--ghost .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--ghost .bx--btn__icon {
-  position: static;
-  margin-left: 0.5rem;
-}
-
-.bx--btn--ghost:hover, .bx--btn--ghost:active {
-  color: var(--cds-hover-primary-text, #0043ce);
-}
-
-.bx--btn--ghost:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--btn--ghost:disabled, .bx--btn--ghost:hover:disabled, .bx--btn--ghost:focus:disabled, .bx--btn--ghost.bx--btn--disabled, .bx--btn--ghost.bx--btn--disabled:hover, .bx--btn--ghost.bx--btn--disabled:focus {
-  color: var(--cds-disabled-03, #8d8d8d);
-  background: transparent;
-  border-color: transparent;
-  outline: none;
-}
-
-.bx--btn--ghost.bx--btn--sm {
-  padding: calc(0.375rem - 3px) 16px;
-}
-
-.bx--btn--ghost.bx--btn--field {
-  padding: calc(0.675rem - 3px) 16px;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  overflow: visible;
-  cursor: pointer;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
-  outline: 1px solid var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
-  outline: 1px solid transparent;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
-  outline: 1px solid var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
-    outline-style: dotted;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-  position: absolute;
-  z-index: 6000;
-  display: flex;
-  align-items: center;
-  opacity: 0;
-  pointer-events: none;
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-    display: inline-block;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
-  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
-  transition: none;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::before {
-  width: 0;
-  height: 0;
-  border-style: solid;
-  content: '';
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-  box-sizing: content-box;
-  color: inherit;
-  white-space: normal;
-  word-break: break-word;
-  opacity: 1;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  width: max-content;
-  min-width: 1.5rem;
-  max-width: 13rem;
-  height: auto;
-  padding: 0.1875rem 1rem;
-  color: var(--cds-inverse-01, #ffffff);
-  font-weight: 400;
-  text-align: left;
-  background-color: var(--cds-inverse-02, #393939);
-  border-radius: 0.125rem;
-  transform: translateX(-50%);
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@supports (-ms-accelerator: true) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@supports (-ms-ime-align: auto) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger .bx--assistive-text,
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger + .bx--assistive-text {
-    border: 1px solid transparent;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger::after {
-  content: attr(aria-label);
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--a11y::after {
-  content: none;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover::after, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus::after {
-  opacity: 1;
-}
-
-@keyframes tooltip-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text {
-  margin: auto;
-  overflow: visible;
-  clip: auto;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus + .bx--assistive-text, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus.bx--tooltip--a11y::before {
-  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden .bx--assistive-text,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden + .bx--assistive-text {
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--tooltip--hidden.bx--tooltip--a11y::before {
-  opacity: 0;
-  animation: none;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger svg,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:hover svg,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus svg {
-  fill: currentColor;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::before, .bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled.bx--tooltip--a11y::after,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger.bx--btn--disabled .bx--assistive-text {
-  margin: -1px;
-  overflow: hidden;
-  opacity: 0;
-  clip: rect(0, 0, 0, 0);
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
-  border-color: var(--cds-focus, #0f62fe);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:active:not([disabled]) {
-  border-color: transparent;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger:focus
-svg {
-  outline-color: transparent;
-}
-
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:hover,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:focus,
-.bx--btn.bx--btn--icon-only.bx--tooltip__trigger[disabled]:active {
-  cursor: not-allowed;
-  fill: var(--cds-disabled-03, #8d8d8d);
-}
-
-.bx--btn--icon-only--top {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  overflow: visible;
-  cursor: pointer;
-}
-
-.bx--btn--icon-only--top:focus {
-  outline: 1px solid var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--btn--icon-only--top:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--btn--icon-only--top:focus {
-  outline: 1px solid transparent;
-}
-
-.bx--btn--icon-only--top:focus svg {
-  outline: 1px solid var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--btn--icon-only--top:focus svg {
-    outline-style: dotted;
-  }
-}
-
-.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
-.bx--btn--icon-only--top .bx--assistive-text,
-.bx--btn--icon-only--top + .bx--assistive-text {
-  position: absolute;
-  z-index: 6000;
-  display: flex;
-  align-items: center;
-  opacity: 0;
-  pointer-events: none;
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
-  .bx--btn--icon-only--top .bx--assistive-text,
-  .bx--btn--icon-only--top + .bx--assistive-text {
-    display: inline-block;
-  }
-}
-
-.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after {
-  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--btn--icon-only--top.bx--tooltip--a11y::before, .bx--btn--icon-only--top.bx--tooltip--a11y::after {
-  transition: none;
-}
-
-.bx--btn--icon-only--top::before {
-  width: 0;
-  height: 0;
-  border-style: solid;
-  content: '';
-}
-
-.bx--btn--icon-only--top .bx--assistive-text,
-.bx--btn--icon-only--top + .bx--assistive-text {
-  box-sizing: content-box;
-  color: inherit;
-  white-space: normal;
-  word-break: break-word;
-  opacity: 1;
-}
-
-.bx--btn--icon-only--top::after,
-.bx--btn--icon-only--top .bx--assistive-text,
-.bx--btn--icon-only--top + .bx--assistive-text {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  width: max-content;
-  min-width: 1.5rem;
-  max-width: 13rem;
-  height: auto;
-  padding: 0.1875rem 1rem;
-  color: var(--cds-inverse-01, #ffffff);
-  font-weight: 400;
-  text-align: left;
-  background-color: var(--cds-inverse-02, #393939);
-  border-radius: 0.125rem;
-  transform: translateX(-50%);
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--btn--icon-only--top::after,
-  .bx--btn--icon-only--top .bx--assistive-text,
-  .bx--btn--icon-only--top + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@supports (-ms-accelerator: true) {
-  .bx--btn--icon-only--top::after,
-  .bx--btn--icon-only--top .bx--assistive-text,
-  .bx--btn--icon-only--top + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@supports (-ms-ime-align: auto) {
-  .bx--btn--icon-only--top::after,
-  .bx--btn--icon-only--top .bx--assistive-text,
-  .bx--btn--icon-only--top + .bx--assistive-text {
-    width: auto;
-  }
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--icon-only--top::after,
-  .bx--btn--icon-only--top .bx--assistive-text,
-  .bx--btn--icon-only--top + .bx--assistive-text {
-    border: 1px solid transparent;
-  }
-}
-
-.bx--btn--icon-only--top::after {
-  content: attr(aria-label);
-}
-
-.bx--btn--icon-only--top.bx--tooltip--a11y::after {
-  content: none;
-}
-
-.bx--btn--icon-only--top.bx--tooltip--visible::before, .bx--btn--icon-only--top.bx--tooltip--visible::after, .bx--btn--icon-only--top:hover::before, .bx--btn--icon-only--top:hover::after, .bx--btn--icon-only--top:focus::before, .bx--btn--icon-only--top:focus::after {
-  opacity: 1;
-}
-
-@keyframes tooltip-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
-.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top:hover .bx--assistive-text,
-.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:focus .bx--assistive-text,
-.bx--btn--icon-only--top:focus + .bx--assistive-text {
-  margin: auto;
-  overflow: visible;
-  clip: auto;
-}
-
-.bx--btn--icon-only--top.bx--tooltip--visible .bx--assistive-text,
-.bx--btn--icon-only--top.bx--tooltip--visible + .bx--assistive-text, .bx--btn--icon-only--top.bx--tooltip--visible.bx--tooltip--a11y::before, .bx--btn--icon-only--top:hover .bx--assistive-text,
-.bx--btn--icon-only--top:hover + .bx--assistive-text, .bx--btn--icon-only--top:hover.bx--tooltip--a11y::before, .bx--btn--icon-only--top:focus .bx--assistive-text,
-.bx--btn--icon-only--top:focus + .bx--assistive-text, .bx--btn--icon-only--top:focus.bx--tooltip--a11y::before {
-  animation: tooltip-fade 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--btn--icon-only--top.bx--tooltip--hidden .bx--assistive-text,
-.bx--btn--icon-only--top.bx--tooltip--hidden + .bx--assistive-text {
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-}
-
-.bx--btn--icon-only--top.bx--tooltip--hidden.bx--tooltip--a11y::before {
-  opacity: 0;
-  animation: none;
-}
-
-.bx--btn--icon-only--top::before, .bx--btn--icon-only--top::after,
-.bx--btn--icon-only--top .bx--assistive-text,
-.bx--btn--icon-only--top + .bx--assistive-text {
-  top: 0;
-  left: 50%;
-}
-
-.bx--btn--icon-only--top::before {
-  top: -0.5rem;
-  border-color: var(--cds-inverse-02, #393939) transparent transparent transparent;
-  border-width: 0.3125rem 0.25rem 0 0.25rem;
-  transform: translate(-50%, -100%);
-}
-
-.bx--btn--icon-only--top::after,
-.bx--btn--icon-only--top .bx--assistive-text,
-.bx--btn--icon-only--top + .bx--assistive-text {
-  top: -0.8125rem;
-  left: 50%;
-  transform: translate(-50%, -100%);
-}
-
-.bx--btn--icon-only--bottom::before, .bx--btn--icon-only--bottom::after,
-.bx--btn--icon-only--bottom .bx--assistive-text,
-.bx--btn--icon-only--bottom + .bx--assistive-text {
-  bottom: 0;
-  left: 50%;
-}
-
-.bx--btn--icon-only--bottom::before {
-  bottom: -0.5rem;
-  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
-  border-width: 0 0.25rem 0.3125rem 0.25rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--btn--icon-only--bottom::after,
-.bx--btn--icon-only--bottom .bx--assistive-text,
-.bx--btn--icon-only--bottom + .bx--assistive-text {
-  bottom: -0.8125rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--btn--icon-only {
-  padding-right: 0.9375rem;
-  padding-left: 0.9375rem;
-}
-
-.bx--btn--icon-only .bx--btn__icon {
-  position: static;
-}
-
-.bx--btn--icon-only.bx--btn--ghost .bx--btn__icon,
-.bx--btn--icon-only.bx--btn--danger--ghost .bx--btn__icon {
-  margin: 0;
-}
-
-.bx--btn--icon-only.bx--btn--selected {
-  background: var(--cds-selected-ui, #e0e0e0);
-}
-
-.bx--btn path[data-icon-path='inner-path'] {
-  fill: none;
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn.bx--btn--icon-only.bx--btn--ghost
-.bx--btn__icon path,
-  .bx--btn.bx--btn--icon-only.bx--btn--ghost:hover
-.bx--btn__icon path {
-    fill: ButtonText;
-  }
-}
-
-.bx--btn--ghost.bx--btn--icon-only
-.bx--btn__icon
-path:not([data-icon-path]),
-.bx--btn--ghost.bx--btn--icon-only .bx--btn__icon {
-  fill: var(--cds-icon-01, #161616);
-}
-
-.bx--btn--ghost.bx--btn--icon-only[disabled]
-.bx--btn__icon
-path,
-.bx--btn--ghost.bx--btn--icon-only[disabled]
-.bx--btn__icon,
-.bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
-.bx--btn__icon {
-  fill: var(--cds-disabled-03, #8d8d8d);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--ghost.bx--btn--icon-only[disabled]
-.bx--btn__icon
-path path,
-  .bx--btn--ghost.bx--btn--icon-only[disabled]
-.bx--btn__icon path,
-  .bx--btn.bx--btn--icon-only.bx--btn--ghost[disabled]:hover
-.bx--btn__icon path {
-    fill: GrayText;
-  }
-}
-
-.bx--btn--ghost.bx--btn--icon-only[disabled] {
-  cursor: not-allowed;
-}
-
-.bx--btn--field.bx--btn--icon-only {
-  padding-right: 0.6875rem;
-  padding-left: 0.6875rem;
-}
-
-.bx--btn--sm.bx--btn--icon-only {
-  padding-right: 0.4375rem;
-  padding-left: 0.4375rem;
-}
-
-.bx--btn--danger {
-  color: var(--cds-text-04, #ffffff);
-  background-color: var(--cds-danger-01, #da1e28);
-  border-color: transparent;
-  border-style: solid;
-  border-width: 1px;
-}
-
-.bx--btn--danger:hover {
-  background-color: var(--cds-hover-danger, #b81921);
-}
-
-.bx--btn--danger:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--danger:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--danger:active {
-  background-color: var(--cds-active-danger, #750e13);
-}
-
-.bx--btn--danger .bx--btn__icon,
-.bx--btn--danger .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--danger:hover {
-  color: var(--cds-text-04, #ffffff);
-}
-
-.bx--btn--danger-tertiary, .bx--btn--danger--tertiary {
-  color: var(--cds-danger-02, #da1e28);
-  background-color: transparent;
-  border-color: var(--cds-danger-02, #da1e28);
-  border-style: solid;
-  border-width: 1px;
-}
-
-.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
-  background-color: var(--cds-hover-danger, #b81921);
-}
-
-.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
-  background-color: var(--cds-active-danger, #750e13);
-}
-
-.bx--btn--danger-tertiary .bx--btn__icon,
-.bx--btn--danger-tertiary .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--tertiary .bx--btn__icon,
-.bx--btn--danger--tertiary .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--danger-tertiary:hover, .bx--btn--danger--tertiary:hover {
-  color: var(--cds-text-04, #ffffff);
-  border-color: var(--cds-hover-danger, #b81921);
-}
-
-.bx--btn--danger-tertiary:focus, .bx--btn--danger--tertiary:focus {
-  color: var(--cds-text-04, #ffffff);
-  background-color: var(--cds-danger-01, #da1e28);
-}
-
-.bx--btn--danger-tertiary:active, .bx--btn--danger--tertiary:active {
-  color: var(--cds-text-04, #ffffff);
-  border-color: var(--cds-active-danger, #750e13);
-}
-
-.bx--btn--danger-tertiary:disabled, .bx--btn--danger-tertiary:hover:disabled, .bx--btn--danger-tertiary:focus:disabled, .bx--btn--danger-tertiary.bx--btn--disabled, .bx--btn--danger-tertiary.bx--btn--disabled:hover, .bx--btn--danger-tertiary.bx--btn--disabled:focus, .bx--btn--danger--tertiary:disabled, .bx--btn--danger--tertiary:hover:disabled, .bx--btn--danger--tertiary:focus:disabled, .bx--btn--danger--tertiary.bx--btn--disabled, .bx--btn--danger--tertiary.bx--btn--disabled:hover, .bx--btn--danger--tertiary.bx--btn--disabled:focus {
-  color: var(--cds-disabled-03, #8d8d8d);
-  background: transparent;
-  outline: none;
-}
-
-.bx--btn--danger-ghost, .bx--btn--danger--ghost {
-  color: var(--cds-danger-02, #da1e28);
-  background-color: transparent;
-  border-color: transparent;
-  border-style: solid;
-  border-width: 1px;
-  padding: calc(0.875rem - 3px) 16px;
-}
-
-.bx--btn--danger-ghost:hover, .bx--btn--danger--ghost:hover {
-  background-color: var(--cds-hover-danger, #b81921);
-}
-
-.bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
-  border-color: var(--cds-focus, #0f62fe);
-  box-shadow: inset 0 0 0 1px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--btn--danger-ghost:focus, .bx--btn--danger--ghost:focus {
-    outline: 3px solid transparent;
-    outline-offset: -3px;
-  }
-}
-
-.bx--btn--danger-ghost:active, .bx--btn--danger--ghost:active {
-  background-color: var(--cds-active-danger, #750e13);
-}
-
-.bx--btn--danger-ghost .bx--btn__icon,
-.bx--btn--danger-ghost .bx--btn__icon path:not([data-icon-path]), .bx--btn--danger--ghost .bx--btn__icon,
-.bx--btn--danger--ghost .bx--btn__icon path:not([data-icon-path]) {
-  fill: currentColor;
-}
-
-.bx--btn--danger-ghost .bx--btn__icon, .bx--btn--danger--ghost .bx--btn__icon {
-  position: static;
-  margin-left: 0.5rem;
-}
-
-.bx--btn--danger-ghost:hover, .bx--btn--danger-ghost:active, .bx--btn--danger--ghost:hover, .bx--btn--danger--ghost:active {
-  color: var(--cds-text-04, #ffffff);
-}
-
-.bx--btn--danger-ghost:disabled, .bx--btn--danger-ghost:hover:disabled, .bx--btn--danger-ghost:focus:disabled, .bx--btn--danger-ghost.bx--btn--disabled, .bx--btn--danger-ghost.bx--btn--disabled:hover, .bx--btn--danger-ghost.bx--btn--disabled:focus, .bx--btn--danger--ghost:disabled, .bx--btn--danger--ghost:hover:disabled, .bx--btn--danger--ghost:focus:disabled, .bx--btn--danger--ghost.bx--btn--disabled, .bx--btn--danger--ghost.bx--btn--disabled:hover, .bx--btn--danger--ghost.bx--btn--disabled:focus {
-  color: var(--cds-disabled-02, #c6c6c6);
-  background: transparent;
-  border-color: transparent;
-  outline: none;
-}
-
-.bx--btn--danger-ghost.bx--btn--sm, .bx--btn--danger--ghost.bx--btn--sm {
-  padding: calc(0.375rem - 3px) 16px;
-}
-
-.bx--btn--danger-ghost.bx--btn--field, .bx--btn--danger--ghost.bx--btn--field {
-  padding: calc(0.675rem - 3px) 16px;
-}
-
-.bx--btn--sm {
-  min-height: 2rem;
-  padding: calc(0.375rem - 3px) 60px calc(0.375rem - 3px) 12px;
-}
-
-.bx--btn--xl:not(.bx--btn--icon-only) {
-  align-items: baseline;
-  padding-top: var(--cds-spacing-05, 1rem);
-  padding-right: var(--cds-layout-05, 4rem);
-  padding-left: var(--cds-spacing-05, 1rem);
-  min-height: 5rem;
-}
-
-.bx--btn--lg:not(.bx--btn--icon-only) {
-  align-items: baseline;
-  padding-top: var(--cds-spacing-05, 1rem);
-  padding-right: var(--cds-layout-05, 4rem);
-  padding-left: var(--cds-spacing-05, 1rem);
-  min-height: 4rem;
-}
-
-.bx--btn--field {
-  min-height: 2.5rem;
-  padding: calc(0.675rem - 3px) 60px calc(0.675rem - 3px) 12px;
-}
-
-.bx--btn.bx--skeleton {
-  position: relative;
-  padding: 0;
-  background: var(--cds-skeleton-01, #e5e5e5);
-  border: none;
-  box-shadow: none;
-  pointer-events: none;
-  width: 9.375rem;
-}
-
-.bx--btn.bx--skeleton:hover, .bx--btn.bx--skeleton:focus, .bx--btn.bx--skeleton:active {
-  border: none;
-  outline: none;
-  cursor: default;
-}
-
-.bx--btn.bx--skeleton::before {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background: var(--cds-skeleton-02, #c6c6c6);
-  animation: 3000ms ease-in-out skeleton infinite;
-  content: '';
-  will-change: transform-origin, transform, opacity;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bx--btn.bx--skeleton::before {
-    animation: none;
-  }
-}
-
-.bx--btn-set {
-  display: flex;
-}
-
-.bx--btn-set--stacked {
-  flex-direction: column;
-}
-
-.bx--btn-set .bx--btn {
-  width: 100%;
-  max-width: 12.25rem;
-}
-
-.bx--btn-set .bx--btn:not(:focus) {
-  box-shadow: -0.0625rem 0 0 0 var(--cds-button-separator, #e0e0e0);
-}
-
-.bx--btn-set .bx--btn:first-of-type:not(:focus) {
-  box-shadow: inherit;
-}
-
-.bx--btn-set .bx--btn:focus + .bx--btn {
-  box-shadow: inherit;
-}
-
-.bx--btn-set--stacked .bx--btn:not(:focus) {
-  box-shadow: 0 -0.0625rem 0 0 var(--cds-button-separator, #e0e0e0);
-}
-
-.bx--btn-set--stacked .bx--btn:first-of-type:not(:focus) {
-  box-shadow: inherit;
-}
-
-.bx--btn-set .bx--btn.bx--btn--disabled {
-  box-shadow: -0.0625rem 0 0 0 var(--cds-disabled-03, #8d8d8d);
-}
-
-.bx--btn-set .bx--btn.bx--btn--disabled:first-of-type {
-  box-shadow: none;
-}
-
-.bx--btn-set--stacked .bx--btn.bx--btn--disabled {
-  box-shadow: 0 -0.0625rem 0 0 var(--cds-disabled-03, #8d8d8d);
-}
-
-.bx--btn-set--stacked .bx--btn.bx--btn--disabled:first-of-type {
-  box-shadow: none;
 }
 
 .bx--modal {
@@ -2190,7 +3173,7 @@ a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
     margin: 0;
     padding: var(--cds-spacing-04, 0.75rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-03, 0.5rem);
     line-height: inherit;
-    border-bottom: 2px solid var(--cds-ui-03, #e0e0e0);
+    border-bottom: 2px solid #e0e0e0;
   }
   a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
     width: 10rem;
@@ -2216,7 +3199,7 @@ a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
   .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
 .bx--tabs__nav-link {
     color: var(--cds-text-01, #161616);
-    border-bottom: 2px solid var(--cds-ui-04, #8d8d8d);
+    border-bottom: 2px solid #8d8d8d;
   }
 }
 
@@ -2229,19 +3212,19 @@ a.bx--tabs__nav-link:focus, a.bx--tabs__nav-link:active {
 }
 
 .bx--tabs__nav-item--disabled .bx--tabs__nav-link {
-  color: var(--cds-disabled-02, #c6c6c6);
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  color: #c6c6c6;
+  border-bottom: 2px solid #f4f4f4;
   pointer-events: none;
 }
 
 .bx--tabs__nav-item--disabled:hover .bx--tabs__nav-link {
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  border-bottom: 2px solid #f4f4f4;
   cursor: no-drop;
 }
 
 .bx--tabs__nav-item--disabled .bx--tabs__nav-link:focus,
 .bx--tabs__nav-item--disabled a.bx--tabs__nav-link:active {
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  border-bottom: 2px solid #f4f4f4;
   outline: none;
 }
 
@@ -2627,7 +3610,7 @@ a.bx--tabs__nav-link:active {
   text-align: left;
   text-decoration: none;
   text-overflow: ellipsis;
-  border-bottom: 2px solid var(--cds-ui-03, #e0e0e0);
+  border-bottom: 2px solid #e0e0e0;
   transition: border 70ms cubic-bezier(0.2, 0, 0.38, 0.9), outline 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
 }
 
@@ -2662,7 +3645,7 @@ a.bx--tabs__nav-link:active {
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-item:hover
 .bx--tabs--scrollable__nav-link {
   color: var(--cds-text-01, #161616);
-  border-bottom: 2px solid var(--cds-ui-04, #8d8d8d);
+  border-bottom: 2px solid #8d8d8d;
 }
 
 .bx--tabs--scrollable.bx--tabs--scrollable--container .bx--tabs--scrollable__nav-item
@@ -2672,14 +3655,14 @@ a.bx--tabs__nav-link:active {
 
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled
 .bx--tabs--scrollable__nav-link {
-  color: var(--cds-disabled-02, #c6c6c6);
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  color: #c6c6c6;
+  border-bottom: 2px solid #f4f4f4;
 }
 
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled:hover
 .bx--tabs--scrollable__nav-link {
-  color: var(--cds-disabled-02, #c6c6c6);
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  color: #c6c6c6;
+  border-bottom: 2px solid #f4f4f4;
   cursor: not-allowed;
   pointer-events: none;
 }
@@ -2688,7 +3671,7 @@ a.bx--tabs__nav-link:active {
 .bx--tabs--scrollable__nav-link:focus,
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-item--disabled
 .bx--tabs--scrollable__nav-link:active {
-  border-bottom: 2px solid var(--cds-disabled-01, #f4f4f4);
+  border-bottom: 2px solid #f4f4f4;
   outline: none;
 }
 
@@ -2812,15 +3795,11 @@ a.bx--tabs__nav-link:active {
   clip: rect(0, 0, 0, 0);
 }
 
-.exp--about-modal {
-  background-color: var(--cds-ui-background, #ffffff);
-}
-
 .exp--about-modal .bx--modal-container {
   grid-template-rows: auto auto 1fr auto;
 }
 
-.exp--about-modal__logo {
+.exp--about-modal .exp--about-modal__logo {
   margin: var(--cds-spacing-05, 1rem);
 }
 
@@ -5550,6 +6529,335 @@ svg {
   margin: 0 var(--cds-spacing-02, 0.25rem);
 }
 
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+.bx--loading {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-size: 100%;
+  font-family: inherit;
+  vertical-align: baseline;
+  border: 0;
+  animation-name: rotate;
+  animation-duration: 690ms;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-fill-mode: forwards;
+  width: 5.5rem;
+  height: 5.5rem;
+}
+
+.bx--loading *,
+.bx--loading *::before,
+.bx--loading *::after {
+  box-sizing: inherit;
+}
+
+.bx--loading svg circle {
+  animation-name: init-stroke;
+  animation-duration: 10ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.bx--loading__svg {
+  fill: transparent;
+}
+
+.bx--loading__svg circle {
+  stroke-width: 10;
+  stroke-linecap: butt;
+  stroke-dasharray: 240;
+}
+
+.bx--loading__stroke {
+  stroke: var(--cds-interactive-04, #0f62fe);
+  stroke-dashoffset: 16;
+}
+
+.bx--loading--small .bx--loading__stroke {
+  stroke-dashoffset: 110;
+}
+
+.bx--loading--stop {
+  animation: rotate-end-p1 700ms cubic-bezier(0.2, 0, 1, 0.9) forwards, rotate-end-p2 700ms cubic-bezier(0.2, 0, 1, 0.9) 700ms forwards;
+}
+
+.bx--loading--stop svg circle {
+  animation-name: stroke-end;
+  animation-duration: 700ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 1, 0.9);
+  animation-delay: 700ms;
+  animation-fill-mode: forwards;
+}
+
+.bx--loading--small {
+  width: 1rem;
+  height: 1rem;
+}
+
+.bx--loading--small circle {
+  stroke-width: 16;
+}
+
+.bx--loading--small .bx--loading__svg {
+  stroke: var(--cds-interactive-04, #0f62fe);
+}
+
+.bx--loading__background {
+  stroke: var(--cds-ui-03, #e0e0e0);
+  stroke-dashoffset: -22;
+}
+
+@media not all and (min-resolution: 0.001dpcm) {
+  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+    circle.bx--loading__background {
+      stroke-dashoffset: 0;
+      stroke-dasharray: 265;
+    }
+  }
+}
+
+.bx--loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 6000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
+  transition: background-color 720ms cubic-bezier(0.4, 0.14, 0.3, 1);
+}
+
+.bx--loading-overlay--stop {
+  display: none;
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+.bx--inline-loading {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 2rem;
+}
+
+.bx--inline-loading .bx--loading__svg circle {
+  stroke-width: 12;
+}
+
+.bx--inline-loading .bx--loading__stroke {
+  stroke-dashoffset: 110;
+}
+
+.bx--inline-loading__text {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  color: var(--cds-text-02, #525252);
+}
+
+.bx--inline-loading__animation {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+}
+
+.bx--inline-loading__checkmark-container {
+  fill: var(--cds-support-02, #24a148);
+}
+
+.bx--inline-loading__checkmark-container.bx--inline-loading__svg {
+  position: absolute;
+  top: 0.75rem;
+  width: 0.75rem;
+}
+
+.bx--inline-loading__checkmark-container[hidden] {
+  display: none;
+}
+
+.bx--inline-loading__checkmark {
+  transform-origin: 50% 50%;
+  animation-name: stroke;
+  animation-duration: 250ms;
+  animation-fill-mode: forwards;
+  fill: none;
+  stroke: var(--cds-interactive-04, #0f62fe);
+  stroke-width: 1.8;
+  stroke-dasharray: 12;
+  stroke-dashoffset: 12;
+}
+
+.bx--inline-loading--error {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.bx--inline-loading--error[hidden] {
+  display: none;
+}
+
+.bx--loading--small .bx--inline-loading__svg {
+  stroke: var(--cds-interactive-04, #0f62fe);
+}
+
+/* If IE11 Don't show check animation */
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  .bx--inline-loading__checkmark-container {
+    top: 1px;
+    right: 0.5rem;
+  }
+  .bx--inline-loading__checkmark {
+    animation: none;
+    stroke-dashoffset: 0;
+    stroke-dasharray: 0;
+  }
+}
+
+.exp--action-set {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.exp--action-set.exp--action-set--xs {
+  flex-direction: column;
+}
+
+.exp--action-set.exp--action-set--xs.exp--action-set--triple-plus .exp--action-set__action-button,
+.exp--action-set.exp--action-set--xs.exp--action-set--double .exp--action-set__action-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp--action-set.exp--action-set--sm {
+  flex-direction: column;
+}
+
+.exp--action-set.exp--action-set--sm.exp--action-set--triple-plus .exp--action-set__action-button,
+.exp--action-set.exp--action-set--sm.exp--action-set--double .exp--action-set__action-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp--action-set.exp--action-set--md {
+  flex-direction: row;
+}
+
+.exp--action-set.exp--action-set--md.exp--action-set--triple-plus {
+  flex-direction: column;
+}
+
+.exp--action-set.exp--action-set--md.exp--action-set--triple-plus .exp--action-set__action-button {
+  width: 100%;
+}
+
+.exp--action-set.exp--action-set--lg.exp--action-set--triple-plus .exp--action-set__action-button.exp--action-set__ghost-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp--action-set.exp--action-set--lg.exp--action-set--single .exp--action-set__action-button.exp--action-set__ghost-button {
+  width: 100%;
+  max-width: 100%;
+}
+
+.exp--action-set.exp--action-set__actions--max.exp--action-set--triple-plus .exp--action-set__action-button.exp--action-set__ghost-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp--action-set.exp--action-set__actions--max.exp--action-set--single {
+  justify-content: flex-start;
+}
+
+.exp--action-set .exp--action-set__action-button {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+}
+
+.exp--action-set.exp--action-set--double .exp--action-set__action-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp--action-set.exp--action-set--single.exp--action-set--lg
+.exp--action-set__action-button,
+.exp--action-set.exp--action-set--double.exp--action-set--lg
+.exp--action-set__action-button {
+  width: 50%;
+  max-width: 50%;
+}
+
+.exp--action-set.exp--action-set--triple-plus.exp--action-set--lg
+.exp--action-set__action-button,
+.exp--action-set.exp--action-set--max .exp--action-set__action-button {
+  width: 25%;
+  max-width: 25%;
+}
+
+.exp--action-set .exp--action-set__action-button .bx--inline-loading {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: var(--cds-spacing-07, 2rem);
+}
+
 .bx--breadcrumb {
   box-sizing: border-box;
   margin: 0;
@@ -5659,32 +6967,32 @@ svg {
   }
 }
 
-.exp-breadcrumb-with-overflow {
+.exp--breadcrumb-with-overflow {
   display: block;
 }
 
-.exp-breadcrumb-with-overflow--space {
+.exp--breadcrumb-with-overflow--space {
   position: relative;
   display: block;
   width: 100%;
   white-space: nowrap;
 }
 
-.exp-breadcrumb-with-overflow--space--right {
+.exp--breadcrumb-with-overflow--space--right {
   text-align: end;
 }
 
-.exp-breadcrumb-with-overflow--breadcrumb-container {
+.exp--breadcrumb-with-overflow--breadcrumb-container {
   display: inline-flex;
   width: 100%;
 }
 
-.exp-breadcrumb-with-overflow--breadcrumb-container .bx--breadcrumb {
+.exp--breadcrumb-with-overflow--breadcrumb-container .bx--breadcrumb {
   flex-wrap: nowrap;
   width: 100%;
 }
 
-.exp-breadcrumb-with-overflow--breadcrumb-container--hidden {
+.exp--breadcrumb-with-overflow--breadcrumb-container--hidden {
   position: absolute;
   top: -100vh;
   left: -100vw;
@@ -5698,6 +7006,7 @@ svg {
   position: relative;
   width: 1.25rem;
   height: 1.25rem;
+  margin-top: calc(-1 * var(--cds-spacing-02, 0.25rem));
 }
 
 .bx--breadcrumb-item .bx--overflow-menu:focus {
@@ -5717,6 +7026,10 @@ svg {
   opacity: 0;
   transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
   content: '';
+}
+
+.bx--breadcrumb-item {
+  display: inline-flex;
 }
 
 .bx--breadcrumb-item .bx--overflow-menu:hover::after {
@@ -5757,991 +7070,8 @@ svg {
   border-left: 0.4375rem solid transparent;
 }
 
-.exp-breadcrumb-with-overflow--displayed-breadcrumb {
+.exp--breadcrumb-with-overflow--displayed-breadcrumb {
   overflow: hidden;
-}
-
-@keyframes hide-feedback {
-  0% {
-    visibility: inherit;
-    opacity: 1;
-  }
-  100% {
-    visibility: hidden;
-    opacity: 0;
-  }
-}
-
-@keyframes show-feedback {
-  0% {
-    visibility: hidden;
-    opacity: 0;
-  }
-  100% {
-    visibility: inherit;
-    opacity: 1;
-  }
-}
-
-.bx--snippet {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-}
-
-.bx--snippet *,
-.bx--snippet *::before,
-.bx--snippet *::after {
-  box-sizing: inherit;
-}
-
-.bx--snippet--disabled,
-.bx--snippet--disabled
-.bx--btn.bx--snippet-btn--expand {
-  color: var(--cds-disabled-02, #c6c6c6);
-  background-color: var(--cds-disabled-01, #f4f4f4);
-}
-
-.bx--snippet--disabled .bx--snippet-btn--expand:hover,
-.bx--snippet--disabled .bx--copy-btn:hover {
-  color: var(--cds-disabled-02, #c6c6c6);
-  background-color: var(--cds-disabled-01, #f4f4f4);
-  cursor: not-allowed;
-}
-
-.bx--snippet--disabled .bx--snippet__icon,
-.bx--snippet--disabled
-.bx--snippet-btn--expand
-.bx--icon-chevron--down {
-  fill: var(--cds-disabled-02, #c6c6c6);
-}
-
-.bx--snippet code {
-  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
-  font-size: var(--cds-code-01-font-size, 0.75rem);
-  font-weight: var(--cds-code-01-font-weight, 400);
-  line-height: var(--cds-code-01-line-height, 1.34);
-  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
-}
-
-.bx--snippet--inline {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  position: relative;
-  display: inline;
-  padding: 0;
-  color: var(--cds-text-01, #161616);
-  background-color: var(--cds-field-01, #f4f4f4);
-  border: 2px solid transparent;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.bx--snippet--inline *,
-.bx--snippet--inline *::before,
-.bx--snippet--inline *::after {
-  box-sizing: inherit;
-}
-
-.bx--snippet--inline:hover {
-  background-color: var(--cds-ui-03, #e0e0e0);
-}
-
-.bx--snippet--inline:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--snippet--inline:focus {
-  border: 2px solid var(--cds-focus, #0f62fe);
-  outline: none;
-}
-
-@media screen and (prefers-contrast) {
-  .bx--snippet--inline:focus {
-    border-style: dotted;
-  }
-}
-
-.bx--snippet--inline::before {
-  position: absolute;
-  z-index: 6000;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  content: '';
-  display: none;
-}
-
-.bx--snippet--inline .bx--copy-btn__feedback {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  width: max-content;
-  min-width: 1.5rem;
-  max-width: 13rem;
-  height: auto;
-  padding: 0.1875rem 1rem;
-  color: var(--cds-inverse-01, #ffffff);
-  font-weight: 400;
-  text-align: left;
-  background-color: var(--cds-inverse-02, #393939);
-  border-radius: 0.125rem;
-  transform: translateX(-50%);
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  display: none;
-  box-sizing: content-box;
-  margin: auto;
-  overflow: visible;
-  clip: auto;
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--snippet--inline .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@supports (-ms-accelerator: true) {
-  .bx--snippet--inline .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@supports (-ms-ime-align: auto) {
-  .bx--snippet--inline .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--snippet--inline .bx--copy-btn__feedback {
-    border: 1px solid transparent;
-  }
-}
-
-.bx--snippet--inline::before, .bx--snippet--inline::after,
-.bx--snippet--inline .bx--assistive-text,
-.bx--snippet--inline + .bx--assistive-text {
-  bottom: 0;
-  left: 50%;
-}
-
-.bx--snippet--inline::before {
-  bottom: -0.5rem;
-  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
-  border-width: 0 0.25rem 0.3125rem 0.25rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--snippet--inline::after,
-.bx--snippet--inline .bx--assistive-text,
-.bx--snippet--inline + .bx--assistive-text {
-  bottom: -0.8125rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--snippet--inline.bx--copy-btn--animating::before,
-.bx--snippet--inline.bx--copy-btn--animating
-.bx--copy-btn__feedback {
-  display: block;
-}
-
-.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
-.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-out
-.bx--copy-btn__feedback {
-  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
-}
-
-.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
-.bx--snippet--inline.bx--copy-btn--animating.bx--copy-btn--fade-in
-.bx--copy-btn__feedback {
-  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
-}
-
-.bx--snippet--inline code {
-  padding: 0 var(--cds-spacing-03, 0.5rem);
-}
-
-.bx--snippet--inline.bx--snippet--no-copy {
-  display: inline-block;
-}
-
-.bx--snippet--inline.bx--snippet--no-copy:hover {
-  background-color: var(--cds-field-01, #f4f4f4);
-  cursor: auto;
-}
-
-.bx--snippet--light.bx--snippet--inline.bx--snippet--no-copy:hover {
-  background-color: var(--cds-field-02, #ffffff);
-  cursor: auto;
-}
-
-.bx--snippet--single {
-  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
-  font-size: var(--cds-code-01-font-size, 0.75rem);
-  font-weight: var(--cds-code-01-font-weight, 400);
-  line-height: var(--cds-code-01-line-height, 1.34);
-  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
-  position: relative;
-  width: 100%;
-  max-width: 37.5rem;
-  background-color: var(--cds-field-01, #f4f4f4);
-  display: flex;
-  align-items: center;
-  max-width: 47.5rem;
-  height: 2.5rem;
-  padding-right: 2.5rem;
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--snippet--single {
-    outline: 2px solid transparent;
-  }
-}
-
-.bx--snippet--single.bx--snippet--no-copy {
-  padding: 0;
-}
-
-.bx--snippet--single.bx--snippet--no-copy::after {
-  right: 1rem;
-}
-
-.bx--snippet--single .bx--snippet-container {
-  position: relative;
-  display: flex;
-  align-items: center;
-  height: 100%;
-  padding-left: 1rem;
-  overflow-x: auto;
-}
-
-.bx--snippet--single .bx--snippet-container:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-}
-
-@media screen and (prefers-contrast) {
-  .bx--snippet--single .bx--snippet-container:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--snippet--single pre {
-  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
-  font-size: var(--cds-code-01-font-size, 0.75rem);
-  font-weight: var(--cds-code-01-font-weight, 400);
-  line-height: var(--cds-code-01-line-height, 1.34);
-  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
-  padding-right: var(--cds-spacing-03, 0.5rem);
-}
-
-.bx--snippet--single pre,
-.bx--snippet--inline code {
-  white-space: pre;
-}
-
-.bx--snippet--multi {
-  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
-  font-size: var(--cds-code-01-font-size, 0.75rem);
-  font-weight: var(--cds-code-01-font-weight, 400);
-  line-height: var(--cds-code-01-line-height, 1.34);
-  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
-  position: relative;
-  width: 100%;
-  max-width: 37.5rem;
-  background-color: var(--cds-field-01, #f4f4f4);
-  display: flex;
-  max-width: 100%;
-  padding: 1rem;
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--snippet--multi {
-    outline: 2px solid transparent;
-  }
-}
-
-.bx--snippet--multi .bx--snippet-container {
-  position: relative;
-  order: 1;
-  min-height: 3.5rem;
-  max-height: 14.875rem;
-  overflow: hidden;
-  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--snippet--multi.bx--snippet--expand
-.bx--snippet-container {
-  max-height: 100%;
-  padding-bottom: var(--cds-spacing-05, 1rem);
-  transition: max-height 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--snippet--multi.bx--snippet--wraptext pre {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-.bx--snippet--multi .bx--snippet-container pre {
-  padding-right: 2.5rem;
-  padding-bottom: 1.5rem;
-  overflow-x: auto;
-}
-
-.bx--snippet--multi.bx--snippet--no-copy
-.bx--snippet-container
-pre {
-  padding-right: 0;
-}
-
-.bx--snippet--multi.bx--snippet--expand
-.bx--snippet-container
-pre {
-  overflow-x: auto;
-}
-
-.bx--snippet--multi .bx--snippet-container pre::after {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 1rem;
-  height: 100%;
-  background-image: linear-gradient(to right, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
-  content: '';
-}
-
-.bx--snippet--multi .bx--snippet-container pre code {
-  overflow: hidden;
-}
-
-.bx--snippet__icon {
-  width: 1rem;
-  height: 1rem;
-  transition: all 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-  fill: var(--cds-icon-01, #161616);
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--snippet__icon {
-    fill: ButtonText;
-  }
-}
-
-.bx--snippet-button {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  overflow: visible;
-  background-color: var(--cds-field-01, #f4f4f4);
-  border: none;
-  outline: none;
-  cursor: pointer;
-}
-
-.bx--snippet-button *,
-.bx--snippet-button *::before,
-.bx--snippet-button *::after {
-  box-sizing: inherit;
-}
-
-.bx--snippet-button:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-  outline-color: var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--snippet-button:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--snippet--multi .bx--snippet-button {
-  top: var(--cds-spacing-03, 0.5rem);
-  right: var(--cds-spacing-03, 0.5rem);
-  width: 2rem;
-  height: 2rem;
-}
-
-.bx--snippet-button:hover {
-  background: var(--cds-hover-ui, #e5e5e5);
-}
-
-.bx--snippet-button:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--btn--copy__feedback {
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-  top: 0.75rem;
-  right: 1.25rem;
-  left: inherit;
-  z-index: 6000;
-  font-weight: 400;
-}
-
-.bx--btn--copy__feedback::before,
-.bx--btn--copy__feedback::after {
-  background: var(--cds-inverse-02, #393939);
-}
-
-.bx--btn--copy__feedback::after {
-  border: none;
-}
-
-.bx--snippet .bx--copy-btn {
-  position: absolute;
-  top: 0;
-  right: 0;
-  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-}
-
-.bx--snippet-btn--expand {
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  font-family: 'IBM Plex Sans', 'Helvetica Neue', Arial, sans-serif;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  z-index: 10;
-  display: inline-flex;
-  align-items: center;
-  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
-  color: var(--cds-text-01, #161616);
-  background-color: var(--cds-field-01, #f4f4f4);
-  border: 0;
-}
-
-.bx--snippet-btn--expand .bx--snippet-btn--text {
-  position: relative;
-  top: -0.0625rem;
-}
-
-.bx--snippet-btn--expand--hide.bx--snippet-btn--expand {
-  display: none;
-}
-
-.bx--snippet-btn--expand .bx--icon-chevron--down {
-  margin-left: var(--cds-spacing-03, 0.5rem);
-  transform: rotate(0deg);
-  transition: 150ms cubic-bezier(0.2, 0, 0.38, 0.9);
-  fill: var(--cds-text-01, #161616);
-}
-
-.bx--snippet-btn--expand:hover {
-  color: var(--cds-text-01, #161616);
-  background: var(--cds-hover-ui, #e5e5e5);
-}
-
-.bx--snippet-btn--expand:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--snippet-btn--expand:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-  border-color: transparent;
-}
-
-@media screen and (prefers-contrast) {
-  .bx--snippet-btn--expand:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--snippet--expand
-.bx--snippet-btn--expand
-.bx--icon-chevron--down {
-  transform: rotate(180deg);
-  transition: transform 240ms;
-}
-
-.bx--snippet--light,
-.bx--snippet--light .bx--snippet-button,
-.bx--snippet--light .bx--btn.bx--snippet-btn--expand,
-.bx--snippet--light .bx--copy-btn {
-  background-color: var(--cds-field-02, #ffffff);
-}
-
-.bx--snippet--light.bx--snippet--inline:hover,
-.bx--snippet--light .bx--snippet-button:hover,
-.bx--snippet--light
-.bx--btn.bx--snippet-btn--expand:hover,
-.bx--snippet--light .bx--copy-btn:hover {
-  background-color: var(--cds-hover-light-ui, #e5e5e5);
-}
-
-.bx--snippet--light.bx--snippet--inline:active,
-.bx--snippet--light .bx--snippet-button:active,
-.bx--snippet--light
-.bx--btn.bx--snippet-btn--expand:active,
-.bx--snippet--light .bx--copy-btn:active {
-  background-color: var(--cds-active-light-ui, #c6c6c6);
-}
-
-.bx--snippet--light.bx--snippet--single::after,
-.bx--snippet--light.bx--snippet--multi
-.bx--snippet-container
-pre::after {
-  background-image: linear-gradient(to right, rgba(var(--cds-field-02, #ffffff), 0), var(--cds-field-02, #ffffff));
-}
-
-.bx--snippet--code.bx--skeleton {
-  height: 6.125rem;
-}
-
-.bx--snippet--terminal.bx--skeleton {
-  height: 3.5rem;
-}
-
-.bx--snippet.bx--skeleton .bx--snippet-container {
-  height: 100%;
-}
-
-.bx--snippet.bx--skeleton code {
-  position: relative;
-  padding: 0;
-  background: var(--cds-skeleton-01, #e5e5e5);
-  border: none;
-  box-shadow: none;
-  pointer-events: none;
-  display: block;
-  width: 100%;
-  height: 1rem;
-}
-
-.bx--snippet.bx--skeleton code:hover, .bx--snippet.bx--skeleton code:focus, .bx--snippet.bx--skeleton code:active {
-  border: none;
-  outline: none;
-  cursor: default;
-}
-
-.bx--snippet.bx--skeleton code::before {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background: var(--cds-skeleton-02, #c6c6c6);
-  animation: 3000ms ease-in-out skeleton infinite;
-  content: '';
-  will-change: transform-origin, transform, opacity;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bx--snippet.bx--skeleton code::before {
-    animation: none;
-  }
-}
-
-.bx--snippet-button .bx--btn--copy__feedback {
-  top: 3.175rem;
-  right: auto;
-  left: 50%;
-}
-
-.bx--snippet-button .bx--btn--copy__feedback::before {
-  top: 0;
-}
-
-.bx--snippet-button .bx--btn--copy__feedback::after {
-  top: -0.25rem;
-}
-
-.bx--snippet--multi .bx--copy-btn {
-  top: 0.5rem;
-  right: 0.5rem;
-  z-index: 10;
-  width: 2rem;
-  height: 2rem;
-}
-
-.bx--snippet--multi
-.bx--snippet-button
-.bx--btn--copy__feedback {
-  top: 2.675rem;
-}
-
-.bx--snippet--inline .bx--btn--copy__feedback {
-  top: calc(100% - 0.25rem);
-  right: auto;
-  left: 50%;
-}
-
-.bx--snippet__overflow-indicator--left,
-.bx--snippet__overflow-indicator--right {
-  z-index: 1;
-  flex: 1 0 auto;
-  width: 1rem;
-}
-
-.bx--snippet__overflow-indicator--left {
-  order: 0;
-  margin-right: -1rem;
-  background-image: linear-gradient(to left, transparent, var(--cds-field-01, #f4f4f4));
-}
-
-.bx--snippet__overflow-indicator--right {
-  order: 2;
-  margin-left: -1rem;
-  background-image: linear-gradient(to right, transparent, var(--cds-field-01, #f4f4f4));
-}
-
-.bx--snippet--single .bx--snippet__overflow-indicator--right,
-.bx--snippet--single .bx--snippet__overflow-indicator--left {
-  position: absolute;
-  width: 2rem;
-  height: calc(100% - 0.25rem);
-}
-
-.bx--snippet--single .bx--snippet__overflow-indicator--right {
-  right: 2.5rem;
-}
-
-.bx--snippet--single
-.bx--snippet-container:focus
-~ .bx--snippet__overflow-indicator--right {
-  right: calc(2.5rem + 0.125rem);
-}
-
-.bx--snippet--single
-.bx--snippet-container:focus
-+ .bx--snippet__overflow-indicator--left {
-  left: 0.125rem;
-}
-
-.bx--snippet--light .bx--snippet__overflow-indicator--left {
-  background-image: linear-gradient(to left, transparent, var(--cds-field-02, #ffffff));
-}
-
-.bx--snippet--light .bx--snippet__overflow-indicator--right {
-  background-image: linear-gradient(to right, transparent, var(--cds-field-02, #ffffff));
-}
-
-@media not all and (min-resolution: 0.001dpcm) {
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-    .bx--snippet__overflow-indicator--left {
-      background-image: linear-gradient(to left, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
-    }
-    .bx--snippet__overflow-indicator--right {
-      background-image: linear-gradient(to right, rgba(var(--cds-field-01, #f4f4f4), 0), var(--cds-field-01, #f4f4f4));
-    }
-  }
-}
-
-bx--snippet--multi.bx--skeleton {
-  height: 6.125rem;
-}
-
-.bx--snippet--single.bx--skeleton {
-  height: 3.5rem;
-}
-
-.bx--snippet.bx--skeleton span {
-  position: relative;
-  padding: 0;
-  background: var(--cds-skeleton-01, #e5e5e5);
-  border: none;
-  box-shadow: none;
-  pointer-events: none;
-  display: block;
-  width: 100%;
-  height: 1rem;
-  margin-top: 0.5rem;
-}
-
-.bx--snippet.bx--skeleton span:hover, .bx--snippet.bx--skeleton span:focus, .bx--snippet.bx--skeleton span:active {
-  border: none;
-  outline: none;
-  cursor: default;
-}
-
-.bx--snippet.bx--skeleton span::before {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background: var(--cds-skeleton-02, #c6c6c6);
-  animation: 3000ms ease-in-out skeleton infinite;
-  content: '';
-  will-change: transform-origin, transform, opacity;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bx--snippet.bx--skeleton span::before {
-    animation: none;
-  }
-}
-
-.bx--snippet.bx--skeleton span:first-child {
-  margin: 0;
-}
-
-.bx--snippet.bx--skeleton span:nth-child(2) {
-  width: 85%;
-}
-
-.bx--snippet.bx--skeleton span:nth-child(3) {
-  width: 95%;
-}
-
-.bx--snippet--single.bx--skeleton
-.bx--snippet-container {
-  padding-bottom: 0;
-}
-
-@keyframes hide-feedback {
-  0% {
-    visibility: inherit;
-    opacity: 1;
-  }
-  100% {
-    visibility: hidden;
-    opacity: 0;
-  }
-}
-
-@keyframes show-feedback {
-  0% {
-    visibility: hidden;
-    opacity: 0;
-  }
-  100% {
-    visibility: inherit;
-    opacity: 1;
-  }
-}
-
-.bx--btn--copy {
-  position: relative;
-  overflow: visible;
-}
-
-.bx--btn--copy .bx--btn__icon {
-  margin-left: 0.3125rem;
-}
-
-.bx--btn--copy__feedback {
-  position: absolute;
-  top: 1.2rem;
-  left: 50%;
-  display: none;
-}
-
-.bx--btn--copy__feedback:focus {
-  border: 2px solid var(--cds-support-01, #da1e28);
-}
-
-.bx--btn--copy__feedback::before {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  top: 1.1rem;
-  z-index: 2;
-  padding: var(--cds-spacing-02, 0.25rem);
-  color: var(--cds-inverse-01, #ffffff);
-  font-weight: 400;
-  white-space: nowrap;
-  border-radius: 4px;
-  transform: translateX(-50%);
-  content: attr(data-feedback);
-  pointer-events: none;
-}
-
-.bx--btn--copy__feedback::after {
-  top: 0.85rem;
-  left: -0.3rem;
-  z-index: 1;
-  width: 0.6rem;
-  height: 0.6rem;
-  border-right: 1px solid var(--cds-inverse-02, #393939);
-  border-bottom: 1px solid var(--cds-inverse-02, #393939);
-  transform: rotate(-135deg);
-  content: '';
-}
-
-.bx--btn--copy__feedback::before, .bx--btn--copy__feedback::after {
-  position: absolute;
-  display: block;
-  background: var(--cds-inverse-02, #393939);
-}
-
-.bx--btn--copy__feedback--displayed {
-  display: inline-flex;
-}
-
-.bx--copy-btn {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  background-color: var(--cds-ui-01, #f4f4f4);
-  border: none;
-  cursor: pointer;
-}
-
-.bx--copy-btn *,
-.bx--copy-btn *::before,
-.bx--copy-btn *::after {
-  box-sizing: inherit;
-}
-
-.bx--copy-btn:hover {
-  background-color: var(--cds-hover-ui, #e5e5e5);
-}
-
-.bx--copy-btn:active {
-  background-color: var(--cds-active-ui, #c6c6c6);
-}
-
-.bx--copy-btn::before {
-  position: absolute;
-  z-index: 6000;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  content: '';
-  display: none;
-}
-
-.bx--copy-btn .bx--copy-btn__feedback {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  width: max-content;
-  min-width: 1.5rem;
-  max-width: 13rem;
-  height: auto;
-  padding: 0.1875rem 1rem;
-  color: var(--cds-inverse-01, #ffffff);
-  font-weight: 400;
-  text-align: left;
-  background-color: var(--cds-inverse-02, #393939);
-  border-radius: 0.125rem;
-  transform: translateX(-50%);
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  z-index: 3;
-  display: none;
-  box-sizing: content-box;
-  margin: auto;
-  overflow: visible;
-  clip: auto;
-}
-
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  .bx--copy-btn .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@supports (-ms-accelerator: true) {
-  .bx--copy-btn .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@supports (-ms-ime-align: auto) {
-  .bx--copy-btn .bx--copy-btn__feedback {
-    width: auto;
-  }
-}
-
-@media screen and (-ms-high-contrast: active), screen and (prefers-contrast) {
-  .bx--copy-btn .bx--copy-btn__feedback {
-    border: 1px solid transparent;
-  }
-}
-
-.bx--copy-btn::before, .bx--copy-btn::after,
-.bx--copy-btn .bx--assistive-text,
-.bx--copy-btn + .bx--assistive-text {
-  bottom: 0;
-  left: 50%;
-}
-
-.bx--copy-btn::before {
-  bottom: -0.5rem;
-  border-color: transparent transparent var(--cds-inverse-02, #393939) transparent;
-  border-width: 0 0.25rem 0.3125rem 0.25rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--copy-btn::after,
-.bx--copy-btn .bx--assistive-text,
-.bx--copy-btn + .bx--assistive-text {
-  bottom: -0.8125rem;
-  transform: translate(-50%, 100%);
-}
-
-.bx--copy-btn:focus {
-  outline: 2px solid var(--cds-focus, #0f62fe);
-  outline-offset: -2px;
-  outline-color: var(--cds-focus, #0f62fe);
-}
-
-@media screen and (prefers-contrast) {
-  .bx--copy-btn:focus {
-    outline-style: dotted;
-  }
-}
-
-.bx--copy-btn.bx--copy-btn--animating::before,
-.bx--copy-btn.bx--copy-btn--animating .bx--copy-btn__feedback {
-  display: block;
-}
-
-.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out::before,
-.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-out .bx--copy-btn__feedback {
-  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) hide-feedback;
-}
-
-.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in::before,
-.bx--copy-btn.bx--copy-btn--animating.bx--copy-btn--fade-in .bx--copy-btn__feedback {
-  animation: 110ms cubic-bezier(0.2, 0, 0.38, 0.9) show-feedback;
-}
-
-.bx--copy {
-  font-size: 0;
 }
 
 .exp--empty-state .exp--empty-state__header,
@@ -7104,111 +7434,6 @@ input:not(output):not([data-invalid]):-moz-ui-invalid {
   100% {
     stroke-dashoffset: 240;
   }
-}
-
-.bx--loading {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  font-size: 100%;
-  font-family: inherit;
-  vertical-align: baseline;
-  border: 0;
-  animation-name: rotate;
-  animation-duration: 690ms;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-  animation-fill-mode: forwards;
-  width: 5.5rem;
-  height: 5.5rem;
-}
-
-.bx--loading *,
-.bx--loading *::before,
-.bx--loading *::after {
-  box-sizing: inherit;
-}
-
-.bx--loading svg circle {
-  animation-name: init-stroke;
-  animation-duration: 10ms;
-  animation-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.bx--loading__svg {
-  fill: transparent;
-}
-
-.bx--loading__svg circle {
-  stroke-width: 10;
-  stroke-linecap: butt;
-  stroke-dasharray: 240;
-}
-
-.bx--loading__stroke {
-  stroke: var(--cds-interactive-04, #0f62fe);
-  stroke-dashoffset: 16;
-}
-
-.bx--loading--small .bx--loading__stroke {
-  stroke-dashoffset: 110;
-}
-
-.bx--loading--stop {
-  animation: rotate-end-p1 700ms cubic-bezier(0.2, 0, 1, 0.9) forwards, rotate-end-p2 700ms cubic-bezier(0.2, 0, 1, 0.9) 700ms forwards;
-}
-
-.bx--loading--stop svg circle {
-  animation-name: stroke-end;
-  animation-duration: 700ms;
-  animation-timing-function: cubic-bezier(0.2, 0, 1, 0.9);
-  animation-delay: 700ms;
-  animation-fill-mode: forwards;
-}
-
-.bx--loading--small {
-  width: 1rem;
-  height: 1rem;
-}
-
-.bx--loading--small circle {
-  stroke-width: 16;
-}
-
-.bx--loading--small .bx--loading__svg {
-  stroke: var(--cds-interactive-04, #0f62fe);
-}
-
-.bx--loading__background {
-  stroke: var(--cds-ui-03, #e0e0e0);
-  stroke-dashoffset: -22;
-}
-
-@media not all and (min-resolution: 0.001dpcm) {
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-    circle.bx--loading__background {
-      stroke-dashoffset: 0;
-      stroke-dasharray: 265;
-    }
-  }
-}
-
-.bx--loading-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 6000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
-  transition: background-color 720ms cubic-bezier(0.4, 0.14, 0.3, 1);
-}
-
-.bx--loading-overlay--stop {
-  display: none;
 }
 
 .bx--file {
@@ -8430,7 +8655,7 @@ svg:hover {
 .bx--toggle:disabled
 + .bx--toggle__label
 .bx--toggle__text--right {
-  color: var(--cds-disabled-02, #c6c6c6);
+  color: #c6c6c6;
 }
 
 .bx--toggle:disabled:active
@@ -8633,7 +8858,7 @@ svg:hover {
 }
 
 .bx--toggle-input:disabled + .bx--toggle-input__label {
-  color: var(--cds-disabled-02, #c6c6c6);
+  color: #c6c6c6;
   cursor: not-allowed;
 }
 
@@ -11282,1060 +11507,6 @@ svg:hover {
   height: 100%;
 }
 
-@keyframes rotate {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes rotate-end-p1 {
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes rotate-end-p2 {
-  100% {
-    transform: rotate(-360deg);
-  }
-}
-
-/* Stroke animations */
-@keyframes init-stroke {
-  0% {
-    stroke-dashoffset: 240;
-  }
-  100% {
-    stroke-dashoffset: 16;
-  }
-}
-
-@keyframes stroke-end {
-  0% {
-    stroke-dashoffset: 16;
-  }
-  100% {
-    stroke-dashoffset: 240;
-  }
-}
-
-@keyframes stroke {
-  100% {
-    stroke-dashoffset: 0;
-  }
-}
-
-.bx--inline-loading {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-height: 2rem;
-}
-
-.bx--inline-loading .bx--loading__svg circle {
-  stroke-width: 12;
-}
-
-.bx--inline-loading .bx--loading__stroke {
-  stroke-dashoffset: 110;
-}
-
-.bx--inline-loading__text {
-  font-size: var(--cds-label-01-font-size, 0.75rem);
-  font-weight: var(--cds-label-01-font-weight, 400);
-  line-height: var(--cds-label-01-line-height, 1.34);
-  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
-  color: var(--cds-text-02, #525252);
-}
-
-.bx--inline-loading__animation {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-}
-
-.bx--inline-loading__checkmark-container {
-  fill: var(--cds-support-02, #24a148);
-}
-
-.bx--inline-loading__checkmark-container.bx--inline-loading__svg {
-  position: absolute;
-  top: 0.75rem;
-  width: 0.75rem;
-}
-
-.bx--inline-loading__checkmark-container[hidden] {
-  display: none;
-}
-
-.bx--inline-loading__checkmark {
-  transform-origin: 50% 50%;
-  animation-name: stroke;
-  animation-duration: 250ms;
-  animation-fill-mode: forwards;
-  fill: none;
-  stroke: var(--cds-interactive-04, #0f62fe);
-  stroke-width: 1.8;
-  stroke-dasharray: 12;
-  stroke-dashoffset: 12;
-}
-
-.bx--inline-loading--error {
-  width: 1rem;
-  height: 1rem;
-  fill: var(--cds-support-01, #da1e28);
-}
-
-.bx--inline-loading--error[hidden] {
-  display: none;
-}
-
-.bx--loading--small .bx--inline-loading__svg {
-  stroke: var(--cds-interactive-04, #0f62fe);
-}
-
-/* If IE11 Don't show check animation */
-@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-  .bx--inline-loading__checkmark-container {
-    top: 1px;
-    right: 0.5rem;
-  }
-  .bx--inline-loading__checkmark {
-    animation: none;
-    stroke-dashoffset: 0;
-    stroke-dasharray: 0;
-  }
-}
-
-@keyframes sidePanelExitLeft {
-  0% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  100% {
-    transform: translateX(-30rem);
-    opacity: 0;
-  }
-}
-
-@keyframes sidePanelExitRight {
-  0% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  100% {
-    transform: translateX(30rem);
-    opacity: 0;
-  }
-}
-
-.exp-side-panel-container {
-  position: fixed;
-  top: var(--cds-spacing-09, 3rem);
-  z-index: 3;
-  box-sizing: border-box;
-  min-width: 30rem;
-  max-width: 30rem;
-  height: calc(100% - 3rem);
-  overflow: auto;
-  color: var(--cds-text-01, #161616);
-  background-color: var(--cds-ui-01, #f4f4f4);
-  transition: transform 240ms;
-  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
-.exp-side-panel-container.exp-side-panel-container-light {
-  --cds-interactive-01: #0f62fe;
-  --cds-interactive-02: #393939;
-  --cds-interactive-03: #0f62fe;
-  --cds-interactive-04: #0f62fe;
-  --cds-ui-background: #f4f4f4;
-  --cds-ui-01: #ffffff;
-  --cds-ui-02: #f4f4f4;
-  --cds-ui-03: #e0e0e0;
-  --cds-ui-04: #8d8d8d;
-  --cds-ui-05: #161616;
-  --cds-text-01: #161616;
-  --cds-text-02: #525252;
-  --cds-text-03: #a8a8a8;
-  --cds-text-04: #ffffff;
-  --cds-text-05: #6f6f6f;
-  --cds-text-error: #da1e28;
-  --cds-icon-01: #161616;
-  --cds-icon-02: #525252;
-  --cds-icon-03: #ffffff;
-  --cds-link-01: #0f62fe;
-  --cds-link-02: #0043ce;
-  --cds-inverse-link: #78a9ff;
-  --cds-field-01: #ffffff;
-  --cds-field-02: #f4f4f4;
-  --cds-inverse-01: #ffffff;
-  --cds-inverse-02: #393939;
-  --cds-support-01: #da1e28;
-  --cds-support-02: #24a148;
-  --cds-support-03: #f1c21b;
-  --cds-support-04: #0043ce;
-  --cds-inverse-support-01: #fa4d56;
-  --cds-inverse-support-02: #42be65;
-  --cds-inverse-support-03: #f1c21b;
-  --cds-inverse-support-04: #4589ff;
-  --cds-overlay-01: rgba(22, 22, 22, 0.5);
-  --cds-danger-01: #da1e28;
-  --cds-danger-02: #da1e28;
-  --cds-focus: #0f62fe;
-  --cds-inverse-focus-ui: #ffffff;
-  --cds-hover-primary: #0353e9;
-  --cds-active-primary: #002d9c;
-  --cds-hover-primary-text: #0043ce;
-  --cds-hover-secondary: #4c4c4c;
-  --cds-active-secondary: #6f6f6f;
-  --cds-hover-tertiary: #0353e9;
-  --cds-active-tertiary: #002d9c;
-  --cds-hover-ui: #e5e5e5;
-  --cds-hover-light-ui: #e5e5e5;
-  --cds-hover-selected-ui: #cacaca;
-  --cds-active-ui: #c6c6c6;
-  --cds-active-light-ui: #c6c6c6;
-  --cds-selected-ui: #e0e0e0;
-  --cds-selected-light-ui: #e0e0e0;
-  --cds-inverse-hover-ui: #4c4c4c;
-  --cds-hover-danger: #b81921;
-  --cds-active-danger: #750e13;
-  --cds-hover-row: #e5e5e5;
-  --cds-visited-link: #8a3ffc;
-  --cds-disabled-01: #ffffff;
-  --cds-disabled-02: #c6c6c6;
-  --cds-disabled-03: #8d8d8d;
-  --cds-highlight: #edf5ff;
-  --cds-decorative-01: #e0e0e0;
-  --cds-button-separator: #e0e0e0;
-  --cds-skeleton-01: #e5e5e5;
-  --cds-skeleton-02: #c6c6c6;
-  --cds-brand-01: #0f62fe;
-  --cds-brand-02: #393939;
-  --cds-brand-03: #0f62fe;
-  --cds-active-01: #c6c6c6;
-  --cds-hover-field: #e5e5e5;
-  --cds-danger: #da1e28;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.34;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-label-01-font-size: 0.75rem;
-  --cds-label-01-font-weight: 400;
-  --cds-label-01-line-height: 1.34;
-  --cds-label-01-letter-spacing: 0.32px;
-  --cds-helper-text-01-font-size: 0.75rem;
-  --cds-helper-text-01-line-height: 1.34;
-  --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-body-short-01-font-size: 0.875rem;
-  --cds-body-short-01-font-weight: 400;
-  --cds-body-short-01-line-height: 1.29;
-  --cds-body-short-01-letter-spacing: 0.16px;
-  --cds-body-long-01-font-size: 0.875rem;
-  --cds-body-long-01-font-weight: 400;
-  --cds-body-long-01-line-height: 1.43;
-  --cds-body-long-01-letter-spacing: 0.16px;
-  --cds-body-short-02-font-size: 1rem;
-  --cds-body-short-02-font-weight: 400;
-  --cds-body-short-02-line-height: 1.375;
-  --cds-body-short-02-letter-spacing: 0;
-  --cds-body-long-02-font-size: 1rem;
-  --cds-body-long-02-font-weight: 400;
-  --cds-body-long-02-line-height: 1.5;
-  --cds-body-long-02-letter-spacing: 0;
-  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-  --cds-code-01-font-size: 0.75rem;
-  --cds-code-01-font-weight: 400;
-  --cds-code-01-line-height: 1.34;
-  --cds-code-01-letter-spacing: 0.32px;
-  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-  --cds-code-02-font-size: 0.875rem;
-  --cds-code-02-font-weight: 400;
-  --cds-code-02-line-height: 1.43;
-  --cds-code-02-letter-spacing: 0.32px;
-  --cds-heading-01-font-size: 0.875rem;
-  --cds-heading-01-font-weight: 600;
-  --cds-heading-01-line-height: 1.29;
-  --cds-heading-01-letter-spacing: 0.16px;
-  --cds-productive-heading-01-font-size: 0.875rem;
-  --cds-productive-heading-01-font-weight: 600;
-  --cds-productive-heading-01-line-height: 1.29;
-  --cds-productive-heading-01-letter-spacing: 0.16px;
-  --cds-heading-02-font-size: 1rem;
-  --cds-heading-02-font-weight: 600;
-  --cds-heading-02-line-height: 1.375;
-  --cds-heading-02-letter-spacing: 0;
-  --cds-productive-heading-02-font-size: 1rem;
-  --cds-productive-heading-02-font-weight: 600;
-  --cds-productive-heading-02-line-height: 1.375;
-  --cds-productive-heading-02-letter-spacing: 0;
-  --cds-productive-heading-03-font-size: 1.25rem;
-  --cds-productive-heading-03-font-weight: 400;
-  --cds-productive-heading-03-line-height: 1.4;
-  --cds-productive-heading-03-letter-spacing: 0;
-  --cds-productive-heading-04-font-size: 1.75rem;
-  --cds-productive-heading-04-font-weight: 400;
-  --cds-productive-heading-04-line-height: 1.29;
-  --cds-productive-heading-04-letter-spacing: 0;
-  --cds-productive-heading-05-font-size: 2rem;
-  --cds-productive-heading-05-font-weight: 400;
-  --cds-productive-heading-05-line-height: 1.25;
-  --cds-productive-heading-05-letter-spacing: 0;
-  --cds-productive-heading-06-font-size: 2.625rem;
-  --cds-productive-heading-06-font-weight: 300;
-  --cds-productive-heading-06-line-height: 1.199;
-  --cds-productive-heading-06-letter-spacing: 0;
-  --cds-productive-heading-07-font-size: 3.375rem;
-  --cds-productive-heading-07-font-weight: 300;
-  --cds-productive-heading-07-line-height: 1.19;
-  --cds-productive-heading-07-letter-spacing: 0;
-  --cds-expressive-heading-01-font-size: 0.875rem;
-  --cds-expressive-heading-01-font-weight: 600;
-  --cds-expressive-heading-01-line-height: 1.25;
-  --cds-expressive-heading-01-letter-spacing: 0.16px;
-  --cds-expressive-heading-02-font-size: 1rem;
-  --cds-expressive-heading-02-font-weight: 600;
-  --cds-expressive-heading-02-line-height: 1.5;
-  --cds-expressive-heading-02-letter-spacing: 0;
-  --cds-expressive-heading-03-font-size: 1.25rem;
-  --cds-expressive-heading-03-font-weight: 400;
-  --cds-expressive-heading-03-line-height: 1.4;
-  --cds-expressive-heading-03-letter-spacing: 0;
-  --cds-expressive-heading-04-font-size: 1.75rem;
-  --cds-expressive-heading-04-font-weight: 400;
-  --cds-expressive-heading-04-line-height: 1.29;
-  --cds-expressive-heading-04-letter-spacing: 0;
-  --cds-expressive-heading-05-font-size: 2rem;
-  --cds-expressive-heading-05-font-weight: 400;
-  --cds-expressive-heading-05-line-height: 1.25;
-  --cds-expressive-heading-05-letter-spacing: 0;
-  --cds-expressive-heading-06-font-size: 2rem;
-  --cds-expressive-heading-06-font-weight: 600;
-  --cds-expressive-heading-06-line-height: 1.25;
-  --cds-expressive-heading-06-letter-spacing: 0;
-  --cds-expressive-paragraph-01-font-size: 1.5rem;
-  --cds-expressive-paragraph-01-font-weight: 300;
-  --cds-expressive-paragraph-01-line-height: 1.334;
-  --cds-expressive-paragraph-01-letter-spacing: 0;
-  --cds-quotation-01-font-size: 1.25rem;
-  --cds-quotation-01-font-weight: 400;
-  --cds-quotation-01-line-height: 1.3;
-  --cds-quotation-01-letter-spacing: 0;
-  --cds-quotation-02-font-size: 2rem;
-  --cds-quotation-02-font-weight: 300;
-  --cds-quotation-02-line-height: 1.25;
-  --cds-quotation-02-letter-spacing: 0;
-  --cds-display-01-font-size: 2.625rem;
-  --cds-display-01-font-weight: 300;
-  --cds-display-01-line-height: 1.19;
-  --cds-display-01-letter-spacing: 0;
-  --cds-display-02-font-size: 2.625rem;
-  --cds-display-02-font-weight: 600;
-  --cds-display-02-line-height: 1.19;
-  --cds-display-02-letter-spacing: 0;
-  --cds-display-03-font-size: 2.625rem;
-  --cds-display-03-font-weight: 300;
-  --cds-display-03-line-height: 1.19;
-  --cds-display-03-letter-spacing: 0;
-  --cds-display-04-font-size: 2.625rem;
-  --cds-display-04-font-weight: 600;
-  --cds-display-04-line-height: 1.19;
-  --cds-display-04-letter-spacing: 0;
-  --cds-spacing-01: 0.125rem;
-  --cds-spacing-02: 0.25rem;
-  --cds-spacing-03: 0.5rem;
-  --cds-spacing-04: 0.75rem;
-  --cds-spacing-05: 1rem;
-  --cds-spacing-06: 1.5rem;
-  --cds-spacing-07: 2rem;
-  --cds-spacing-08: 2.5rem;
-  --cds-spacing-09: 3rem;
-  --cds-spacing-10: 4rem;
-  --cds-spacing-11: 5rem;
-  --cds-spacing-12: 6rem;
-  --cds-fluid-spacing-01: 0;
-  --cds-fluid-spacing-02: 2vw;
-  --cds-fluid-spacing-03: 5vw;
-  --cds-fluid-spacing-04: 10vw;
-  --cds-layout-01: 1rem;
-  --cds-layout-02: 1.5rem;
-  --cds-layout-03: 2rem;
-  --cds-layout-04: 3rem;
-  --cds-layout-05: 4rem;
-  --cds-layout-06: 6rem;
-  --cds-layout-07: 10rem;
-  --cds-container-01: 1.5rem;
-  --cds-container-02: 2rem;
-  --cds-container-03: 2.5rem;
-  --cds-container-04: 3rem;
-  --cds-container-05: 4rem;
-  --cds-icon-size-01: 1rem;
-  --cds-icon-size-02: 1.25rem;
-}
-
-.exp-side-panel-container.exp-side-panel-container-dark,
-.exp-side-panel-container.exp-side-panel-container-dark .exp-side-panel-body-content {
-  --cds-interactive-01: #0f62fe;
-  --cds-interactive-02: #6f6f6f;
-  --cds-interactive-03: #ffffff;
-  --cds-interactive-04: #4589ff;
-  --cds-ui-background: #161616;
-  --cds-ui-01: #262626;
-  --cds-ui-02: #393939;
-  --cds-ui-03: #393939;
-  --cds-ui-04: #6f6f6f;
-  --cds-ui-05: #f4f4f4;
-  --cds-text-01: #f4f4f4;
-  --cds-text-02: #c6c6c6;
-  --cds-text-03: #6f6f6f;
-  --cds-text-04: #ffffff;
-  --cds-text-05: #8d8d8d;
-  --cds-text-error: #ff8389;
-  --cds-icon-01: #f4f4f4;
-  --cds-icon-02: #c6c6c6;
-  --cds-icon-03: #ffffff;
-  --cds-link-01: #78a9ff;
-  --cds-link-02: #a6c8ff;
-  --cds-inverse-link: #0f62fe;
-  --cds-field-01: #262626;
-  --cds-field-02: #393939;
-  --cds-inverse-01: #161616;
-  --cds-inverse-02: #f4f4f4;
-  --cds-support-01: #fa4d56;
-  --cds-support-02: #42be65;
-  --cds-support-03: #f1c21b;
-  --cds-support-04: #4589ff;
-  --cds-inverse-support-01: #da1e28;
-  --cds-inverse-support-02: #24a148;
-  --cds-inverse-support-03: #f1c21b;
-  --cds-inverse-support-04: #0f62fe;
-  --cds-overlay-01: rgba(22, 22, 22, 0.7);
-  --cds-danger-01: #da1e28;
-  --cds-danger-02: #fa4d56;
-  --cds-focus: #ffffff;
-  --cds-inverse-focus-ui: #0f62fe;
-  --cds-hover-primary: #0353e9;
-  --cds-active-primary: #002d9c;
-  --cds-hover-primary-text: #a6c8ff;
-  --cds-hover-secondary: #606060;
-  --cds-active-secondary: #393939;
-  --cds-hover-tertiary: #f4f4f4;
-  --cds-active-tertiary: #c6c6c6;
-  --cds-hover-ui: #353535;
-  --cds-hover-light-ui: #4c4c4c;
-  --cds-hover-selected-ui: #4c4c4c;
-  --cds-active-ui: #525252;
-  --cds-active-light-ui: #6f6f6f;
-  --cds-selected-ui: #393939;
-  --cds-selected-light-ui: #525252;
-  --cds-inverse-hover-ui: #e5e5e5;
-  --cds-hover-danger: #b81921;
-  --cds-active-danger: #750e13;
-  --cds-hover-row: #353535;
-  --cds-visited-link: #be95ff;
-  --cds-disabled-01: #262626;
-  --cds-disabled-02: #525252;
-  --cds-disabled-03: #8d8d8d;
-  --cds-highlight: #002d9c;
-  --cds-decorative-01: #525252;
-  --cds-button-separator: #161616;
-  --cds-skeleton-01: #353535;
-  --cds-skeleton-02: #525252;
-  --cds-brand-01: #0f62fe;
-  --cds-brand-02: #6f6f6f;
-  --cds-brand-03: #ffffff;
-  --cds-active-01: #525252;
-  --cds-hover-field: #353535;
-  --cds-danger: #da1e28;
-  --cds-caption-01-font-size: 0.75rem;
-  --cds-caption-01-font-weight: 400;
-  --cds-caption-01-line-height: 1.34;
-  --cds-caption-01-letter-spacing: 0.32px;
-  --cds-label-01-font-size: 0.75rem;
-  --cds-label-01-font-weight: 400;
-  --cds-label-01-line-height: 1.34;
-  --cds-label-01-letter-spacing: 0.32px;
-  --cds-helper-text-01-font-size: 0.75rem;
-  --cds-helper-text-01-line-height: 1.34;
-  --cds-helper-text-01-letter-spacing: 0.32px;
-  --cds-body-short-01-font-size: 0.875rem;
-  --cds-body-short-01-font-weight: 400;
-  --cds-body-short-01-line-height: 1.29;
-  --cds-body-short-01-letter-spacing: 0.16px;
-  --cds-body-long-01-font-size: 0.875rem;
-  --cds-body-long-01-font-weight: 400;
-  --cds-body-long-01-line-height: 1.43;
-  --cds-body-long-01-letter-spacing: 0.16px;
-  --cds-body-short-02-font-size: 1rem;
-  --cds-body-short-02-font-weight: 400;
-  --cds-body-short-02-line-height: 1.375;
-  --cds-body-short-02-letter-spacing: 0;
-  --cds-body-long-02-font-size: 1rem;
-  --cds-body-long-02-font-weight: 400;
-  --cds-body-long-02-line-height: 1.5;
-  --cds-body-long-02-letter-spacing: 0;
-  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-  --cds-code-01-font-size: 0.75rem;
-  --cds-code-01-font-weight: 400;
-  --cds-code-01-line-height: 1.34;
-  --cds-code-01-letter-spacing: 0.32px;
-  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-  --cds-code-02-font-size: 0.875rem;
-  --cds-code-02-font-weight: 400;
-  --cds-code-02-line-height: 1.43;
-  --cds-code-02-letter-spacing: 0.32px;
-  --cds-heading-01-font-size: 0.875rem;
-  --cds-heading-01-font-weight: 600;
-  --cds-heading-01-line-height: 1.29;
-  --cds-heading-01-letter-spacing: 0.16px;
-  --cds-productive-heading-01-font-size: 0.875rem;
-  --cds-productive-heading-01-font-weight: 600;
-  --cds-productive-heading-01-line-height: 1.29;
-  --cds-productive-heading-01-letter-spacing: 0.16px;
-  --cds-heading-02-font-size: 1rem;
-  --cds-heading-02-font-weight: 600;
-  --cds-heading-02-line-height: 1.375;
-  --cds-heading-02-letter-spacing: 0;
-  --cds-productive-heading-02-font-size: 1rem;
-  --cds-productive-heading-02-font-weight: 600;
-  --cds-productive-heading-02-line-height: 1.375;
-  --cds-productive-heading-02-letter-spacing: 0;
-  --cds-productive-heading-03-font-size: 1.25rem;
-  --cds-productive-heading-03-font-weight: 400;
-  --cds-productive-heading-03-line-height: 1.4;
-  --cds-productive-heading-03-letter-spacing: 0;
-  --cds-productive-heading-04-font-size: 1.75rem;
-  --cds-productive-heading-04-font-weight: 400;
-  --cds-productive-heading-04-line-height: 1.29;
-  --cds-productive-heading-04-letter-spacing: 0;
-  --cds-productive-heading-05-font-size: 2rem;
-  --cds-productive-heading-05-font-weight: 400;
-  --cds-productive-heading-05-line-height: 1.25;
-  --cds-productive-heading-05-letter-spacing: 0;
-  --cds-productive-heading-06-font-size: 2.625rem;
-  --cds-productive-heading-06-font-weight: 300;
-  --cds-productive-heading-06-line-height: 1.199;
-  --cds-productive-heading-06-letter-spacing: 0;
-  --cds-productive-heading-07-font-size: 3.375rem;
-  --cds-productive-heading-07-font-weight: 300;
-  --cds-productive-heading-07-line-height: 1.19;
-  --cds-productive-heading-07-letter-spacing: 0;
-  --cds-expressive-heading-01-font-size: 0.875rem;
-  --cds-expressive-heading-01-font-weight: 600;
-  --cds-expressive-heading-01-line-height: 1.25;
-  --cds-expressive-heading-01-letter-spacing: 0.16px;
-  --cds-expressive-heading-02-font-size: 1rem;
-  --cds-expressive-heading-02-font-weight: 600;
-  --cds-expressive-heading-02-line-height: 1.5;
-  --cds-expressive-heading-02-letter-spacing: 0;
-  --cds-expressive-heading-03-font-size: 1.25rem;
-  --cds-expressive-heading-03-font-weight: 400;
-  --cds-expressive-heading-03-line-height: 1.4;
-  --cds-expressive-heading-03-letter-spacing: 0;
-  --cds-expressive-heading-04-font-size: 1.75rem;
-  --cds-expressive-heading-04-font-weight: 400;
-  --cds-expressive-heading-04-line-height: 1.29;
-  --cds-expressive-heading-04-letter-spacing: 0;
-  --cds-expressive-heading-05-font-size: 2rem;
-  --cds-expressive-heading-05-font-weight: 400;
-  --cds-expressive-heading-05-line-height: 1.25;
-  --cds-expressive-heading-05-letter-spacing: 0;
-  --cds-expressive-heading-06-font-size: 2rem;
-  --cds-expressive-heading-06-font-weight: 600;
-  --cds-expressive-heading-06-line-height: 1.25;
-  --cds-expressive-heading-06-letter-spacing: 0;
-  --cds-expressive-paragraph-01-font-size: 1.5rem;
-  --cds-expressive-paragraph-01-font-weight: 300;
-  --cds-expressive-paragraph-01-line-height: 1.334;
-  --cds-expressive-paragraph-01-letter-spacing: 0;
-  --cds-quotation-01-font-size: 1.25rem;
-  --cds-quotation-01-font-weight: 400;
-  --cds-quotation-01-line-height: 1.3;
-  --cds-quotation-01-letter-spacing: 0;
-  --cds-quotation-02-font-size: 2rem;
-  --cds-quotation-02-font-weight: 300;
-  --cds-quotation-02-line-height: 1.25;
-  --cds-quotation-02-letter-spacing: 0;
-  --cds-display-01-font-size: 2.625rem;
-  --cds-display-01-font-weight: 300;
-  --cds-display-01-line-height: 1.19;
-  --cds-display-01-letter-spacing: 0;
-  --cds-display-02-font-size: 2.625rem;
-  --cds-display-02-font-weight: 600;
-  --cds-display-02-line-height: 1.19;
-  --cds-display-02-letter-spacing: 0;
-  --cds-display-03-font-size: 2.625rem;
-  --cds-display-03-font-weight: 300;
-  --cds-display-03-line-height: 1.19;
-  --cds-display-03-letter-spacing: 0;
-  --cds-display-04-font-size: 2.625rem;
-  --cds-display-04-font-weight: 600;
-  --cds-display-04-line-height: 1.19;
-  --cds-display-04-letter-spacing: 0;
-  --cds-spacing-01: 0.125rem;
-  --cds-spacing-02: 0.25rem;
-  --cds-spacing-03: 0.5rem;
-  --cds-spacing-04: 0.75rem;
-  --cds-spacing-05: 1rem;
-  --cds-spacing-06: 1.5rem;
-  --cds-spacing-07: 2rem;
-  --cds-spacing-08: 2.5rem;
-  --cds-spacing-09: 3rem;
-  --cds-spacing-10: 4rem;
-  --cds-spacing-11: 5rem;
-  --cds-spacing-12: 6rem;
-  --cds-fluid-spacing-01: 0;
-  --cds-fluid-spacing-02: 2vw;
-  --cds-fluid-spacing-03: 5vw;
-  --cds-fluid-spacing-04: 10vw;
-  --cds-layout-01: 1rem;
-  --cds-layout-02: 1.5rem;
-  --cds-layout-03: 2rem;
-  --cds-layout-04: 3rem;
-  --cds-layout-05: 4rem;
-  --cds-layout-06: 6rem;
-  --cds-layout-07: 10rem;
-  --cds-container-01: 1.5rem;
-  --cds-container-02: 2rem;
-  --cds-container-03: 2.5rem;
-  --cds-container-04: 3rem;
-  --cds-container-05: 4rem;
-  --cds-icon-size-01: 1rem;
-  --cds-icon-size-02: 1.25rem;
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement {
-  right: 0;
-  border-left: 1px solid var(--cds-decorative-01, #e0e0e0);
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--extra-small {
-  min-width: 16rem;
-  max-width: 16rem;
-}
-
-@keyframes sidePanelEntranceRight {
-  0% {
-    transform: translateX(16rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--small {
-  min-width: 20rem;
-  max-width: 20rem;
-}
-
-@keyframes sidePanelEntranceRight {
-  0% {
-    transform: translateX(20rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--medium {
-  min-width: 30rem;
-  max-width: 30rem;
-}
-
-@keyframes sidePanelEntranceRight {
-  0% {
-    transform: translateX(30rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--large {
-  min-width: 40rem;
-  max-width: 40rem;
-}
-
-@keyframes sidePanelEntranceRight {
-  0% {
-    transform: translateX(40rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-right-placement.exp-side-panel-container--max {
-  min-width: 75%;
-  max-width: 75%;
-}
-
-@keyframes sidePanelEntranceRight {
-  0% {
-    transform: translateX(75%);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement {
-  left: 0;
-  border-right: 1px solid var(--cds-decorative-01, #e0e0e0);
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--extra-small {
-  min-width: 16rem;
-  max-width: 16rem;
-}
-
-@keyframes sidePanelEntranceLeft {
-  0% {
-    transform: translateX(-16rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--small {
-  min-width: 20rem;
-  max-width: 20rem;
-}
-
-@keyframes sidePanelEntranceLeft {
-  0% {
-    transform: translateX(-20rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--medium {
-  min-width: 30rem;
-  max-width: 30rem;
-}
-
-@keyframes sidePanelEntranceLeft {
-  0% {
-    transform: translateX(-30rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--large {
-  min-width: 40rem;
-  max-width: 40rem;
-}
-
-@keyframes sidePanelEntranceLeft {
-  0% {
-    transform: translateX(-40rem);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-container-left-placement.exp-side-panel-container--max {
-  min-width: 75%;
-  max-width: 75%;
-}
-
-@keyframes sidePanelEntranceLeft {
-  0% {
-    transform: translateX(-75%);
-    opacity: 0;
-  }
-  100% {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-.exp-side-panel-container.exp-side-panel-with-condensed-header .exp-side-panel-title-text {
-  font-size: var(--cds-productive-heading-02-font-size, 1rem);
-  font-weight: var(--cds-productive-heading-02-font-weight, 600);
-  line-height: var(--cds-productive-heading-02-line-height, 1.375);
-  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
-}
-
-.exp-side-panel-container.exp-side-panel-with-condensed-header .exp-side-panel-header {
-  border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
-}
-
-.exp-side-panel-container .exp-side-panel-title-text {
-  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
-  font-weight: var(--cds-productive-heading-03-font-weight, 400);
-  line-height: var(--cds-productive-heading-03-line-height, 1.4);
-  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
-  display: -webkit-box;
-  margin-right: var(--cds-spacing-07, 2rem);
-  margin-bottom: var(--cds-spacing-03, 0.5rem);
-  overflow: hidden;
-  transition: font-size 150ms, font-weight 240ms;
-  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.exp-side-panel-container .exp-side-panel-subtitle-text {
-  font-size: var(--cds-body-short-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-short-01-font-weight, 400);
-  line-height: var(--cds-body-short-01-line-height, 1.29);
-  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  margin-bottom: var(--cds-spacing-05, 1rem);
-  overflow: hidden;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-}
-
-.exp-side-panel-container .exp-side-panel-label-text {
-  font-size: var(--cds-label-01-font-size, 0.75rem);
-  font-weight: var(--cds-label-01-font-weight, 400);
-  line-height: var(--cds-label-01-line-height, 1.34);
-  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
-}
-
-.exp-side-panel-container .exp-side-panel-action-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  margin-bottom: var(--cds-spacing-03, 0.5rem);
-}
-
-.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button {
-  min-width: 2rem;
-}
-
-.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-icon-only-button {
-  padding: 0;
-  color: var(--cds-text-01, #161616);
-}
-
-.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-icon-only-button svg {
-  margin-left: var(--cds-spacing-03, 0.5rem);
-}
-
-.exp-side-panel-container .exp-side-panel-action-toolbar .exp-side-panel-action-toolbar-button.exp-side-panel-action-toolbar-leading-button {
-  margin-right: var(--cds-spacing-03, 0.5rem);
-}
-
-.exp-side-panel-container .bx--btn.exp-side-panel-navigation-back-button,
-.exp-side-panel-container .bx--btn.exp-side-panel-close-button {
-  min-width: 2rem;
-  padding: 0;
-  color: var(--cds-text-01, #161616);
-}
-
-.exp-side-panel-container .bx--btn.exp-side-panel-close-button {
-  position: absolute;
-  top: var(--cds-spacing-03, 0.5rem);
-  right: var(--cds-spacing-03, 0.5rem);
-}
-
-.exp-side-panel-container .exp-side-panel-body-content {
-  padding: var(--cds-spacing-05, 1rem);
-  padding-top: 0;
-  padding-bottom: var(--cds-layout-07, 10rem);
-}
-
-.exp-side-panel-container .exp-side-panel-header {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  padding: var(--cds-spacing-05, 1rem);
-  background-color: var(--cds-ui-01, #f4f4f4);
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  width: 100%;
-  height: var(--cds-layout-05, 4rem);
-  background-color: var(--cds-ui-01, #f4f4f4);
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small {
-  min-width: 16rem;
-  max-width: 16rem;
-  flex-direction: column;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button,
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--extra-small.exp-side-panel-actions-container--multi-action .exp-side-panel-primary-action-button {
-  width: 100%;
-  max-width: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small {
-  min-width: 20rem;
-  max-width: 20rem;
-  flex-direction: column;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button,
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--small.exp-side-panel-actions-container--multi-action .exp-side-panel-primary-action-button {
-  width: 100%;
-  max-width: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium {
-  min-width: 30rem;
-  max-width: 30rem;
-  flex-direction: row;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium.exp-side-panel-actions-container--multi-action-3-buttons-or-more {
-  flex-direction: column;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--medium.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button {
-  width: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large {
-  min-width: 40rem;
-  max-width: 40rem;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
-  width: 50%;
-  max-width: 50%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--large.exp-side-panel-actions-container--single-action .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
-  width: 100%;
-  max-width: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max.exp-side-panel-actions-container--multi-action-3-buttons-or-more .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
-  width: 50%;
-  max-width: 50%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max.exp-side-panel-actions-container--single-action .exp-side-panel-primary-action-button.exp-side-panel-ghost-button {
-  width: 100%;
-  max-width: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container-condensed {
-  height: var(--cds-layout-04, 3rem);
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container .exp-side-panel-primary-action-button {
-  display: flex;
-  align-items: flex-start;
-  width: 100%;
-  max-width: 100%;
-  height: 100%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action
-.exp-side-panel-primary-action-button {
-  width: 50%;
-  max-width: 50%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--single-action.exp-side-panel-actions--large
-.exp-side-panel-primary-action-button,
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action.exp-side-panel-actions--large
-.exp-side-panel-primary-action-button {
-  width: 50%;
-  max-width: 50%;
-}
-
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions-container--multi-action-3-buttons-or-more.exp-side-panel-actions--large
-.exp-side-panel-primary-action-button,
-.exp-side-panel-container .exp-side-panel-actions-container.exp-side-panel-actions--max
-.exp-side-panel-primary-action-button {
-  width: 25%;
-  max-width: 25%;
-}
-
-.exp-side-panel-primary-action-button .bx--inline-loading {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: var(--cds-spacing-07, 2rem);
-}
-
-@keyframes sidePanelOverlayEntrance {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes sidePanelOverlayExit {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-.exp-side-panel--visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  border: 0;
-  visibility: inherit;
-  clip: rect(0, 0, 0, 0);
-}
-
-.exp-side-panel-overlay {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-  width: 100%;
-  height: 100%;
-  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
-  transition: background-color 240ms;
-  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
-}
-
 .bx--content-switcher {
   display: flex;
   justify-content: space-evenly;
@@ -12442,7 +11613,7 @@ svg:hover {
   display: block;
   width: 0.0625rem;
   height: 1rem;
-  background-color: var(--cds-ui-03, #e0e0e0);
+  background-color: #e0e0e0;
   content: '';
 }
 
@@ -12624,14 +11795,14 @@ svg:hover {
 }
 
 .bx--search-input[disabled] {
-  color: var(--cds-disabled-02, #c6c6c6);
+  color: #c6c6c6;
   background-color: var(--cds-disabled-01, #f4f4f4);
   border-bottom: 1px solid transparent;
   cursor: not-allowed;
 }
 
 .bx--search-input[disabled]::placeholder {
-  color: var(--cds-disabled-02, #c6c6c6);
+  color: #c6c6c6;
 }
 
 .bx--search--light .bx--search-input {
@@ -12815,7 +11986,7 @@ svg:hover {
 }
 
 .bx--search--disabled svg {
-  fill: var(--cds-disabled-02, #c6c6c6);
+  fill: #c6c6c6;
 }
 
 .bx--search-close:focus::before,
@@ -13332,108 +12503,6 @@ svg:hover {
   min-width: initial;
 }
 
-.exp-breadcrumb-with-overflow {
-  display: block;
-}
-
-.exp-breadcrumb-with-overflow--space {
-  position: relative;
-  display: block;
-  width: 100%;
-  white-space: nowrap;
-}
-
-.exp-breadcrumb-with-overflow--space--right {
-  text-align: end;
-}
-
-.exp-breadcrumb-with-overflow--breadcrumb-container {
-  display: inline-flex;
-  width: 100%;
-}
-
-.exp-breadcrumb-with-overflow--breadcrumb-container .bx--breadcrumb {
-  flex-wrap: nowrap;
-  width: 100%;
-}
-
-.exp-breadcrumb-with-overflow--breadcrumb-container--hidden {
-  position: absolute;
-  top: -100vh;
-  left: -100vw;
-  max-width: 0;
-  overflow: hidden;
-  visibility: hidden;
-  pointer-events: none;
-}
-
-.bx--breadcrumb-item .bx--overflow-menu {
-  position: relative;
-  width: 1.25rem;
-  height: 1.25rem;
-}
-
-.bx--breadcrumb-item .bx--overflow-menu:focus {
-  outline: 1px solid var(--cds-focus, #0f62fe);
-}
-
-.bx--breadcrumb-item .bx--overflow-menu:hover {
-  background: transparent;
-}
-
-.bx--breadcrumb-item .bx--overflow-menu::after {
-  position: absolute;
-  bottom: 2px;
-  width: 0.75rem;
-  height: 1px;
-  background: var(--cds-hover-primary-text, #0043ce);
-  opacity: 0;
-  transition: opacity 70ms cubic-bezier(0.2, 0, 0.38, 0.9);
-  content: '';
-}
-
-.bx--breadcrumb-item .bx--overflow-menu:hover::after {
-  opacity: 1;
-}
-
-.bx--breadcrumb-item
-.bx--overflow-menu.bx--overflow-menu--open {
-  background: transparent;
-  box-shadow: none;
-}
-
-.bx--breadcrumb-item .bx--overflow-menu__icon {
-  position: relative;
-  transform: translateY(4px);
-  fill: var(--cds-link-01, #0f62fe);
-}
-
-.bx--breadcrumb-item
-.bx--overflow-menu:hover
-.bx--overflow-menu__icon {
-  fill: var(--cds-hover-primary-text, #0043ce);
-}
-
-.bx--breadcrumb-menu-options:focus {
-  outline: none;
-}
-
-.bx--breadcrumb-menu-options.bx--overflow-menu-options::after {
-  top: -0.4375rem;
-  left: 0.875rem;
-  width: 0;
-  height: 0;
-  margin: 0 auto;
-  background: transparent;
-  border-right: 0.4375rem solid transparent;
-  border-bottom: 0.4375rem solid var(--cds-field-01, #f4f4f4);
-  border-left: 0.4375rem solid transparent;
-}
-
-.exp-breadcrumb-with-overflow--displayed-breadcrumb {
-  overflow: hidden;
-}
-
 .exp-temp-combo-button {
   justify-content: flex-start;
   min-width: 160px;
@@ -13745,8 +12814,18 @@ svg:hover {
   }
 }
 
+.exp-page-header--action-bar-column .exp-page-header--page-actions {
+  margin-top: 0;
+}
+
 .exp-page-header--page-actions-container {
-  justify-content: flex-end;
+  justify-content: flex-start;
+}
+
+@media (min-width: 42rem) {
+  .exp-page-header--page-actions-container {
+    justify-content: flex-end;
+  }
 }
 
 .exp-page-header--title-row .exp-page-header--page-actions {
@@ -13875,6 +12954,839 @@ svg:hover {
 
 .exp-remove-delete-modal-body {
   margin-bottom: var(--cds-spacing-05, 1rem);
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes sidePanelExitLeft {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-30rem);
+    opacity: 0;
+  }
+}
+
+@keyframes sidePanelExitRight {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(30rem);
+    opacity: 0;
+  }
+}
+
+.exp--side-panel__container {
+  position: fixed;
+  top: var(--cds-spacing-09, 3rem);
+  z-index: 3;
+  box-sizing: border-box;
+  min-width: 30rem;
+  max-width: 30rem;
+  height: calc(100% - 3rem);
+  overflow: auto;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-01, #f4f4f4);
+  transition: transform 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement {
+  right: 0;
+  border-left: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement.exp--side-panel__container--extra-small {
+  min-width: 16rem;
+  max-width: 16rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(16rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement.exp--side-panel__container--small {
+  min-width: 20rem;
+  max-width: 20rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(20rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement.exp--side-panel__container--medium {
+  min-width: 30rem;
+  max-width: 30rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(30rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement.exp--side-panel__container--large {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(40rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-right-placement.exp--side-panel__container--max {
+  min-width: 75%;
+  max-width: 75%;
+}
+
+@keyframes sidePanelEntranceRight {
+  0% {
+    transform: translateX(75%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement {
+  left: 0;
+  border-right: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement.exp--side-panel__container--extra-small {
+  min-width: 16rem;
+  max-width: 16rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-16rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement.exp--side-panel__container--small {
+  min-width: 20rem;
+  max-width: 20rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-20rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement.exp--side-panel__container--medium {
+  min-width: 30rem;
+  max-width: 30rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-30rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement.exp--side-panel__container--large {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-40rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__container-left-placement.exp--side-panel__container--max {
+  min-width: 75%;
+  max-width: 75%;
+}
+
+@keyframes sidePanelEntranceLeft {
+  0% {
+    transform: translateX(-75%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.exp--side-panel__container.exp--side-panel__with-condensed-header .exp--side-panel__title-text {
+  font-size: var(--cds-productive-heading-02-font-size, 1rem);
+  font-weight: var(--cds-productive-heading-02-font-weight, 600);
+  line-height: var(--cds-productive-heading-02-line-height, 1.375);
+  letter-spacing: var(--cds-productive-heading-02-letter-spacing, 0);
+}
+
+.exp--side-panel__container.exp--side-panel__with-condensed-header .exp--side-panel__header {
+  border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp--side-panel__container .exp--side-panel__title-text {
+  font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
+  font-weight: var(--cds-productive-heading-03-font-weight, 400);
+  line-height: var(--cds-productive-heading-03-line-height, 1.4);
+  letter-spacing: var(--cds-productive-heading-03-letter-spacing, 0);
+  display: -webkit-box;
+  margin-right: var(--cds-spacing-07, 2rem);
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+  overflow: hidden;
+  transition: font-size 150ms, font-weight 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.exp--side-panel__container .exp--side-panel__subtitle-text {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  margin-bottom: var(--cds-spacing-05, 1rem);
+  overflow: hidden;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.exp--side-panel__container .exp--side-panel__label-text {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.exp--side-panel__container .exp--side-panel__action-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--side-panel__container .exp--side-panel__action-toolbar .exp--side-panel__action-toolbar-button {
+  min-width: 2rem;
+}
+
+.exp--side-panel__container .exp--side-panel__action-toolbar .exp--side-panel__action-toolbar-button.exp--side-panel__action-toolbar-icon-only-button {
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--side-panel__container .exp--side-panel__action-toolbar .exp--side-panel__action-toolbar-button.exp--side-panel__action-toolbar-icon-only-button svg {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--side-panel__container .exp--side-panel__action-toolbar .exp--side-panel__action-toolbar-button.exp--side-panel__action-toolbar-leading-button {
+  margin-right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--side-panel__container .bx--btn.exp--side-panel__navigation-back-button,
+.exp--side-panel__container .bx--btn.exp--side-panel__close-button {
+  min-width: 2rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--side-panel__container .bx--btn.exp--side-panel__close-button {
+  position: absolute;
+  top: var(--cds-spacing-03, 0.5rem);
+  right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--side-panel__container .exp--side-panel__body-content {
+  padding: var(--cds-spacing-05, 1rem);
+  padding-top: 0;
+  padding-bottom: var(--cds-layout-07, 10rem);
+}
+
+.exp--side-panel__container .exp--side-panel__header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: var(--cds-spacing-05, 1rem);
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container {
+  position: sticky;
+  bottom: 0;
+  height: var(--cds-layout-05, 4rem);
+  background-color: var(--cds-ui-01, #f4f4f4);
+  border-top: 1px solid var(--cds-decorative-01, #e0e0e0);
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container.exp--action-set--xs {
+  min-width: 16rem;
+  max-width: 16rem;
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container.exp--action-set__sm {
+  min-width: 20rem;
+  max-width: 20rem;
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container.exp--action-set__md {
+  min-width: 30rem;
+  max-width: 30rem;
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container.exp--action-set__lg {
+  min-width: 40rem;
+  max-width: 40rem;
+}
+
+.exp--side-panel__container .exp--side-panel__actions-container.exp--side-panel__actions-container-condensed {
+  height: var(--cds-layout-04, 3rem);
+}
+
+@keyframes sidePanelOverlayEntrance {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes sidePanelOverlayExit {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.exp--side-panel__visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  visibility: inherit;
+  clip: rect(0, 0, 0, 0);
+}
+
+.exp--side-panel__overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  background-color: var(--cds-overlay-01, rgba(22, 22, 22, 0.5));
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+@keyframes rotating {
+  0% {
+    transform: scaleY(-1) rotate(360deg);
+  }
+  100% {
+    transform: scaleY(-1) rotate(0deg);
+  }
+}
+
+.exp-status-icon {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.exp-status-icon--light.exp-status-icon--light-minor-warning svg,
+.exp-status-icon--dark.exp-status-icon--dark-minor-warning svg {
+  fill: #fdd13a;
+}
+
+.exp-status-icon--light.exp-status-icon--light-minor-warning svg > path:nth-of-type(1),
+.exp-status-icon--dark.exp-status-icon--dark-minor-warning svg > path:nth-of-type(1) {
+  fill: #161616;
+}
+
+.exp-status-icon--light.exp-status-icon--light-fatal svg {
+  fill: #000000;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-fatal svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-fatal svg {
+  fill: #000000;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-fatal svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-critical svg {
+  fill: #da1e28;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-critical svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-critical svg {
+  fill: #da1e28;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-critical svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-major-warning svg {
+  fill: #ba4e00;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-major-warning svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-major-warning svg {
+  fill: #ba4e00;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-major-warning svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-undefined svg {
+  fill: #491d8b;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-undefined svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-undefined svg {
+  fill: #491d8b;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-undefined svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-unknown svg {
+  fill: #6f6f6f;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-unknown svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-unknown svg {
+  fill: #6f6f6f;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-unknown svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-normal svg {
+  fill: #198038;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-normal svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-normal svg {
+  fill: #198038;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-normal svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-info svg {
+  fill: #0f62fe;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-info svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-info svg {
+  fill: #0f62fe;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-info svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-in-progress svg {
+  animation: rotating 8s infinite linear;
+  fill: #0f62fe;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exp-status-icon--light.exp-status-icon--light-in-progress svg {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-in-progress svg {
+  animation: rotating 8s infinite linear;
+  fill: #0f62fe;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exp-status-icon--light.exp-status-icon--dark-in-progress svg {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--light-running svg {
+  transform: scaleY(-1);
+  fill: #198038;
+}
+
+.exp-status-icon--light.exp-status-icon--dark-running svg {
+  transform: scaleY(-1);
+  fill: #198038;
+}
+
+.exp-status-icon--light.exp-status-icon--light-pending svg {
+  fill: #6f6f6f;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--light-pending svg .exp-status-icon--light.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--light.exp-status-icon--dark-pending svg {
+  fill: #6f6f6f;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--light.exp-status-icon--dark-pending svg .exp-status-icon--light.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-fatal svg {
+  fill: #c6c6c6;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-fatal svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-fatal svg {
+  fill: #c6c6c6;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-fatal svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-critical svg {
+  fill: #fa4d56;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-critical svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-critical svg {
+  fill: #fa4d56;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-critical svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-major-warning svg {
+  fill: #ff832b;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-major-warning svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-major-warning svg {
+  fill: #ff832b;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-major-warning svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-undefined svg {
+  fill: #a56eff;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-undefined svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-undefined svg {
+  fill: #a56eff;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-undefined svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-unknown svg {
+  fill: #a8a8a8;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-unknown svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-unknown svg {
+  fill: #a8a8a8;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-unknown svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-normal svg {
+  fill: #42be65;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-normal svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-normal svg {
+  fill: #42be65;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-normal svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-info svg {
+  fill: #4589ff;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-info svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-info svg {
+  fill: #4589ff;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-info svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-in-progress svg {
+  animation: rotating 8s infinite linear;
+  fill: #4589ff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exp-status-icon--dark.exp-status-icon--light-in-progress svg {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-in-progress svg {
+  animation: rotating 8s infinite linear;
+  fill: #4589ff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exp-status-icon--dark.exp-status-icon--dark-in-progress svg {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--light-running svg {
+  transform: scaleY(-1);
+  fill: #42be65;
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-running svg {
+  transform: scaleY(-1);
+  fill: #42be65;
+}
+
+.exp-status-icon--dark.exp-status-icon--light-pending svg {
+  fill: #a8a8a8;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--light-pending svg .exp-status-icon--dark.exp-status-icon--light-in-progress {
+    animation: none;
+  }
+}
+
+.exp-status-icon--dark.exp-status-icon--dark-pending svg {
+  fill: #a8a8a8;
+}
+
+@media (prefers-reduced-motion) {
+  .exp-status-icon--dark.exp-status-icon--dark-pending svg .exp-status-icon--dark.exp-status-icon--dark-in-progress {
+    animation: none;
+  }
 }
 
 .exp-tag-set {

--- a/packages/cloud-cognitive/src/__tests__/styles.test.js
+++ b/packages/cloud-cognitive/src/__tests__/styles.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { renderSync } = require('node-sass');
+const { resolve } = require('path');
+
+describe('Styles', () => {
+  // This identifies and raises awareness to style changes of the public API in pull requests. If these are intended, update the snapshot.
+  test('Public API', () => {
+    expect(
+      renderSync({
+        file: resolve(__dirname, '../index.scss'),
+        includePaths: [resolve(__dirname, '../../../../node_modules')],
+        outputStyle: 'expanded',
+      }).css.toString()
+    ).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
**Affected issue -** contributes to #577

As part of an investigation into integrating Carbon for Cloud & Cognitive CSS into Security applications already containing both an installation of Carbon and Carbon for IBM Security, a number of style conflicts and duplications were brought to the surface.

I will be providing some additional requirements and potential recommendations over the next few weeks, but as a first step I'd like to propose a workflow for better identifying and mitigating unwanted side effects from the CSS distributable of this library - moving forward, it will enable the team to understand the impact of any style additions and removals (the public API) and have better control over them in pull requests, [for example](https://github.com/SimonFinney/ibm-cloud-cognitive/compare/css-snapshot...SimonFinney:remove-carbon-utility).

It's worth noting that this PR only contains a test to cover the public API for the package's styles - in the future, I recommend having a similar safeguard for the [JavaScript output](https://github.com/carbon-design-system/carbon/blob/main/packages/react/__tests__/PublicAPI-test.js).

#### Proposed changes

- Add styles public API test
- Add initial styles snapshot
- Update contributing guidelines to accommodate workflow change
