### PR TITLE
fix(SidePanel): add transition to divider appearing during animation

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -127,21 +127,26 @@ export let SidePanel = React.forwardRef(
       );
     };
 
-    // Title and subtitle animaton
+    // Title and subtitle scroll animaton
     useEffect(() => {
       if (open && animateTitle && animationComplete) {
         const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
+        const sidePanelTitleElement = document.querySelector(
+          `.${blockClass}__title-text`
+        );
         const sidePanelSubtitleElement = document.querySelector(
           `.${`${blockClass}__subtitle-text`}`
         );
         sidePanelOuter &&
           sidePanelOuter.addEventListener('scroll', () => {
             const scrollTop = sidePanelRef.current.scrollTop;
+            // if scrolling has occured
             if (scrollTop > 0) {
               sidePanelOuter.classList.add(
                 `${blockClass}__with-condensed-header`
               );
-              // set subtitle opacity calculation here
+              // Set subtitle opacity calculation here
+              // as scroll progresses
               sidePanelOuter.style.setProperty(
                 `--${blockClass}--subtitle-opacity`,
                 `${Math.min(
@@ -150,16 +155,40 @@ export let SidePanel = React.forwardRef(
                     sidePanelSubtitleElement.offsetHeight
                 )}`
               );
-              // set title font size here, previously this was done
+
+              // Calculate divider opacity to avoid border
+              // abruptly appearing when scrolling starts.
+              // This approach uses a pseudo element and sets
+              // the opacity as scroll progresses.
+              let dividerOpacity = Math.min(
+                scrollTop / sidePanelSubtitleElement.offsetHeight,
+                1
+              );
+              sidePanelOuter.style.setProperty(
+                `--${blockClass}--divider-opacity`,
+                `${Math.min(1, dividerOpacity)}`
+              );
+
+              // We need to know the height of the title element
+              // so that we know how far to place the action toolbar
+              // from the top since it is sticky
+              const titleHeight = Math.max(sidePanelTitleElement.offsetHeight);
+              sidePanelOuter.style.setProperty(
+                `--${blockClass}--title-height`,
+                `${titleHeight + 16}px`
+              );
+
+              // Set title font size here, previously this was done
               // via a class addition, however, it is choppier that
               // way, using css variables allows for a smoother animation
               // to the title font size
-              let fontSize = Math.min(
-                (sidePanelSubtitleElement.offsetHeight - scrollTop) /
-                  sidePanelSubtitleElement.offsetHeight +
-                  0.25
+              let fontSize = Math.max(
+                1,
+                1 +
+                  (0.25 * (sidePanelSubtitleElement.offsetHeight - scrollTop)) /
+                    sidePanelSubtitleElement.offsetHeight
               );
-              fontSize = fontSize < 1 ? 1 : fontSize;
+              fontSize = fontSize.toFixed(4);
               sidePanelOuter.style.setProperty(
                 `--${blockClass}--title-font-size`,
                 `${fontSize}rem`
@@ -175,6 +204,10 @@ export let SidePanel = React.forwardRef(
               sidePanelOuter.style.setProperty(
                 `--${blockClass}--title-font-size`,
                 '1.25rem'
+              );
+              sidePanelOuter.style.setProperty(
+                `--${blockClass}--divider-opacity`,
+                0
               );
             }
           });

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -65,6 +65,18 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
   max-width: $size;
 }
 
+@mixin setDividerStyles() {
+  position: absolute;
+  // stylelint-disable-next-line carbon/layout-token-use
+  bottom: -2px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: $decorative-01;
+  opacity: var(--#{$block-class}--divider-opacity);
+  content: '';
+}
+
 @mixin side-panel {
   @keyframes sidePanelExitLeft {
     0% {
@@ -94,6 +106,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
 
   .#{$block-class}__container {
     --#{$block-class}--subtitle-opacity: 1;
+    --#{$block-class}--divider-opacity: 0;
     --#{$block-class}--title-font-size: 1.25rem;
     --#{$block-class}--content-bottom-padding: #{$spacing-10};
 
@@ -150,16 +163,17 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       .#{$block-class}__title-text {
         @include carbon--font-weight('semibold');
       }
-      .#{$block-class}__title-container {
-        border-bottom: 1px solid $decorative-01;
-      }
     }
     &.#{$block-class}__container-with-action-toolbar.#{$block-class}__with-condensed-header {
       .#{$block-class}__title-container {
-        border-bottom: 0;
+        &::before {
+          content: none;
+        }
       }
       .#{$block-class}__action-toolbar {
-        border-bottom: 1px solid $decorative-01;
+        &::before {
+          @include setDividerStyles();
+        }
       }
     }
     .#{$block-class}__title-container {
@@ -168,6 +182,9 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       z-index: 4;
       padding: $spacing-05 $spacing-05 0 $spacing-05;
       background-color: $ui-01;
+      &::before {
+        @include setDividerStyles();
+      }
     }
     .#{$block-class}__title-text {
       @include carbon--type-style('productive-heading-03');
@@ -202,8 +219,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
     }
     .#{$block-class}__action-toolbar {
       position: sticky;
-      // stylelint-disable-next-line carbon/layout-token-use
-      top: 3.75rem;
+      top: var(--#{$block-class}--title-height);
       z-index: 4;
       display: flex;
       align-items: center;


### PR DESCRIPTION
Contributes to #64 

This adds an animation to the title divider line during the scroll animation. Previously this was a border bottom that just appears immediately once the user started scrolling. This was causing a slight jump and also appeared quite abruptly. This is now implemented through a pseudo element that changes opacity as the scroll animation is progressed.

#### What did you change?
`SidePanel.js`
`_side-panel.scss`
#### How did you test and verify your work?
Storybook