### PR TITLE
Fix styling on ActionSet to ensure SidePanel and Tearsheet buttons match design

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -31,6 +31,7 @@ const ActionSetButton = React.forwardRef(
       label,
       loading,
       onClick,
+      size,
       // Collect any other property values passed in.
       ...rest
     },
@@ -46,7 +47,7 @@ const ActionSetButton = React.forwardRef(
         { [`${blockClass}__action-button--ghost`]: kind === 'ghost' },
       ])}
       disabled={disabled || loading || false}
-      {...{ kind, onClick, ref }}>
+      {...{ kind, onClick, ref, size }}>
       {label}
       {loading && <InlineLoading />}
     </Button>
@@ -60,6 +61,7 @@ ActionSetButton.propTypes = {
   label: PropTypes.string,
   loading: PropTypes.bool,
   onClick: PropTypes.func,
+  size: Button.propTypes.size,
 };
 
 const defaultKind = Button.defaultProps.kind;
@@ -84,6 +86,7 @@ export const ActionSet = React.forwardRef(
     {
       // The component props, in alphabetical order (for consistency).
       actions,
+      buttonSize,
       className,
       size,
       // Collect any other property values passed in.
@@ -135,7 +138,11 @@ export const ActionSet = React.forwardRef(
         role="presentation"
         stacked={stack}>
         {buttons.map((action, index) => (
-          <ActionSetButton {...action} key={index} />
+          <ActionSetButton
+            key={action.key || index}
+            {...action}
+            size={buttonSize}
+          />
         ))}
       </ButtonSet>
     );
@@ -229,6 +236,14 @@ ActionSet.propTypes = {
       })
     ),
   ]),
+
+  /**
+   * Specify the size of buttons to use for the actions. The allowed values are
+   * those for the size prop of carbon Button. If this prop is specified, all
+   * the buttons will be set to this size, overriding any 'size' values (if any)
+   * supplied in the actions array (if any).
+   */
+  buttonSize: Button.propTypes.size,
 
   /**
    * Sets an optional className to be added to the side panel outermost element.

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
@@ -40,10 +40,11 @@ export default {
 };
 
 // eslint-disable-next-line react/prop-types
-const Template = ({ actions, ...args }) => {
+const Template = ({ actions, size, ...args }) => {
   return (
-    <div className={`${blockClass}__story-container`}>
-      <ActionSet {...args} actions={actions} />
+    <div
+      className={`${blockClass}__story-container ${blockClass}__story-container--${size}`}>
+      <ActionSet {...{ actions, size, ...args }} />
     </div>
   );
 };

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -21,22 +21,34 @@
     justify-content: flex-end;
   }
 
-  // For stacking,
-  // or row-single in medium,
-  // or for ghosts in row-single,
-  // buttons are 100% width -- so set that by default
+  .#{$block-class}.#{$block-class}--stack {
+    align-items: stretch;
+  }
+
   .#{$block-class} .#{$block-class}__action-button {
-    width: 100%;
-    max-width: 100%;
+    align-items: center;
+    max-width: none;
+    height: $spacing-10;
+    margin: 0;
+    padding-top: $spacing-05;
+    padding-bottom: $spacing-07;
+  }
+
+  // For row-single in medium,
+  // or for ghosts in row-single,
+  // buttons are 100% width
+  .#{$block-class}.#{$block-class}--row-single.#{$block-class}--md
+    .#{$block-class}__action-button,
+  .#{$block-class}.#{$block-class}--row-single
+    .#{$block-class}__action-button--ghost {
+    flex: 0 1 100%;
   }
 
   // For ghosts in row-double,
   // buttons are 75% width
-  .#{$block-class}__action-button,
   .#{$block-class}.#{$block-class}--row-double
     .#{$block-class}__action-button--ghost {
-    width: 75%;
-    max-width: 75%;
+    flex: 0 1 75%;
   }
 
   // For row-single in large (non-ghost),
@@ -51,8 +63,7 @@
     .#{$block-class}__action-button,
   .#{$block-class}.#{$block-class}--row-triple
     .#{$block-class}__action-button--ghost {
-    width: 50%;
-    max-width: 50%;
+    flex: 0 1 50%;
   }
 
   // For row-triple in large (non-ghost),
@@ -67,8 +78,7 @@
     .#{$block-class}__action-button:not(.#{$block-class}__action-button--ghost),
   .#{$block-class}.#{$block-class}--row-quadruple
     .#{$block-class}__action-button {
-    width: 25%;
-    max-width: 25%;
+    flex: 0 1 25%;
   }
 
   .#{$block-class} .#{$block-class}__action-button .bx--inline-loading {

--- a/packages/cloud-cognitive/src/components/ActionSet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_storybook-styles.scss
@@ -11,24 +11,28 @@
 $block-class: #{$pkg-prefix}--action-set;
 
 .#{$block-class}__story-container {
-  min-width: 90vw;
+  min-width: 96vw;
   min-height: 3rem;
   border: 1px solid $decorative-01;
   box-shadow: 0 0 10px 5px $ui-04;
 }
 
-.#{$block-class}.#{$block-class}--lg {
+.#{$block-class}__story-container--xlg {
+  min-width: 75vw;
+}
+
+.#{$block-class}__story-container--lg {
   min-width: 60vw;
 }
 
-.#{$block-class}.#{$block-class}--md {
+.#{$block-class}__story-container--md {
   min-width: 45vw;
 }
 
-.#{$block-class}.#{$block-class}--sm {
+.#{$block-class}__story-container--sm {
   min-width: 30vw;
 }
 
-.#{$block-class}.#{$block-class}--xs {
+.#{$block-class}__story-container--xs {
   min-width: 25vw;
 }

--- a/packages/cloud-cognitive/src/components/ActionSet/actions.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/actions.js
@@ -19,11 +19,12 @@ export const actionsLabels = {
 };
 
 export const actionsMapping = (labels, action) => {
-  const act = (label, kind) => {
+  const act = (label, kind, key) => {
     const actionCall = action && action(`Click on '${label}'`);
     return {
       label,
       kind,
+      key,
       onClick:
         actionCall &&
         ((evt) => {
@@ -32,10 +33,10 @@ export const actionsMapping = (labels, action) => {
         }),
     };
   };
-  const primary = act(labels?.primary ?? 'Primary button', 'primary');
-  const secondary = act(labels?.secondary ?? 'Secondary button', 'secondary');
-  const secondary2 = act(labels?.secondary2 ?? 'Secondary button', 'secondary');
-  const ghost = act(labels?.ghost ?? 'Ghost button', 'ghost');
+  const primary = act(labels?.primary ?? 'Primary', 'primary', 1);
+  const secondary = act(labels?.secondary ?? 'Secondary', 'secondary', 2);
+  const secondary2 = act(labels?.secondary2 ?? 'Secondary', 'secondary', 3);
+  const ghost = act(labels?.ghost ?? 'Ghost', 'ghost', 4);
 
   return {
     0: [],

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -298,11 +298,11 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
         max-width: 75%;
       }
       .#{$action-set-block-class}__action-button {
-        min-height: $layout-05;
+        height: $layout-05;
       }
       &.#{$block-class}__actions-container-condensed
         .#{$action-set-block-class}__action-button {
-        min-height: $layout-04;
+        height: $layout-04;
       }
     }
   }

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
@@ -102,6 +102,7 @@ export let Tearsheet = React.forwardRef(
             <ActionSet
               actions={actions}
               size="max"
+              buttonSize="xl"
               className={`${blockClass}__buttons`}
             />
           )}

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -39,12 +39,19 @@
     "test": "bundler check '**/*.scss'"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^10.29.0",
+    "@carbon/import-once": "^10.5.0",
+    "carbon-components": "^10.32.1",
+    "carbon-components-react": "^7.32.1",
+    "carbon-icons": "^7.0.7",
     "react": "^16.13.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@carbon/ibm-cloud-cognitive": "^0.35.9",
-    "@carbon/telemetry": "^0.0.0-alpha.6"
+    "@carbon/ibm-cloud-cognitive-security": "^0.4.14",
+    "@carbon/telemetry": "^0.0.0-alpha.6",
+    "react-resize-detector": "^5.2.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"


### PR DESCRIPTION
Contributes to #546

The carbon ButtonSet only applies full bleed styling when placed into a modal footer, and does not have any other way to request full bleed style. So replicate the full bleed style into ActionSet to ensure the correct styles are used: heights, and alignment. Also enabled Tearsheet to request extra large buttons, and improved the stories a little.

#### What did you change?

ActionSet, also SidePanel styles (changed way button heights are set), and Tearsheet.

#### How did you test and verify your work?

Ran build, ran tests, ran storybook.