### PR TITLE
Align Tearsheet to updated design

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1180,8 +1180,28 @@ path:nth-of-type(1),
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header {
   margin: 0;
-  padding: var(--cds-spacing-06, 1.5rem);
+  padding: var(--cds-spacing-07, 2rem);
   border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--tearsheet.exp--tearsheet--narrow .exp--tearsheet__header {
+  margin: 0;
+  padding: var(--cds-spacing-05, 1rem);
+}
+
+.exp--tearsheet.exp--tearsheet--wide
+.exp--tearsheet__header--with-close-icon {
+  margin-right: var(--cds-spacing-09, 3rem);
+  padding-right: var(--cds-spacing-05, 1rem);
+}
+
+.exp--tearsheet .exp--tearsheet__header-content {
+  display: flex;
+  justify-content: space-between;
+}
+
+.exp--tearsheet .exp--tearsheet__header-actions {
+  padding-left: var(--cds-spacing-06, 1.5rem);
 }
 
 .exp--tearsheet .exp--tearsheet__header--no-close-icon {

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -11,8 +11,11 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import '../../utils/enable-all'; // must come before component is imported (directly or indirectly)
+
 import {
   Button,
+  ButtonSet,
+  Dropdown,
   Form,
   FormGroup,
   Tab,
@@ -37,67 +40,59 @@ import mdx from './Tearsheet.mdx';
 export default {
   title: `${storybookPrefix}/Tearsheets/${Tearsheet.displayName}`,
   component: Tearsheet,
-  subcomponents: {
-    TearsheetNarrow,
-  },
+  subcomponents: { TearsheetNarrow },
   parameters: { styles, docs: { page: mdx } },
   argTypes: {
     actions: {
-      control: {
-        type: 'select',
-        labels: actionsLabels,
-      },
+      control: { type: 'select', labels: actionsLabels },
       options: actionsOptions,
       mapping: actionsMapping(
         {
           primary: 'Replace',
-          secondary: 'Stop',
+          secondary: 'Back',
           secondary2: 'Keep Both',
           ghost: 'Cancel',
         },
         action
       ),
     },
-    description: {
+    description: { control: { type: 'text' } },
+    headerActions: {
       control: {
-        type: 'text',
+        type: 'select',
+        labels: {
+          0: 'none',
+          1: 'drop-down',
+          2: 'buttons',
+        },
+      },
+      options: [0, 1, 2],
+      mapping: {
+        0: null,
+        1: (
+          <Dropdown
+            label="Choose an option"
+            items={['option 1', 'option 2', 'option 3', 'option 4']}
+          />
+        ),
+        2: (
+          <ButtonSet>
+            <Button kind="secondary" size="sm" style={{ width: 'initial' }}>
+              Secondary
+            </Button>
+            <Button kind="primary" size="sm" style={{ width: 'initial' }}>
+              Primary
+            </Button>
+          </ButtonSet>
+        ),
       },
     },
-    label: {
-      control: {
-        type: 'text',
-      },
-    },
-    title: {
-      control: {
-        type: 'text',
-      },
-    },
-    children: {
-      control: {
-        disable: true,
-      },
-    },
-    influencer: {
-      control: {
-        disable: true,
-      },
-    },
-    onClose: {
-      control: {
-        disable: true,
-      },
-    },
-    navigation: {
-      control: {
-        disable: true,
-      },
-    },
-    open: {
-      control: {
-        disable: true,
-      },
-    },
+    label: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    influencer: { control: { disable: true } },
+    onClose: { control: { disable: true } },
+    navigation: { control: { disable: true } },
+    open: { control: { disable: true } },
   },
 };
 
@@ -105,14 +100,9 @@ export default {
 
 const closeIconDescription = 'Close the tearsheet';
 
-const description = (
-  <span>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor <strong>incididunt ut labore</strong> et dolore magna aliqua. Ut enim
-    ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
-    ex ea commodo consequat.
-  </span>
-);
+const description =
+  'This is a description for the tearsheet, providing an opportunity to \
+  describe the flow.';
 
 const influencer = (
   <div className="tearsheet-stories__dummy-content-block">Influencer</div>
@@ -152,7 +142,7 @@ const Template = ({ actions, ...args }) => {
 
   return (
     <>
-      <style>{`.${pkg.prefix}-tearsheet { opacity: 0 }`};</style>
+      <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
       <Button onClick={() => setOpen(true)}>Open Tearsheet</Button>
       <Tearsheet
         {...args}
@@ -165,11 +155,47 @@ const Template = ({ actions, ...args }) => {
 };
 
 // Stories
-export const AllAttributesSet = Template.bind({});
-AllAttributesSet.args = {
+export const tearsheet = Template.bind({});
+tearsheet.storyName = 'Tearsheet';
+tearsheet.args = {
+  description,
+  onClose: action('onClose called'),
+  title,
+  actions: 6,
+};
+
+export const withAllHeaderItems = Template.bind({});
+withAllHeaderItems.storyName = 'Tearsheet with navigation';
+withAllHeaderItems.args = {
+  closeIconDescription,
+  description,
+  label,
+  navigation: tabs,
+  onClose: action('onClose called'),
+  title,
+  actions: 6,
+};
+
+export const withInfluencer = Template.bind({});
+withInfluencer.storyName = 'Tearsheet with influencer';
+withInfluencer.args = {
+  description,
+  influencer,
+  influencerPosition: 'left',
+  influencerWidth: 'narrow',
+  onClose: action('onClose called'),
+  title,
+  verticalPosition: 'normal',
+  actions: 6,
+};
+
+export const fullyLoaded = Template.bind({});
+fullyLoaded.storyName = 'Tearsheet with all header items and influencer';
+fullyLoaded.args = {
   closeIconDescription,
   description,
   hasCloseIcon: true,
+  headerActions: 2,
   influencer,
   influencerPosition: 'left',
   influencerWidth: 'narrow',
@@ -178,29 +204,5 @@ AllAttributesSet.args = {
   onClose: action('onClose called'),
   title,
   verticalPosition: 'normal',
-  actions: 3,
-};
-
-export const NoAttributesSet = Template.bind({});
-NoAttributesSet.args = {};
-
-export const NoHeaderNavigation = Template.bind({});
-NoHeaderNavigation.args = {
-  closeIconDescription,
-  description,
-  influencer,
-  label,
-  onClose: action('onClose called'),
-  title,
-  actions: 3,
-};
-
-export const NoHeaderNavigationOrInfluencer = Template.bind({});
-NoHeaderNavigationOrInfluencer.args = {
-  closeIconDescription,
-  description,
-  label,
-  onClose: action('onClose called'),
-  title,
-  actions: 3,
+  actions: 0,
 };

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
@@ -14,7 +14,7 @@ import '../../utils/enable-all'; // must come before component is imported (dire
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-import { Tab, Tabs } from 'carbon-components-react';
+import { Button, ButtonSet, Tab, Tabs } from 'carbon-components-react';
 import { Tearsheet, TearsheetNarrow } from '.';
 
 const blockClass = `${pkg.prefix}--tearsheet`;
@@ -43,6 +43,12 @@ const description = (
     ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
     ex ea commodo consequat.
   </span>
+);
+const headerActionButtonLabel = `Button ${uuidv4()}`;
+const headerActions = (
+  <ButtonSet>
+    <Button>{headerActionButtonLabel}</Button>
+  </ButtonSet>
 );
 const influencerFragment = `This is a ${uuidv4()} convincing influencer`;
 const influencer = <div>{influencerFragment}</div>;
@@ -194,6 +200,11 @@ const commonTests = (Ts, name) => {
 
 describe(componentName, () => {
   commonTests(Tearsheet, componentName);
+
+  it('renders headerActions', () => {
+    render(<Tearsheet {...{ headerActions }} />);
+    screen.getByText(headerActionButtonLabel);
+  });
 
   it('renders influencer', () => {
     render(<Tearsheet {...{ influencer }} />);

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -31,16 +31,11 @@ import mdx from './Tearsheet.mdx';
 export default {
   title: `${storybookPrefix}/Tearsheets/${TearsheetNarrow.displayName}`,
   component: TearsheetNarrow,
-  subcomponents: {
-    Tearsheet,
-  },
+  subcomponents: { Tearsheet },
   parameters: { styles, docs: { page: mdx } },
   argTypes: {
     actions: {
-      control: {
-        type: 'select',
-        labels: actionsLabels,
-      },
+      control: { type: 'select', labels: actionsLabels },
       options: actionsOptions,
       mapping: actionsMapping(
         {
@@ -52,68 +47,27 @@ export default {
         action
       ),
     },
-    className,
     closeIconDescription: {},
-    description: {
-      control: {
-        type: 'text',
-      },
-    },
-    hasCloseIcon: {},
-    height: {},
-    label: {
-      control: {
-        type: 'text',
-      },
-    },
-    preventCloseOnClickOutside: {},
-    title: {
-      control: {
-        type: 'text',
-      },
-    },
-    buttons: {
-      control: {
-        disable: true,
-      },
-    },
-    children: {
-      control: {
-        disable: true,
-      },
-    },
-    onClose: {
-      control: {
-        disable: true,
-      },
-    },
-    open: {
-      control: {
-        disable: true,
-      },
-    },
+    description: { control: { type: 'text' } },
+    label: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    onClose: { control: { disable: true } },
+    open: { control: { disable: true } },
   },
 };
 
 // Test values for props.
 
-const className = 'client-class-1 client-class-2';
-
 const closeIconDescription = 'Close the tearsheet';
 
-const description = (
-  <span>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor <strong>incididunt ut labore</strong> et dolore magna aliqua. Ut enim
-    ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
-    ex ea commodo consequat.
-  </span>
-);
+const description =
+  'This is a description for the tearsheet, providing an opportunity to \
+  describe the flow.';
 
 const label = 'The label of the tearsheet';
 
 const mainContent = (
-  <div className="tearsheet-stories__dummy-content-block">
+  <div className="tearsheet-stories__narrow-content-block">
     <Form>
       <p>Main content</p>
       <FormGroup>
@@ -132,7 +86,7 @@ const Template = ({ actions, ...args }) => {
 
   return (
     <>
-      <style>{`.${pkg.prefix}-tearsheet { opacity: 0 }`};</style>
+      <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
       <Button onClick={() => setOpen(true)}>Open Tearsheet</Button>
       <TearsheetNarrow
         {...args}
@@ -145,17 +99,24 @@ const Template = ({ actions, ...args }) => {
 };
 
 // Stories
-export const AllAttributesSet = Template.bind({});
-AllAttributesSet.args = {
+export const tearsheetNarrow = Template.bind({});
+tearsheetNarrow.storyName = 'Narrow tearsheet';
+tearsheetNarrow.args = {
+  description,
+  onClose: action('onClose called'),
+  title,
+  actions: 6,
+};
+
+export const fullyLoaded = Template.bind({});
+fullyLoaded.storyName = 'Narrow tearsheet with all header items';
+fullyLoaded.args = {
   closeIconDescription,
   description,
   hasCloseIcon: true,
   label,
-  preventCloseOnClickOutside: true,
+  onClose: action('onClose called'),
   title,
   verticalPosition: 'normal',
-  actions: 3,
+  actions: 0,
 };
-
-export const NoAttributesSet = Template.bind({});
-NoAttributesSet.args = {};

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -11,7 +11,7 @@ import React, { useEffect, useLayoutEffect, useState, useRef } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.
 import { ComposedModal, ModalHeader, ModalBody } from 'carbon-components-react';
@@ -19,6 +19,7 @@ import { ActionSet } from '../ActionSet';
 
 // The block part of our conventional BEM class names (bc__E--M).
 const bc = `${pkg.prefix}--tearsheet`;
+const bcModalHeader = `${carbon.prefix}--modal-header`;
 const componentName = 'TearsheetShell';
 
 const maxDepth = 3;
@@ -35,21 +36,28 @@ const stack = { open: [], all: [] };
 
 // these props are only applicable when size='wide'
 export const tearsheetShellWideProps = [
+  'headerActions',
   'influencer',
   'influencerPosition',
   'influencerWidth',
   'navigation',
 ];
 
-// A simple <div> wrapper conditional on the content being truthy
-const Div = ({ children, cx, ...rest }) =>
+// A simple <div> (or other element) wrapper that only renders conditionally
+// on the content being truthy
+const DivIf = ({ Element, children, cx, ...rest }) =>
   children ? (
-    <div {...rest} className={cx}>
+    <Element {...rest} className={cx}>
       {children}
-    </div>
+    </Element>
   ) : null;
 
-Div.propTypes = { children: PropTypes.node, cx: PropTypes.string };
+DivIf.propTypes = {
+  Element: PropTypes.string,
+  children: PropTypes.node,
+  cx: PropTypes.string,
+};
+DivIf.defaultProps = { Element: 'div' };
 
 // TearSheetShell is used internally by TearSheet and TearSheetNarrow
 export const TearsheetShell = React.forwardRef(
@@ -62,6 +70,7 @@ export const TearsheetShell = React.forwardRef(
       closeIconDescription,
       description,
       hasCloseIcon,
+      headerActions,
       influencer,
       influencerPosition,
       influencerWidth,
@@ -136,12 +145,25 @@ export const TearsheetShell = React.forwardRef(
     }, [open]);
 
     if (position <= depth) {
+      // we include a modal header if and only if one or more of these is given
+      const includeHeader =
+        label ||
+        title ||
+        description ||
+        headerActions ||
+        navigation ||
+        hasCloseIcon;
+
+      // We include an ActionSet if and only if one or more actions is given
+      const includeActions = actions && actions?.length > 0;
+
       return (
         <ComposedModal
           {
             // Pass through any other property values.
             ...rest
           }
+          aria-label={title}
           className={cx(bc, className, {
             [`${bc}--stacked-${position}-of-${depth}`]:
               // Don't apply this on the initial open of a single tearsheet.
@@ -154,29 +176,44 @@ export const TearsheetShell = React.forwardRef(
           })}
           {...{ onClose, open, preventCloseOnClickOutside, ref }}
           size="sm">
-          {(label || title || description || navigation || hasCloseIcon) && (
+          {includeHeader && (
             <ModalHeader
-              className={`${bc}__header`}
+              className={cx(`${bc}__header`, {
+                [`${bc}__header--with-close-icon`]: hasCloseIcon,
+              })}
               closeClassName={cx({
                 [`${bc}__header--no-close-icon`]: !hasCloseIcon,
               })}
-              {...{ iconDescription: closeIconDescription, label, title }}>
-              <Div cx={`${bc}__header-description`}>{description}</Div>
-              <Div cx={`${bc}__header-navigation`}>{navigation}</Div>
+              iconDescription={closeIconDescription}>
+              <DivIf cx={`${bc}__header-content`}>
+                <DivIf>
+                  {/* we create the label and title here instead of passing them
+                      as modal header props so we can wrap them in layout divs */}
+                  <DivIf Element="h2" cx={`${bcModalHeader}__label`}>
+                    {label}
+                  </DivIf>
+                  <DivIf Element="h3" cx={`${bcModalHeader}__heading`}>
+                    {title}
+                  </DivIf>
+                  <DivIf cx={`${bc}__header-description`}>{description}</DivIf>
+                </DivIf>
+                <DivIf cx={`${bc}__header-actions`}>{headerActions}</DivIf>
+              </DivIf>
+              <DivIf cx={`${bc}__header-navigation`}>{navigation}</DivIf>
             </ModalHeader>
           )}
           <ModalBody className={`${bc}__body`}>
-            <Div
+            <DivIf
               cx={cx({
                 [`${bc}__influencer`]: true,
                 [`${bc}__influencer--right`]: influencerPosition === 'right',
                 [`${bc}__influencer--wide`]: influencerWidth === 'wide',
               })}>
               {influencer}
-            </Div>
-            <Div cx={`${bc}__right`}>
-              <Div cx={`${bc}__main`}>{children}</Div>
-              {actions && actions.length > 0 && (
+            </DivIf>
+            <DivIf cx={`${bc}__right`}>
+              <DivIf cx={`${bc}__main`}>{children}</DivIf>
+              {includeActions && (
                 <ActionSet
                   actions={actions}
                   buttonSize={size === 'wide' ? 'xl' : null}
@@ -184,7 +221,7 @@ export const TearsheetShell = React.forwardRef(
                   size={size === 'wide' ? 'max' : 'lg'}
                 />
               )}
-            </Div>
+            </DivIf>
           </ModalBody>
         </ComposedModal>
       );
@@ -256,6 +293,14 @@ TearsheetShell.propTypes = {
    * a "passive tearsheet").
    */
   hasCloseIcon: PropTypes.bool,
+
+  /**
+   * The content for the header actions area, displayed alongside the title in
+   * the header area of the tearsheet. This is typically a drop-down, or a set
+   * of small buttons, or similar. NB the headerActions is only applicable for
+   * wide tearsheets.
+   */
+  headerActions: PropTypes.element,
 
   /**
    * The content for the influencer section of the tearsheet, displayed

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -170,6 +170,7 @@ export const TearsheetShell = React.forwardRef(
               open && (depth > 1 || (depth === 1 && prevDepth.current > 1)),
             [`${bc}--stacked-closed`]: !open && depth > 0,
             [`${bc}--wide`]: size === 'wide',
+            [`${bc}--narrow`]: size !== 'wide',
           })}
           containerClassName={cx(`${bc}__container`, {
             [`${bc}__container--lower`]: verticalPosition === 'lower',

--- a/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
@@ -12,36 +12,15 @@
   align-items: top;
   justify-content: flex-start;
   height: 100%;
-  padding: $layout-04;
+  padding: $layout-02 $layout-03;
 }
 
-.tearsheet-stories__buttons {
+.tearsheet-stories__narrow-content-block {
   display: flex;
-  justify-content: flex-end;
-}
-
-.tearsheet-stories__button-25,
-.tearsheet-stories__button-50 {
-  max-width: none;
-  // stylelint-disable-next-line carbon/layout-token-use
-  margin-left: 1px;
-}
-
-.tearsheet-stories__button-25 {
-  width: 25%;
-}
-
-.tearsheet-stories__button-50 {
-  width: 50%;
-}
-
-.tearsheet-stories__button-25:first-child,
-.tearsheet-stories__button-50:first-child {
-  margin-left: 0;
-}
-
-.tearsheet-stories__button-padding {
-  width: 100%;
+  align-items: top;
+  justify-content: flex-start;
+  height: 100%;
+  padding: $layout-01;
 }
 
 .tearsheet-stories__tabs {

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -151,8 +151,13 @@
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__header {
     margin: 0;
-    padding: $spacing-06;
+    padding: $spacing-07;
     border-bottom: 1px solid $ui-03;
+  }
+
+  .#{$block-class}.#{$block-class}--narrow .#{$block-class}__header {
+    margin: 0;
+    padding: $spacing-05;
   }
 
   .#{$block-class}.#{$block-class}--wide

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -155,6 +155,21 @@
     border-bottom: 1px solid $ui-03;
   }
 
+  .#{$block-class}.#{$block-class}--wide
+    .#{$block-class}__header--with-close-icon {
+    margin-right: $spacing-09;
+    padding-right: $spacing-05;
+  }
+
+  .#{$block-class} .#{$block-class}__header-content {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .#{$block-class} .#{$block-class}__header-actions {
+    padding-left: $spacing-06;
+  }
+
   .#{$block-class} .#{$block-class}__header--no-close-icon {
     display: none;
   }


### PR DESCRIPTION
Resolves #546 (hopefully properly this time :-) @andrea-gm)

Add a `headerActions` prop to allow actions to be inserted into the header. Adjust some margins and padding. Fix the stories to align with the recommended design to, and rework the stories to make a more useful set of scenarios.

#### What did you change?

Tearsheet files. NB this PR changes the SCSS for released components (Tearsheet/TearsheetNarrow).

#### How did you test and verify your work?

Ran build, tests, storybook. Verified that Tearsheet test coverage remains at 100%.