### PR TITLE
Pass additional action fields to action buttons as props or HTML attrs

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -21,21 +21,40 @@ const componentName = 'ActionSet';
 
 // NOTE: the component SCSS is not imported here: it is rolled up separately.
 
-const ActionSetButton = ({ disabled, kind, label, loading, onClick }) => (
-  <Button
-    disabled={disabled || loading || false}
-    onClick={onClick}
-    kind={kind}
-    className={cx([
-      `${blockClass}__action-button`,
-      { [`${blockClass}__ghost-button`]: kind === 'ghost' },
-    ])}>
-    {label}
-    {loading && <InlineLoading />}
-  </Button>
+const ActionSetButton = React.forwardRef(
+  (
+    {
+      // The component props, in alphabetical order (for consistency).
+      className,
+      disabled,
+      kind,
+      label,
+      loading,
+      onClick,
+      // Collect any other property values passed in.
+      ...rest
+    },
+    ref
+  ) => (
+    <Button
+      {
+        // Pass through any other property values as HTML attributes.
+        ...rest
+      }
+      className={cx(className, [
+        `${blockClass}__action-button`,
+        { [`${blockClass}__action-button--ghost`]: kind === 'ghost' },
+      ])}
+      disabled={disabled || loading || false}
+      {...{ kind, onClick, ref }}>
+      {label}
+      {loading && <InlineLoading />}
+    </Button>
+  )
 );
 
 ActionSetButton.propTypes = {
+  className: PropTypes.string,
   disabled: PropTypes.bool,
   kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
   label: PropTypes.string,
@@ -50,7 +69,15 @@ const willStack = (size, numberOfActions) =>
 
 /**
  * An ActionSet presents a set of action buttons, constructed from bundles
- * of prop values and applying some layout rules.
+ * of prop values and applying some layout rules. When the size is 'xs' or 'sm'
+ * the buttons are stacked, and should only include primary and secondary
+ * kinds. When the size is 'md' the buttons are stacked if there are three or
+ * more. When the size is 'md' or 'lg', two buttons share the horizontal space.
+ * When the size is 'lg', three or more buttons use a quarter of the available
+ * horizontal space, and if the size is 'xlg' or 'max' the buttons always use
+ * a quarter of the available horizontal space. If there is a ghost button,
+ * it appears at the left side. If there is a primary button it appears at the
+ * right.
  */
 export const ActionSet = React.forwardRef(
   (
@@ -181,7 +208,14 @@ ActionSet.validateActions = (sizeFn) => (props, propName, componentName) => {
 
 ActionSet.propTypes = {
   /**
-   * Specifies the action buttons to show.
+   * Specifies the action buttons to show. Each action is specified as an
+   * object with optional fields 'label' to supply the button label, 'kind'
+   * to select the button kind (must be 'primary', 'secondary' or 'ghost'),
+   * 'loading' to display a loading indicator, and 'onClick' to receive
+   * notifications when the button is clicked. Additional fields in the object
+   * will be passed to the Button component, and these can include 'disabled',
+   * 'ref', 'className', and any other Button props. Any other fields in the
+   * object will be passed through to the button element as HTML attributes.
    */
   actions: PropTypes.oneOfType([
     ActionSet.validateActions(),
@@ -205,7 +239,7 @@ ActionSet.propTypes = {
    * Sets the size of the action set. Different button arrangements are used
    * in different sizes, to make best use of the available space.
    */
-  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'max']),
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xlg', 'max']),
 };
 
 ActionSet.defaultProps = {

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -21,6 +21,7 @@ import { ActionSet } from '.';
 const blockClass = `${pkg.prefix}--action-set`;
 const componentName = ActionSet.displayName;
 
+const className = `class-${uuidv4()}`;
 const dataTestId = uuidv4();
 const label1 = `Secondary button ${uuidv4()}`;
 const action1 = { label: label1, kind: 'secondary' };
@@ -81,9 +82,18 @@ describe(componentName, () => {
     expect(buttons[1].textContent).toEqual(label1);
   });
 
-  it('renders a single ghost action button', () => {
-    render(<ActionSet actions={[action3]} />);
-    expect(getByRoleAndLabel('button', label3)).toHaveClass(ghostButton);
+  it('applies className to an action button', () => {
+    render(<ActionSet actions={[{ ...action1, className }, action2]} />);
+    expect(getByRoleAndLabel('button', label1)).toHaveClass(className);
+    expect(getByRoleAndLabel('button', label2)).not.toHaveClass(className);
+  });
+
+  it('renders a loading button', () => {
+    render(<ActionSet actions={[{ ...action1, loading: true }]} />);
+    const loader = Loading.defaultProps.description;
+    expect(screen.getByRole('button').textContent).toEqual(
+      `${label1}${loader}${loader}`
+    );
   });
 
   it('reports clicks on an action button', () => {
@@ -94,12 +104,20 @@ describe(componentName, () => {
     expect(onClick).toBeCalledTimes(1);
   });
 
-  it('renders a loading button', () => {
-    render(<ActionSet actions={[{ ...action1, loading: true }]} />);
-    const loader = Loading.defaultProps.description;
-    expect(screen.getByRole('button').textContent).toEqual(
-      `${label1}${loader}${loader}`
-    );
+  it('adds additional properties to an action button', () => {
+    render(<ActionSet actions={[{ ...action1, 'data-testid': dataTestId }]} />);
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an action button', () => {
+    const ref = React.createRef();
+    render(<ActionSet actions={[{ ...action1, ref }, action2]} />);
+    expect(ref.current).toEqual(getByRoleAndLabel('button', label1));
+  });
+
+  it('applies className to the containing node', () => {
+    render(<ActionSet className={className} />);
+    expect(screen.getByRole('presentation')).toHaveClass(className);
   });
 
   it('adds additional properties to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -33,7 +33,8 @@
   // For ghosts in row-double,
   // buttons are 75% width
   .#{$block-class}__action-button,
-  .#{$block-class}.#{$block-class}--row-double .#{$block-class}__ghost-button {
+  .#{$block-class}.#{$block-class}--row-double
+    .#{$block-class}__action-button--ghost {
     width: 75%;
     max-width: 75%;
   }
@@ -43,24 +44,27 @@
   // or ghosts in row-triple,
   // buttons are 50% width
   .#{$block-class}.#{$block-class}--row-single.#{$block-class}--lg
-    .#{$block-class}__action-button:not(.#{$block-class}__ghost-button),
+    .#{$block-class}__action-button:not(.#{$block-class}__action-button--ghost),
   .#{$block-class}.#{$block-class}--row-double.#{$block-class}--md
     .#{$block-class}__action-button,
   .#{$block-class}.#{$block-class}--row-double.#{$block-class}--lg
     .#{$block-class}__action-button,
-  .#{$block-class}.#{$block-class}--row-triple .#{$block-class}__ghost-button {
+  .#{$block-class}.#{$block-class}--row-triple
+    .#{$block-class}__action-button--ghost {
     width: 50%;
     max-width: 50%;
   }
 
   // For row-triple in large (non-ghost),
-  // or any non-ghosts in max,
+  // or any non-ghosts in extra large or max,
   // or row-quadruple,
   // buttons are 25% width
   .#{$block-class}.#{$block-class}--row-triple.#{$block-class}--lg
-    .#{$block-class}__action-button:not(.#{$block-class}__ghost-button),
+    .#{$block-class}__action-button:not(.#{$block-class}__action-button--ghost),
+  .#{$block-class}.#{$block-class}--xlg
+    .#{$block-class}__action-button:not(.#{$block-class}__action-button--ghost),
   .#{$block-class}.#{$block-class}--max
-    .#{$block-class}__action-button:not(.#{$block-class}__ghost-button),
+    .#{$block-class}__action-button:not(.#{$block-class}__action-button--ghost),
   .#{$block-class}.#{$block-class}--row-quadruple
     .#{$block-class}__action-button {
     width: 25%;

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -212,7 +212,7 @@ describe('SidePanel', () => {
       'content'
     );
     const sidePanelOuter = container.querySelector(
-      `.${actionSetBlockClass}__ghost-button`
+      `.${actionSetBlockClass}__action-button--ghost`
     );
     expect(sidePanelOuter).toBeTruthy();
   });


### PR DESCRIPTION
Contributes to #555

Pass any additional fields in each action object to the Button as props. This includes className and ref (with forwardRef). Any other fields are passed directly to the Button, which can consume them as props or pass them to the HTML element as HTML attributes.

Also a minor SCSS tweak to use BEM better, and complete the set of sizes.

#### What did you change?

ActionSet.js, also added tests and tweaked scss.

#### How did you test and verify your work?

Ran build, tests, storybook
