### PR TITLE
chore(Notifications): remove istanbul ignores, refactor side panel tests

### DIFF
--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
@@ -90,11 +90,9 @@ export let NotificationsPanel = React.forwardRef(
       if (open) setRender(true);
     }, [open]);
 
-    /* istanbul ignore next */
     const onAnimationEnd = () => {
       // initialize the notification panel to close
-      /* istanbul ignore next */
-      if (!open) setRender(false);
+      !open && setRender(false);
     };
 
     const sortChronologically = (arr) => {
@@ -216,10 +214,8 @@ export let NotificationsPanel = React.forwardRef(
               )
             )
               return;
-            /* istanbul ignore next */
-            if (event.which === 13) {
+            event.which === 13 &&
               notification.onNotificationClick(notification);
-            }
           }}>
           {notification.type === 'error' && (
             <ErrorFilled16
@@ -321,14 +317,9 @@ export let NotificationsPanel = React.forwardRef(
           ...rest
         }
         id={blockClass}
-        className={cx([blockClass, `${blockClass}__container`], {
-          [className]: className,
-        })}
+        className={cx(blockClass, className, `${blockClass}__container`)}
         style={{
-          animation: `${
-            /* istanbul ignore next */
-            open ? 'fadeIn 250ms' : 'fadeOut 250ms'
-          }`,
+          animation: `${open ? 'fadeIn 250ms' : 'fadeOut 250ms'}`,
         }}
         onAnimationEnd={onAnimationEnd}
         ref={ref || notificationPanelRef}>

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
@@ -46,10 +46,19 @@ const renderNotifications = ({ ...rest }) =>
 
 describe('Notifications', () => {
   it('renders the notification panel', () => {
-    renderNotifications({
+    const { animationStart, animationEnd } = fireEvent;
+    const { container, rerender } = renderNotifications({
       data: [],
     });
     expect(screen.queryAllByText(/Notifications/i)).toBeTruthy();
+    const outerElement = container.querySelector(`.${blockClass}`);
+    userEvent.click(container);
+    expect(onClickOutside).toHaveBeenCalled();
+    animationStart(outerElement);
+    rerender(
+      <NotificationsPanel open={false} onClickOutside={jest.fn()} data={[]} />
+    );
+    animationEnd(outerElement);
   });
 
   it('should toggle do not disturb switch', () => {

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -53,14 +53,11 @@ describe('SidePanel', () => {
   it('renders the side panel', () => {
     const subtitle = uuidv4();
     const labelText = uuidv4();
-    renderSidePanel(
-      {
-        title: 'Test side panel',
-        subtitle,
-        labelText,
-      },
-      'content'
-    );
+    renderSidePanel({
+      title: 'Test side panel',
+      subtitle,
+      labelText,
+    });
     expect(screen.queryAllByText(/Test side panel/i)).toBeTruthy();
     expect(screen.getByText(subtitle));
     expect(screen.getByText(labelText));
@@ -68,13 +65,10 @@ describe('SidePanel', () => {
 
   it('should render a side panel with an overlay and trigger clickOutside hook when clicked', () => {
     const onRequestCloseFn = jest.fn();
-    const { container } = renderSidePanel(
-      {
-        includeOverlay: true,
-        onRequestClose: onRequestCloseFn,
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      includeOverlay: true,
+      onRequestClose: onRequestCloseFn,
+    });
     const overlayElement = container.querySelector(`.${blockClass}__overlay`);
     expect(overlayElement).toBeTruthy();
     userEvent.click(overlayElement);
@@ -82,12 +76,9 @@ describe('SidePanel', () => {
   });
 
   it('should render a side panel from the right', () => {
-    const { container } = renderSidePanel(
-      {
-        placement: 'right',
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      placement: 'right',
+    });
     const sidePanelOuter = container.querySelector(
       `.${blockClass}__container-right-placement`
     );
@@ -95,12 +86,9 @@ describe('SidePanel', () => {
   });
 
   it('should render a side panel from the left', () => {
-    const { container } = renderSidePanel(
-      {
-        placement: 'left',
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      placement: 'left',
+    });
     const sidePanelOuter = container.querySelector(
       `.${blockClass}__container-left-placement`
     );
@@ -143,12 +131,9 @@ describe('SidePanel', () => {
   });
 
   it('should test overlay exit animation', async () => {
-    const { container, rerender } = renderSidePanel(
-      {
-        includeOverlay: true,
-      },
-      'content'
-    );
+    const { container, rerender } = renderSidePanel({
+      includeOverlay: true,
+    });
     const closeIconButton = container.querySelector(
       `.${blockClass}__close-button`
     );
@@ -161,19 +146,16 @@ describe('SidePanel', () => {
   });
 
   it('should render one primary action button', () => {
-    const { container } = renderSidePanel(
-      {
-        includeOverlay: true,
-        actions: [
-          {
-            label: 'Primary button',
-            onClick: () => {},
-            kind: 'primary',
-          },
-        ],
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      includeOverlay: true,
+      actions: [
+        {
+          label: 'Primary button',
+          onClick: () => {},
+          kind: 'primary',
+        },
+      ],
+    });
     const submitButtons = screen.queryAllByText('Primary button');
     const outerElement = container.querySelector(`.${blockClass}`);
     fireEvent.animationStart(outerElement);
@@ -182,40 +164,34 @@ describe('SidePanel', () => {
   });
 
   it('should render two action buttons', () => {
-    renderSidePanel(
-      {
-        actions: [
-          {
-            label: 'Action button',
-            onClick: () => {},
-            kind: 'primary',
-          },
-          {
-            label: 'Action button',
-            onClick: () => {},
-            kind: 'secondary',
-          },
-        ],
-      },
-      'content'
-    );
+    renderSidePanel({
+      actions: [
+        {
+          label: 'Action button',
+          onClick: () => {},
+          kind: 'primary',
+        },
+        {
+          label: 'Action button',
+          onClick: () => {},
+          kind: 'secondary',
+        },
+      ],
+    });
     const submitButtons = screen.queryAllByText('Action button');
     expect(submitButtons).toHaveLength(2);
   });
 
   it('should render a single ghost action button', () => {
-    const { container } = renderSidePanel(
-      {
-        actions: [
-          {
-            label: 'Ghost action button',
-            onClick: () => {},
-            kind: 'ghost',
-          },
-        ],
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      actions: [
+        {
+          label: 'Ghost action button',
+          onClick: () => {},
+          kind: 'ghost',
+        },
+      ],
+    });
     const sidePanelOuter = container.querySelector(
       `.${actionSetBlockClass}__action-button--ghost`
     );
@@ -328,13 +304,10 @@ describe('SidePanel', () => {
   it('should call the onNavigationBack event handler', () => {
     const onNavigationBackFn = jest.fn();
     const { click } = userEvent;
-    const { container } = renderSidePanel(
-      {
-        onNavigationBack: onNavigationBackFn,
-        currentStep: 1,
-      },
-      'content'
-    );
+    const { container } = renderSidePanel({
+      onNavigationBack: onNavigationBackFn,
+      currentStep: 1,
+    });
     const navigationButton = container.querySelector(
       `.${blockClass}__navigation-back-button`
     );
@@ -344,12 +317,9 @@ describe('SidePanel', () => {
 
   sizes.forEach((size) => {
     it('should render the correct size side panel', () => {
-      const { container } = renderSidePanel(
-        {
-          size,
-        },
-        'content'
-      );
+      const { container } = renderSidePanel({
+        size,
+      });
       const sidePanelOuter = container.querySelector(`.${blockClass}`);
       let sizeValue;
       switch (size) {


### PR DESCRIPTION
Contributes to #574 

I was able to remove some `istanbul-ignore`s after learning how to properly test animations with RTL, I also did some refactoring to cleanup side panel tests after adding a default arg value for SidePanel children in `renderSidePanel()` in  `SidePanel.test.js` (thanks @sydrosa for catching this).

#### What did you change?
`NotificationsPanel.js`
`NotificationsPanel.test.js`
`SidePanel.test.js`

#### How did you test and verify your work?
`jest /NotificationsPanel/ --coverage`
`jest /SidePanel/ --coverage`