### PR TITLE
fix(SidePanel): add resize detector to adapt to new actions height

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -264,6 +264,23 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       &.#{$action-set-block-class}--lg {
         @include setActionBarSize($large-panel-size);
       }
+      &.#{$action-set-block-class}--max {
+        .#{$action-set-block-class}__action-button {
+          width: 100%;
+          max-width: 100%;
+        }
+
+        @include carbon--breakpoint(md) {
+          flex-direction: row;
+          .#{$action-set-block-class}__action-button {
+            width: 25%;
+          }
+        }
+
+        flex-direction: column;
+        min-width: 75%;
+        max-width: 75%;
+      }
       .#{$action-set-block-class}__action-button {
         min-height: $layout-05;
       }


### PR DESCRIPTION
Contributes to #594 

To adapt to height changes in the actions container, the resize detector component was added to make sure that the main content always has the correct amount of bottom padding.

#### What did you change?
`SidePanel.js`
`_side-panel.scss`
#### How did you test and verify your work?
Storybook