### PR TITLE
test(styles): add styles public API test

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -32,7 +32,7 @@
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js-modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js-modules -d lib",
     "build:js-modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js','src/utils/**/*'",
-    "build:scss": "bundler bundle:scss src/index.scss && copyfiles 'src/**/*.scss' scss -u 1",
+    "build:scss": "for f in src/*.scss; do bundler bundle:scss ${f} -o css/build; copyfiles 'css/build/**/*' css -u 2; done && rimraf css/build && copyfiles 'src/**/*.scss' scss -u 1",
     "ci-check": "node scripts/import",
     "clean": "rimraf es lib css scss",
     "generate": "cross-env FORCE_COLOR=1 node scripts/generate",

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CSS export checks doesn't change the exported CSS for released components 1`] = `
+".exp--about-modal .bx--modal-container {
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.exp--about-modal .exp--about-modal__logo {
+  margin: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__header {
+  grid-row: auto;
+  margin-bottom: 0;
+  padding: 0 20% var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__title {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--about-modal .exp--about-modal__body {
+  font-size: var(--cds-body-short-02-font-size, 1rem);
+  font-weight: var(--cds-body-short-02-font-weight, 400);
+  line-height: var(--cds-body-short-02-line-height, 1.375);
+  letter-spacing: var(--cds-body-short-02-letter-spacing, 0);
+  grid-row: auto;
+  min-height: var(--cds-layout-05, 4rem);
+  margin-bottom: 0;
+  padding: 0 20% 0 var(--cds-spacing-05, 1rem);
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .exp--about-modal__body {
+  min-height: calc(var(--cds-layout-05, 4rem) + var(--cds-spacing-08, 2.5rem));
+}
+
+.exp--about-modal .exp--about-modal__body-content {
+  margin-bottom: var(--cds-spacing-09, 3rem);
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .exp--about-modal__body-content {
+  margin-bottom: calc(var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem));
+}
+
+.exp--about-modal .exp--about-modal__links-container {
+  margin-top: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__links-container a + a {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+  padding-left: var(--cds-spacing-03, 0.5rem);
+  border-left: 1px solid var(--cds-text-01, #161616);
+}
+
+.exp--about-modal .exp--about-modal__legal-text,
+.exp--about-modal .exp--about-modal__copyright-text {
+  margin-top: var(--cds-spacing-07, 2rem);
+  color: var(--cds-text-03, #a8a8a8);
+}
+
+.exp--about-modal .exp--about-modal__copyright-text {
+  margin-top: var(--cds-spacing-05, 1rem);
+}
+
+.exp--about-modal .exp--about-modal__footer {
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  height: 4.5rem;
+  color: var(--cds-inverse-01, #ffffff);
+  background-color: var(--cds-inverse-02, #393939);
+}
+
+.exp--about-modal .exp--about-modal__footer::before {
+  position: absolute;
+  top: calc(-1 * var(--cds-spacing-09, 3rem));
+  width: 80%;
+  height: var(--cds-spacing-09, 3rem);
+  background: linear-gradient(to bottom, transparent, var(--cds-ui-01, #f4f4f4) 45%);
+  content: '';
+}
+
+.exp--about-modal.exp--about-modal--with-tabs .bx--modal-footer::before {
+  top: calc(-1 * (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem)));
+  height: calc(var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem));
+  background: linear-gradient(to bottom, transparent, var(--cds-ui-01, #f4f4f4) 25%);
+}
+
+.exp--about-modal .exp--about-modal__tab-container {
+  position: absolute;
+  bottom: 100%;
+}
+
+.exp--about-modal .exp--about-modal__version-label,
+.exp--about-modal .exp--about-modal__version-number {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  padding-left: var(--cds-spacing-05, 1rem);
+  color: var(--cds-inverse-01, #ffffff);
+}
+
+.exp--about-modal .exp--about-modal__version-label {
+  font-weight: 600;
+}
+"
+`;

--- a/packages/cloud-cognitive/src/__tests__/index-all-disabled.test.js
+++ b/packages/cloud-cognitive/src/__tests__/index-all-disabled.test.js
@@ -14,7 +14,7 @@ import '../utils/disable-all'; // must come before components are imported (dire
 import * as components from '..';
 
 const canaryClass = `${pkg.prefix}-canary`;
-const name = 'export checks';
+const name = 'JS export checks';
 
 describe(name, () => {
   beforeAll(() => {

--- a/packages/cloud-cognitive/src/__tests__/index-all-enabled.test.js
+++ b/packages/cloud-cognitive/src/__tests__/index-all-enabled.test.js
@@ -14,7 +14,7 @@ import '../utils/enable-all'; // must come before components are imported (direc
 import * as components from '..';
 
 const canaryClass = `${pkg.prefix}-canary`;
-const name = 'export checks';
+const name = 'JS export checks';
 
 describe(name, () => {
   beforeAll(() => {

--- a/packages/cloud-cognitive/src/__tests__/index.test.js
+++ b/packages/cloud-cognitive/src/__tests__/index.test.js
@@ -5,16 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
-// import React from 'react';
-
-import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import React from 'react';
+import { render } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+
 import { pkg } from '../settings';
 
 import * as components from '..';
-const name = 'export checks';
+
 const canaryClass = `${pkg.prefix}-canary`;
+const name = 'JS export checks';
 
 describe(name, () => {
   beforeAll(() => {

--- a/packages/cloud-cognitive/src/__tests__/settings.test.js
+++ b/packages/cloud-cognitive/src/__tests__/settings.test.js
@@ -1,8 +1,18 @@
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
+
 import { pkg } from '../settings';
 import { shallow } from 'enzyme';
 
-describe('settings', () => {
+const name = 'settings';
+
+describe(name, () => {
   it('uses the default css prefix', () => {
     expect(pkg.prefix).toEqual('exp');
   });

--- a/packages/cloud-cognitive/src/__tests__/styles.test.js
+++ b/packages/cloud-cognitive/src/__tests__/styles.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { renderSync } = require('node-sass');
+const { resolve } = require('path');
+
+const name = 'CSS export checks';
+
+describe(name, () => {
+  // This test will fail if the generated CSS changes and no longer matches
+  // the snapshot. If a change to the exported CSS for released components is
+  // intended, re-run the tests with -u to update the snapshot, and check the
+  // fresh snapshot in as part of the PR.
+  it("doesn't change the exported CSS for released components", () => {
+    expect(
+      renderSync({
+        file: resolve(__dirname, '../index-without-carbon-released-only.scss'),
+        includePaths: [resolve(__dirname, '../../../../node_modules')],
+        outputStyle: 'expanded',
+      }).css.toString()
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/cloud-cognitive/src/components/_index-released-only.scss
+++ b/packages/cloud-cognitive/src/components/_index-released-only.scss
@@ -1,0 +1,10 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Package all scss files here for those that want them all bundled up.
+
+@import './AboutModal/index';

--- a/packages/cloud-cognitive/src/index-full-carbon.scss
+++ b/packages/cloud-cognitive/src/index-full-carbon.scss
@@ -11,3 +11,4 @@
 
 @import './components/index';
 @import '@carbon/ibm-cloud-cognitive-security/scss/index';
+@import 'carbon-components/scss/globals/scss/styles';

--- a/packages/cloud-cognitive/src/index-without-carbon-released-only.scss
+++ b/packages/cloud-cognitive/src/index-without-carbon-released-only.scss
@@ -1,0 +1,28 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$imported-modules: 'css--reset' 'css--default-type' 'skeleton' 'helper-classes'
+  'css--font-face' 'css--helpers' 'css--body' 'grid' 'button' 'copy-button'
+  'form' 'loading' 'file-uploader' 'checkbox' 'list-box' 'combo-box'
+  'radio-button' 'toggle' 'search' 'select' 'text-input' 'text-area'
+  'number-input' 'link' 'lists' 'data-table-v2-action' 'data-table-v2-core'
+  'data-table-v2-expandable' 'data-table-sort' 'data-table-inline-edit'
+  'data-table-skeleton' 'structured-list' 'snippet' 'overflow-menu'
+  'content-switcher' 'context-menu' 'date-picker' 'dropdown' 'modal'
+  'multi-select' 'inline-notifications' 'toast-notifications' 'tooltip' 'tabs'
+  'tags' 'pagination' 'accordion' 'progress-indicator' 'breadcrumb' 'toolbar'
+  'time-picker' 'slider' 'tile' 'skeleton-text' 'skeleton-icon'
+  'skeleton-placeholder' 'inline-loading' 'pagination-nav' 'unstable_pagination'
+  'carbon-header' 'carbon-header-panel' 'product-switcher'
+  'carbon-header-switcher' 'carbon-side-nav' 'carbon-navigation'
+  'carbon-content' 'popover';
+
+@import '@carbon/import-once/scss/import-once';
+@import './global/styles/carbon-settings';
+@import './global/styles/project-settings';
+
+@import './components/index-released-only';

--- a/packages/cloud-cognitive/src/index-without-carbon.scss
+++ b/packages/cloud-cognitive/src/index-without-carbon.scss
@@ -1,0 +1,44 @@
+//
+// Copyright IBM Corp. 2020, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$imported-modules: 'css--reset' 'css--default-type' 'skeleton' 'helper-classes'
+  'css--font-face' 'css--helpers' 'css--body' 'grid' 'button' 'copy-button'
+  'form' 'loading' 'file-uploader' 'checkbox' 'list-box' 'combo-box'
+  'radio-button' 'toggle' 'search' 'select' 'text-input' 'text-area'
+  'number-input' 'link' 'lists' 'data-table-v2-action' 'data-table-v2-core'
+  'data-table-v2-expandable' 'data-table-sort' 'data-table-inline-edit'
+  'data-table-skeleton' 'structured-list' 'snippet' 'overflow-menu'
+  'content-switcher' 'context-menu' 'date-picker' 'dropdown' 'modal'
+  'multi-select' 'inline-notifications' 'toast-notifications' 'tooltip' 'tabs'
+  'tags' 'pagination' 'accordion' 'progress-indicator' 'breadcrumb' 'toolbar'
+  'time-picker' 'slider' 'tile' 'skeleton-text' 'skeleton-icon'
+  'skeleton-placeholder' 'inline-loading' 'pagination-nav' 'unstable_pagination'
+  'carbon-header' 'carbon-header-panel' 'product-switcher'
+  'carbon-header-switcher' 'carbon-side-nav' 'carbon-navigation'
+  'carbon-content' 'popover';
+
+// To generate the above values, compile the following SCSS, examine the output,
+// copy the content field from the :root section at the end of the file into the
+// variable initialisation above and in index-without-carbon-released-only.scss.
+//
+// @import '@carbon/import-once/scss/import-once';
+// @import './global/styles/carbon-settings';
+// @import './global/styles/project-settings';
+//
+// @import 'carbon-components/scss/globals/scss/styles';
+//
+// :root {
+//   content: $imported-modules;
+// }
+//
+
+@import '@carbon/import-once/scss/import-once';
+@import './global/styles/carbon-settings';
+@import './global/styles/project-settings';
+
+@import './components/index';
+@import '@carbon/ibm-cloud-cognitive-security/scss/index';


### PR DESCRIPTION
Contributes to #577

Create multiple built and minimised CSS outputs with no/needed/all carbon styles included. This includes a "released only" no-carbon CSS build. Added a test as proposed by @SimonFinney in #571 for the released only no-carbon CSS output. This keeps a snapshot of the released component CSS and will be sensitive to any changes that may inadvertently be introduced there.

#### What did you change?

cloud-cognitive index.scss, export tests, package.json

#### How did you test and verify your work?

Ran build, ran tests. Made a small change to _about-modal.scss and verified that it caused the tests to fail until the snapshot was updated. Reverted the change.
