### PR TITLE
Ensure input fields on Tearsheets have correct colours

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1252,6 +1252,17 @@ path:nth-of-type(1),
   background: var(--cds-ui-02, #ffffff);
 }
 
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-area,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--search-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--select-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown-list,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--number input[type='number'],
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--date-picker__input {
+  background-color: var(--cds-ui-01, #f4f4f4);
+}
+
 .exp--tearsheet .exp--tearsheet__buttons {
   border-top: 1px solid var(--cds-ui-03, #e0e0e0);
 }

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1260,7 +1260,7 @@ path:nth-of-type(1),
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown-list,
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--number input[type='number'],
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--date-picker__input {
-  background-color: var(--cds-ui-01, #f4f4f4);
+  background-color: var(--cds-field-01, #f4f4f4);
 }
 
 .exp--tearsheet .exp--tearsheet__buttons {

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1249,7 +1249,7 @@ path:nth-of-type(1),
 }
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main {
-  background: var(--cds-ui-02, #ffffff);
+  background: var(--cds-ui-background, #ffffff);
 }
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input,
@@ -1263,12 +1263,23 @@ path:nth-of-type(1),
   background-color: var(--cds-field-01, #f4f4f4);
 }
 
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-area--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--search--light .bx--search-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--select--light .bx--select-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown--light .bx--dropdown-list,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--number--light input[type='number'],
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--date-picker--light .bx--date-picker__input {
+  background-color: var(--cds-field-02, #ffffff);
+}
+
 .exp--tearsheet .exp--tearsheet__buttons {
   border-top: 1px solid var(--cds-ui-03, #e0e0e0);
 }
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__buttons {
-  background: var(--cds-ui-02, #ffffff);
+  background: var(--cds-ui-background, #ffffff);
 }
 "
 `;

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -11,7 +11,14 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
-import { Button, Tab, Tabs } from 'carbon-components-react';
+import {
+  Button,
+  Form,
+  FormGroup,
+  Tab,
+  Tabs,
+  TextInput,
+} from 'carbon-components-react';
 
 import { Tearsheet, TearsheetNarrow } from '.';
 import {
@@ -114,7 +121,14 @@ const influencer = (
 const label = 'The label of the tearsheet';
 
 const mainContent = (
-  <div className="tearsheet-stories__dummy-content-block">Main content</div>
+  <div className="tearsheet-stories__dummy-content-block">
+    <Form>
+      <p>Main content</p>
+      <FormGroup>
+        <TextInput labelText="Enter an important value here" />
+      </FormGroup>
+    </Form>
+  </div>
 );
 
 const tabs = (

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -126,6 +126,7 @@ const mainContent = (
       <p>Main content</p>
       <FormGroup>
         <TextInput labelText="Enter an important value here" />
+        <TextInput light labelText="Here is a light entry field:" />
       </FormGroup>
     </Form>
   </div>

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -118,7 +118,6 @@ const mainContent = (
       <p>Main content</p>
       <FormGroup>
         <TextInput labelText="Enter an important value here" />
-        <TextInput light labelText="Here is a light entry field:" />
       </FormGroup>
     </Form>
   </div>

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -118,6 +118,7 @@ const mainContent = (
       <p>Main content</p>
       <FormGroup>
         <TextInput labelText="Enter an important value here" />
+        <TextInput light labelText="Here is a light entry field:" />
       </FormGroup>
     </Form>
   </div>

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -11,7 +11,9 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
-import { getStorybookPrefix } from '../../../config';
+
+import { Button, Form, FormGroup, TextInput } from 'carbon-components-react';
+
 import { Tearsheet, TearsheetNarrow } from '.';
 import {
   actionsOptions,
@@ -19,9 +21,8 @@ import {
   actionsMapping,
 } from '../ActionSet/actions.js';
 
+import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, TearsheetNarrow.displayName);
-
-import { Button } from 'carbon-components-react';
 
 import styles from './_storybook-styles.scss';
 
@@ -112,7 +113,14 @@ const description = (
 const label = 'The label of the tearsheet';
 
 const mainContent = (
-  <div className="tearsheet-stories__dummy-content-block">Main content</div>
+  <div className="tearsheet-stories__dummy-content-block">
+    <Form>
+      <p>Main content</p>
+      <FormGroup>
+        <TextInput labelText="Enter an important value here" />
+      </FormGroup>
+    </Form>
+  </div>
 );
 
 const title = 'Title of the tearsheet';

--- a/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
@@ -9,8 +9,8 @@
 
 .tearsheet-stories__dummy-content-block {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: top;
+  justify-content: flex-start;
   height: 100%;
   padding: $layout-04;
 }

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -216,6 +216,18 @@
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__main {
     background: $ui-02;
+
+    // revert the background colour overridden by bx--modal styles
+    .#{$prefix}--text-input,
+    .#{$prefix}--text-area,
+    .#{$prefix}--search-input,
+    .#{$prefix}--select-input,
+    .#{$prefix}--dropdown,
+    .#{$prefix}--dropdown-list,
+    .#{$prefix}--number input[type='number'],
+    .#{$prefix}--date-picker__input {
+      background-color: $field-01;
+    }
   }
 
   .#{$block-class} .#{$block-class}__buttons {

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -215,7 +215,7 @@
   }
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__main {
-    background: $ui-02;
+    background: $ui-background;
 
     // revert the background colour overridden by bx--modal styles
     .#{$prefix}--text-input,
@@ -228,6 +228,18 @@
     .#{$prefix}--date-picker__input {
       background-color: $field-01;
     }
+
+    // and restore the 'light' prop in case light fields are wanted
+    .#{$prefix}--text-input--light,
+    .#{$prefix}--text-area--light,
+    .#{$prefix}--search--light .#{$prefix}--search-input,
+    .#{$prefix}--select--light .#{$prefix}--select-input,
+    .#{$prefix}--dropdown--light,
+    .#{$prefix}--dropdown--light .#{$prefix}--dropdown-list,
+    .#{$prefix}--number--light input[type='number'],
+    .#{$prefix}--date-picker--light .#{$prefix}--date-picker__input {
+      background-color: $field-02;
+    }
   }
 
   .#{$block-class} .#{$block-class}__buttons {
@@ -235,7 +247,7 @@
   }
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__buttons {
-    background: $ui-02;
+    background: $ui-background;
   }
 }
 

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -15,6 +15,7 @@ const defaults = {
     NotificationsPanel: true,
     StatusIcon: true,
     Tearsheet: true,
+    TearsheetNarrow: true,
 
     // other public components not yet reviewed and released:
     ActionBarItem: false,
@@ -43,7 +44,6 @@ const defaults = {
     Saving: false,
     SidePanel: false,
     TagSet: false,
-    TearsheetNarrow: false,
     UnauthorizedEmptyState: false,
     UserProfileImage: false,
     WebTerminal: false,


### PR DESCRIPTION
Resolves #339 

Modal styles override input fields to use $field-02 over $ui-01. However, in wide Tearsheets, the main content background is set to $ui-02 to create a gray 'layer', so we need to revert the input fields to use $field-01 over this to match.

Also, mark TearsheetNarrow as released, which was accidentally missed.

#### What did you change?

Tearsheet styles and stories, plus package-settings and the global css snapshot.

#### How did you test and verify your work?

Ran build, tests, storybook.
