### PR TITLE
chore(NotificationsPanel): add tests and mark as released

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -111,6 +111,531 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   font-weight: 600;
 }
 
+@keyframes fadeIn {
+  0% {
+    transform: translateY(-38.5rem);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-38.5rem);
+    opacity: 0;
+  }
+}
+
+.exp--notifications-panel__container {
+  --cds-interactive-01: #0f62fe;
+  --cds-interactive-02: #6f6f6f;
+  --cds-interactive-03: #ffffff;
+  --cds-interactive-04: #4589ff;
+  --cds-ui-background: #161616;
+  --cds-ui-01: #262626;
+  --cds-ui-02: #393939;
+  --cds-ui-03: #393939;
+  --cds-ui-04: #6f6f6f;
+  --cds-ui-05: #f4f4f4;
+  --cds-text-01: #f4f4f4;
+  --cds-text-02: #c6c6c6;
+  --cds-text-03: #6f6f6f;
+  --cds-text-04: #ffffff;
+  --cds-text-05: #8d8d8d;
+  --cds-text-error: #ff8389;
+  --cds-icon-01: #f4f4f4;
+  --cds-icon-02: #c6c6c6;
+  --cds-icon-03: #ffffff;
+  --cds-link-01: #78a9ff;
+  --cds-link-02: #a6c8ff;
+  --cds-inverse-link: #0f62fe;
+  --cds-field-01: #262626;
+  --cds-field-02: #393939;
+  --cds-inverse-01: #161616;
+  --cds-inverse-02: #f4f4f4;
+  --cds-support-01: #fa4d56;
+  --cds-support-02: #42be65;
+  --cds-support-03: #f1c21b;
+  --cds-support-04: #4589ff;
+  --cds-inverse-support-01: #da1e28;
+  --cds-inverse-support-02: #24a148;
+  --cds-inverse-support-03: #f1c21b;
+  --cds-inverse-support-04: #0f62fe;
+  --cds-overlay-01: rgba(22, 22, 22, 0.7);
+  --cds-danger-01: #da1e28;
+  --cds-danger-02: #fa4d56;
+  --cds-focus: #ffffff;
+  --cds-inverse-focus-ui: #0f62fe;
+  --cds-hover-primary: #0353e9;
+  --cds-active-primary: #002d9c;
+  --cds-hover-primary-text: #a6c8ff;
+  --cds-hover-secondary: #606060;
+  --cds-active-secondary: #393939;
+  --cds-hover-tertiary: #f4f4f4;
+  --cds-active-tertiary: #c6c6c6;
+  --cds-hover-ui: #353535;
+  --cds-hover-light-ui: #4c4c4c;
+  --cds-hover-selected-ui: #4c4c4c;
+  --cds-active-ui: #525252;
+  --cds-active-light-ui: #6f6f6f;
+  --cds-selected-ui: #393939;
+  --cds-selected-light-ui: #525252;
+  --cds-inverse-hover-ui: #e5e5e5;
+  --cds-hover-danger: #b81921;
+  --cds-active-danger: #750e13;
+  --cds-hover-row: #353535;
+  --cds-visited-link: #be95ff;
+  --cds-disabled-01: #262626;
+  --cds-disabled-02: #525252;
+  --cds-disabled-03: #8d8d8d;
+  --cds-highlight: #002d9c;
+  --cds-decorative-01: #525252;
+  --cds-button-separator: #161616;
+  --cds-skeleton-01: #353535;
+  --cds-skeleton-02: #525252;
+  --cds-brand-01: #0f62fe;
+  --cds-brand-02: #6f6f6f;
+  --cds-brand-03: #ffffff;
+  --cds-active-01: #525252;
+  --cds-hover-field: #353535;
+  --cds-danger: #da1e28;
+  --cds-caption-01-font-size: 0.75rem;
+  --cds-caption-01-font-weight: 400;
+  --cds-caption-01-line-height: 1.34;
+  --cds-caption-01-letter-spacing: 0.32px;
+  --cds-label-01-font-size: 0.75rem;
+  --cds-label-01-font-weight: 400;
+  --cds-label-01-line-height: 1.34;
+  --cds-label-01-letter-spacing: 0.32px;
+  --cds-helper-text-01-font-size: 0.75rem;
+  --cds-helper-text-01-line-height: 1.34;
+  --cds-helper-text-01-letter-spacing: 0.32px;
+  --cds-body-short-01-font-size: 0.875rem;
+  --cds-body-short-01-font-weight: 400;
+  --cds-body-short-01-line-height: 1.29;
+  --cds-body-short-01-letter-spacing: 0.16px;
+  --cds-body-long-01-font-size: 0.875rem;
+  --cds-body-long-01-font-weight: 400;
+  --cds-body-long-01-line-height: 1.43;
+  --cds-body-long-01-letter-spacing: 0.16px;
+  --cds-body-short-02-font-size: 1rem;
+  --cds-body-short-02-font-weight: 400;
+  --cds-body-short-02-line-height: 1.375;
+  --cds-body-short-02-letter-spacing: 0;
+  --cds-body-long-02-font-size: 1rem;
+  --cds-body-long-02-font-weight: 400;
+  --cds-body-long-02-line-height: 1.5;
+  --cds-body-long-02-letter-spacing: 0;
+  --cds-code-01-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-01-font-size: 0.75rem;
+  --cds-code-01-font-weight: 400;
+  --cds-code-01-line-height: 1.34;
+  --cds-code-01-letter-spacing: 0.32px;
+  --cds-code-02-font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+  --cds-code-02-font-size: 0.875rem;
+  --cds-code-02-font-weight: 400;
+  --cds-code-02-line-height: 1.43;
+  --cds-code-02-letter-spacing: 0.32px;
+  --cds-heading-01-font-size: 0.875rem;
+  --cds-heading-01-font-weight: 600;
+  --cds-heading-01-line-height: 1.29;
+  --cds-heading-01-letter-spacing: 0.16px;
+  --cds-productive-heading-01-font-size: 0.875rem;
+  --cds-productive-heading-01-font-weight: 600;
+  --cds-productive-heading-01-line-height: 1.29;
+  --cds-productive-heading-01-letter-spacing: 0.16px;
+  --cds-heading-02-font-size: 1rem;
+  --cds-heading-02-font-weight: 600;
+  --cds-heading-02-line-height: 1.375;
+  --cds-heading-02-letter-spacing: 0;
+  --cds-productive-heading-02-font-size: 1rem;
+  --cds-productive-heading-02-font-weight: 600;
+  --cds-productive-heading-02-line-height: 1.375;
+  --cds-productive-heading-02-letter-spacing: 0;
+  --cds-productive-heading-03-font-size: 1.25rem;
+  --cds-productive-heading-03-font-weight: 400;
+  --cds-productive-heading-03-line-height: 1.4;
+  --cds-productive-heading-03-letter-spacing: 0;
+  --cds-productive-heading-04-font-size: 1.75rem;
+  --cds-productive-heading-04-font-weight: 400;
+  --cds-productive-heading-04-line-height: 1.29;
+  --cds-productive-heading-04-letter-spacing: 0;
+  --cds-productive-heading-05-font-size: 2rem;
+  --cds-productive-heading-05-font-weight: 400;
+  --cds-productive-heading-05-line-height: 1.25;
+  --cds-productive-heading-05-letter-spacing: 0;
+  --cds-productive-heading-06-font-size: 2.625rem;
+  --cds-productive-heading-06-font-weight: 300;
+  --cds-productive-heading-06-line-height: 1.199;
+  --cds-productive-heading-06-letter-spacing: 0;
+  --cds-productive-heading-07-font-size: 3.375rem;
+  --cds-productive-heading-07-font-weight: 300;
+  --cds-productive-heading-07-line-height: 1.19;
+  --cds-productive-heading-07-letter-spacing: 0;
+  --cds-expressive-heading-01-font-size: 0.875rem;
+  --cds-expressive-heading-01-font-weight: 600;
+  --cds-expressive-heading-01-line-height: 1.25;
+  --cds-expressive-heading-01-letter-spacing: 0.16px;
+  --cds-expressive-heading-02-font-size: 1rem;
+  --cds-expressive-heading-02-font-weight: 600;
+  --cds-expressive-heading-02-line-height: 1.5;
+  --cds-expressive-heading-02-letter-spacing: 0;
+  --cds-expressive-heading-03-font-size: 1.25rem;
+  --cds-expressive-heading-03-font-weight: 400;
+  --cds-expressive-heading-03-line-height: 1.4;
+  --cds-expressive-heading-03-letter-spacing: 0;
+  --cds-expressive-heading-04-font-size: 1.75rem;
+  --cds-expressive-heading-04-font-weight: 400;
+  --cds-expressive-heading-04-line-height: 1.29;
+  --cds-expressive-heading-04-letter-spacing: 0;
+  --cds-expressive-heading-05-font-size: 2rem;
+  --cds-expressive-heading-05-font-weight: 400;
+  --cds-expressive-heading-05-line-height: 1.25;
+  --cds-expressive-heading-05-letter-spacing: 0;
+  --cds-expressive-heading-06-font-size: 2rem;
+  --cds-expressive-heading-06-font-weight: 600;
+  --cds-expressive-heading-06-line-height: 1.25;
+  --cds-expressive-heading-06-letter-spacing: 0;
+  --cds-expressive-paragraph-01-font-size: 1.5rem;
+  --cds-expressive-paragraph-01-font-weight: 300;
+  --cds-expressive-paragraph-01-line-height: 1.334;
+  --cds-expressive-paragraph-01-letter-spacing: 0;
+  --cds-quotation-01-font-size: 1.25rem;
+  --cds-quotation-01-font-weight: 400;
+  --cds-quotation-01-line-height: 1.3;
+  --cds-quotation-01-letter-spacing: 0;
+  --cds-quotation-02-font-size: 2rem;
+  --cds-quotation-02-font-weight: 300;
+  --cds-quotation-02-line-height: 1.25;
+  --cds-quotation-02-letter-spacing: 0;
+  --cds-display-01-font-size: 2.625rem;
+  --cds-display-01-font-weight: 300;
+  --cds-display-01-line-height: 1.19;
+  --cds-display-01-letter-spacing: 0;
+  --cds-display-02-font-size: 2.625rem;
+  --cds-display-02-font-weight: 600;
+  --cds-display-02-line-height: 1.19;
+  --cds-display-02-letter-spacing: 0;
+  --cds-display-03-font-size: 2.625rem;
+  --cds-display-03-font-weight: 300;
+  --cds-display-03-line-height: 1.19;
+  --cds-display-03-letter-spacing: 0;
+  --cds-display-04-font-size: 2.625rem;
+  --cds-display-04-font-weight: 600;
+  --cds-display-04-line-height: 1.19;
+  --cds-display-04-letter-spacing: 0;
+  --cds-spacing-01: 0.125rem;
+  --cds-spacing-02: 0.25rem;
+  --cds-spacing-03: 0.5rem;
+  --cds-spacing-04: 0.75rem;
+  --cds-spacing-05: 1rem;
+  --cds-spacing-06: 1.5rem;
+  --cds-spacing-07: 2rem;
+  --cds-spacing-08: 2.5rem;
+  --cds-spacing-09: 3rem;
+  --cds-spacing-10: 4rem;
+  --cds-spacing-11: 5rem;
+  --cds-spacing-12: 6rem;
+  --cds-spacing-13: 10rem;
+  --cds-fluid-spacing-01: 0;
+  --cds-fluid-spacing-02: 2vw;
+  --cds-fluid-spacing-03: 5vw;
+  --cds-fluid-spacing-04: 10vw;
+  --cds-layout-01: 1rem;
+  --cds-layout-02: 1.5rem;
+  --cds-layout-03: 2rem;
+  --cds-layout-04: 3rem;
+  --cds-layout-05: 4rem;
+  --cds-layout-06: 6rem;
+  --cds-layout-07: 10rem;
+  --cds-container-01: 1.5rem;
+  --cds-container-02: 2rem;
+  --cds-container-03: 2.5rem;
+  --cds-container-04: 3rem;
+  --cds-container-05: 4rem;
+  --cds-icon-size-01: 1rem;
+  --cds-icon-size-02: 1.25rem;
+  position: fixed;
+  top: var(--cds-spacing-09, 3rem);
+  right: 0;
+  z-index: 2;
+  min-width: 22.75rem;
+  max-width: 22.75rem;
+  min-height: 38.5rem;
+  max-height: 38.5rem;
+  overflow: auto;
+  color: var(--cds-text-01, #161616);
+  background-color: var(--cds-ui-background, #ffffff);
+  transition: transform 110ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-05, 1rem);
+  background-color: var(--cds-ui-background, #ffffff);
+  border-bottom: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__header-flex {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__do-not-disturb-toggle .bx--toggle__switch {
+  margin-top: var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__dismiss-button {
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__header-container .exp--notifications-panel__header {
+  font-size: var(--cds-productive-heading-01-font-size, 0.875rem);
+  font-weight: var(--cds-productive-heading-01-font-weight, 600);
+  line-height: var(--cds-productive-heading-01-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-01-letter-spacing, 0.16px);
+  margin: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__time-section-label {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  font-weight: 600;
+  position: sticky;
+  top: 4.8125rem;
+  z-index: 2;
+  padding: var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+  color: var(--cds-text-02, #525252);
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:hover,
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus {
+  background-color: var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:hover .exp--notifications-panel__dismiss-single-button,
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus .exp--notifications-panel__dismiss-single-button {
+  opacity: 1;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification:focus {
+  border-color: var(--cds-focus, #0f62fe);
+  outline: 0;
+  box-shadow: inset 0 0 0 2px var(--cds-focus, #0f62fe), inset 0 0 0 2px var(--cds-ui-background, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  min-height: 6.25rem;
+  padding: var(--cds-spacing-05, 1rem);
+  text-align: left;
+  background-color: var(--cds-ui-background, #ffffff);
+  border: 0;
+  cursor: pointer;
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-title {
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-text-04, #ffffff);
+  font-weight: 400;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-title.exp--notifications-panel__notification-title-unread {
+  margin-bottom: var(--cds-spacing-02, 0.25rem);
+  color: var(--cds-text-04, #ffffff);
+  font-weight: 600;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notifications-link {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon {
+  min-width: 1rem;
+  margin-right: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-error {
+  fill: var(--cds-support-01, #da1e28);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-success {
+  fill: var(--cds-support-02, #24a148);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-warning {
+  fill: var(--cds-support-03, #f1c21b);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-status-icon.exp--notifications-panel__notification-status-icon-informational {
+  fill: var(--cds-support-04, #0043ce);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-time-label {
+  margin-bottom: var(--cds-spacing-03, 0.5rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-time-label,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  color: var(--cds-text-02, #525252);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description.exp--notifications-panel__notification-short-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-description.exp--notifications-panel__notification-long-description {
+  display: block;
+  -webkit-line-clamp: initial;
+  overflow: initial;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button {
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  min-width: 5.5rem;
+  padding: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button .bx--btn__icon {
+  transition: transform 240ms ease;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button.exp--notifications-panel__notification-read-more-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button.exp--notifications-panel__notification-read-more-button .bx--btn__icon {
+  transform: rotate(0deg);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-more-button.exp--notifications-panel__notification-read-less-button .bx--btn__icon,
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__notification-content .exp--notifications-panel__notification-read-less-button.exp--notifications-panel__notification-read-less-button .bx--btn__icon {
+  transform: rotate(180deg);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__dismiss-single-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  min-width: 2rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+  opacity: 0;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__dismiss-single-button:hover, .exp--notifications-panel__container .exp--notifications-panel__notification .exp--notifications-panel__dismiss-single-button:focus {
+  opacity: 1;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification-today:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-yesterday:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-previous:not(:first-of-type):before {
+  position: absolute;
+  top: 0;
+  width: calc(100% - (2 * var(--cds-spacing-05, 1rem)));
+  height: 1px;
+  margin: 0 auto;
+  background-color: var(--cds-ui-02, #ffffff);
+  transition: background-color 240ms;
+  transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+  content: '';
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__notification-today:hover
++ .exp--notifications-panel__notification-today:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-yesterday:hover
++ .exp--notifications-panel__notification-yesterday:not(:first-of-type):before,
+.exp--notifications-panel__container .exp--notifications-panel__notification-previous:hover
++ .exp--notifications-panel__notification-previous:not(:first-of-type):before {
+  background-color: transparent;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__main-section-empty.exp--notifications-panel__main-section {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: initial;
+  margin-top: var(--cds-layout-07, 10rem);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__main-section-empty.exp--notifications-panel__main-section .exp-subtext {
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__main-section {
+  min-height: 498px;
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  background-color: var(--cds-ui-background, #ffffff);
+  border-top: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__view-all-button {
+  width: 100%;
+  max-width: calc(100% - 2.5rem);
+  height: 2.5rem;
+  min-height: 2.5rem;
+  color: var(--cds-text-01, #161616);
+  border-right: 1px solid var(--cds-ui-02, #ffffff);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__settings-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0;
+  color: var(--cds-text-01, #161616);
+}
+
+.exp--notifications-panel__container .exp--notifications-panel__bottom-actions .exp--notifications-panel__settings-button .bx--btn__icon {
+  margin: 0;
+}
+
 @keyframes rotating {
   0% {
     transform: scaleY(-1) rotate(360deg);

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
@@ -90,6 +90,7 @@ export let NotificationsPanel = React.forwardRef(
       if (open) setRender(true);
     }, [open]);
 
+    /* istanbul ignore next */
     const onAnimationEnd = () => {
       // initialize the notification panel to close
       /* istanbul ignore next */
@@ -215,6 +216,7 @@ export let NotificationsPanel = React.forwardRef(
               )
             )
               return;
+            /* istanbul ignore next */
             if (event.which === 13) {
               notification.onNotificationClick(notification);
             }
@@ -322,7 +324,12 @@ export let NotificationsPanel = React.forwardRef(
         className={cx([blockClass, `${blockClass}__container`], {
           [className]: className,
         })}
-        style={{ animation: `${open ? 'fadeIn 250ms' : 'fadeOut 250ms'}` }}
+        style={{
+          animation: `${
+            /* istanbul ignore next */
+            open ? 'fadeIn 250ms' : 'fadeOut 250ms'
+          }`,
+        }}
         onAnimationEnd={onAnimationEnd}
         ref={ref || notificationPanelRef}>
         <div className={`${blockClass}__header-container`}>

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
@@ -334,5 +334,29 @@ describe('Notifications', () => {
     expect(NotificationsPanel.defaultProps.daysAgoText('test')).toEqual(
       'test days ago'
     );
+    expect(NotificationsPanel.defaultProps.yesterdayAtText('test')).toEqual(
+      'Yesterday at test'
+    );
+    expect(NotificationsPanel.defaultProps.viewAllLabel('test')).toEqual(
+      'View all (test)'
+    );
+    expect(NotificationsPanel.defaultProps.secondsAgoText('test')).toEqual(
+      'test seconds ago'
+    );
+  });
+
+  it('should click onDismissAllNotification and onDismissSingleNotifications buttons to test default props', () => {
+    renderNotifications({
+      data: testData,
+    });
+    const dismissAllButton = screen.getByText(/Dismiss all/i);
+    userEvent.click(dismissAllButton);
+    const notificationElement = screen.getByText(/Test notification title/i)
+      .parentNode.parentNode;
+    const dismissSingleNotificationClass = `${blockClass}__dismiss-single-button`;
+    const dismissIconButtonElement = notificationElement.querySelector(
+      `.${dismissSingleNotificationClass}`
+    );
+    userEvent.click(dismissIconButtonElement);
   });
 });

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/_notifications-panel.scss
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/_notifications-panel.scss
@@ -240,8 +240,8 @@
         @include carbon--type-style('body-short-01');
       }
     }
-    .#{$block-class}-main-section {
-      min-height: 500px;
+    .#{$block-class}__main-section {
+      min-height: 498px;
     }
     .#{$block-class}__bottom-actions {
       position: sticky;

--- a/packages/cloud-cognitive/src/components/_index-released-only.scss
+++ b/packages/cloud-cognitive/src/components/_index-released-only.scss
@@ -8,5 +8,6 @@
 // Package all scss files here for those that want them all bundled up.
 
 @import './AboutModal/index';
+@import './NotificationsPanel/index';
 @import './StatusIcon/index';
 @import './Tearsheet/index';

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -12,6 +12,7 @@ const defaults = {
   component: {
     // reviewed and released components:
     AboutModal: true,
+    NotificationsPanel: true,
     StatusIcon: true,
     Tearsheet: true,
 
@@ -33,7 +34,6 @@ const defaults = {
     NoDataEmptyState: false,
     NoTagsEmptyState: false,
     NotFoundEmptyState: false,
-    NotificationsPanel: false,
     NotificationsEmptyState: false,
     PageActionItem: false,
     PageHeader: false,


### PR DESCRIPTION
Contributes to #574 

Tests now are at 100%, and component has been marked as released with this PR.

#### What did you change?
css snapshot
`NotificationsPanel.js`
`NotificationsPanel.test.js`
`_notifications-panel.scss`
`_index-released-only.css`
`package-settings.js`

#### How did you test and verify your work?
`jest /NotificationsPanel/ --coverage`
and verified in Storybook

*Note: I learned that testing default props that are functions you can write a test that renders the component _without_ those props passed in and target the element/s that trigger those handlers. This ensures that those default props are used. This was part of the reason function testing coverage wasn't at 100% before.