### PR TITLE
move DivIf out as a new global 'Wrap' component

### DIFF
--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -16,6 +16,7 @@ import { pkg, carbon } from '../../settings';
 // Carbon and package components we use.
 import { ComposedModal, ModalHeader, ModalBody } from 'carbon-components-react';
 import { ActionSet } from '../ActionSet';
+import { Wrap } from '../../global/js/utils/Wrap';
 
 // The block part of our conventional BEM class names (bc__E--M).
 const bc = `${pkg.prefix}--tearsheet`;
@@ -42,22 +43,6 @@ export const tearsheetShellWideProps = [
   'influencerWidth',
   'navigation',
 ];
-
-// A simple <div> (or other element) wrapper that only renders conditionally
-// on the content being truthy
-const DivIf = ({ Element, children, cx, ...rest }) =>
-  children ? (
-    <Element {...rest} className={cx}>
-      {children}
-    </Element>
-  ) : null;
-
-DivIf.propTypes = {
-  Element: PropTypes.string,
-  children: PropTypes.node,
-  cx: PropTypes.string,
-};
-DivIf.defaultProps = { Element: 'div' };
 
 // TearSheetShell is used internally by TearSheet and TearSheetNarrow
 export const TearsheetShell = React.forwardRef(
@@ -145,7 +130,9 @@ export const TearsheetShell = React.forwardRef(
     }, [open]);
 
     if (position <= depth) {
-      // we include a modal header if and only if one or more of these is given
+      // Include a modal header if and only if one or more of these is given.
+      // We can't use a Wrap for the ModalHeader because ComposedModal requires
+      // the direct child to be the ModalHeader instance.
       const includeHeader =
         label ||
         title ||
@@ -154,7 +141,7 @@ export const TearsheetShell = React.forwardRef(
         navigation ||
         hasCloseIcon;
 
-      // We include an ActionSet if and only if one or more actions is given
+      // Include an ActionSet if and only if one or more actions is given.
       const includeActions = actions && actions?.length > 0;
 
       return (
@@ -186,34 +173,38 @@ export const TearsheetShell = React.forwardRef(
                 [`${bc}__header--no-close-icon`]: !hasCloseIcon,
               })}
               iconDescription={closeIconDescription}>
-              <DivIf cx={`${bc}__header-content`}>
-                <DivIf>
+              <Wrap className={`${bc}__header-content`}>
+                <Wrap>
                   {/* we create the label and title here instead of passing them
                       as modal header props so we can wrap them in layout divs */}
-                  <DivIf Element="h2" cx={`${bcModalHeader}__label`}>
+                  <Wrap element="h2" className={`${bcModalHeader}__label`}>
                     {label}
-                  </DivIf>
-                  <DivIf Element="h3" cx={`${bcModalHeader}__heading`}>
+                  </Wrap>
+                  <Wrap element="h3" className={`${bcModalHeader}__heading`}>
                     {title}
-                  </DivIf>
-                  <DivIf cx={`${bc}__header-description`}>{description}</DivIf>
-                </DivIf>
-                <DivIf cx={`${bc}__header-actions`}>{headerActions}</DivIf>
-              </DivIf>
-              <DivIf cx={`${bc}__header-navigation`}>{navigation}</DivIf>
+                  </Wrap>
+                  <Wrap className={`${bc}__header-description`}>
+                    {description}
+                  </Wrap>
+                </Wrap>
+                <Wrap className={`${bc}__header-actions`}>{headerActions}</Wrap>
+              </Wrap>
+              <Wrap className={`${bc}__header-navigation`}>{navigation}</Wrap>
             </ModalHeader>
           )}
-          <ModalBody className={`${bc}__body`}>
-            <DivIf
-              cx={cx({
+          <Wrap element={ModalBody} className={`${bc}__body`}>
+            <Wrap
+              className={cx({
                 [`${bc}__influencer`]: true,
                 [`${bc}__influencer--right`]: influencerPosition === 'right',
                 [`${bc}__influencer--wide`]: influencerWidth === 'wide',
               })}>
               {influencer}
-            </DivIf>
-            <DivIf cx={`${bc}__right`}>
-              <DivIf cx={`${bc}__main`}>{children}</DivIf>
+            </Wrap>
+            <Wrap className={`${bc}__right`}>
+              <Wrap alwaysRender={includeActions} className={`${bc}__main`}>
+                {children}
+              </Wrap>
               {includeActions && (
                 <ActionSet
                   actions={actions}
@@ -222,8 +213,8 @@ export const TearsheetShell = React.forwardRef(
                   size={size === 'wide' ? 'max' : 'lg'}
                 />
               )}
-            </DivIf>
-          </ModalBody>
+            </Wrap>
+          </Wrap>
         </ComposedModal>
       );
     } else {

--- a/packages/cloud-cognitive/src/global/js/utils/Wrap.js
+++ b/packages/cloud-cognitive/src/global/js/utils/Wrap.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+
+// Other standard imports.
+import PropTypes from 'prop-types';
+
+// Examine a flat array of children to decide whether it is effectively empty.
+// If there are no children, or all the children are falsy, or all the non-falsy
+// children are themselves Wrap components that are empty, then return true.
+const isEmpty = (children) => {
+  let result = true;
+  React.Children.forEach(children, (child) => {
+    if (child) {
+      result &&=
+        child?.type?.displayName === 'Wrap' && isEmpty(child?.props?.children);
+    }
+  });
+  return result;
+};
+
+/**
+ * A simple conditional wrapper that encloses its children in a <div> (or other
+ * element if specified), passing any supplied attributes to the <div> (or other
+ * element). The component renders nothing at all if there are no children or
+ * the children are empty/falsy, or if all the non-falsy children are themselves
+ * Wrap components that do not wish to render. This behavior can be overridden
+ * by setting neverRender or alwaysRender to true. Note that if a ref is passed,
+ * the ref.current will be set to the wrapper element if it renders, and will
+ * remain undefined if it does not render.
+ */
+export const Wrap = React.forwardRef(
+  ({ alwaysRender, children, element: Wrapper, neverRender, ...rest }, ref) =>
+    (neverRender || isEmpty(children)) && !alwaysRender ? null : (
+      <Wrapper {...rest} ref={ref}>
+        {children}
+      </Wrapper>
+    )
+);
+
+Wrap.displayName = 'Wrap';
+
+Wrap.propTypes = {
+  /**
+   * Specify whether the wrapper element should render even if there are no
+   * children or the children are themselves empty wrappers. Useful if there
+   * are some conditions in which the wrapper element is still required. Note
+   * that this prop takes precedence over neverRender if both are set to true.
+   */
+  alwaysRender: PropTypes.bool,
+
+  /**
+   * The content of the wrapper element. If no children are supplied, or the
+   * resulting value(s) are falsy, or if all the non-falsy children are Wrap
+   * components that decide not to render, nothing will be rendered in the DOM.
+   */
+  children: PropTypes.node,
+
+  /**
+   * The element name or component to use as a wrapper for the content.
+   */
+  element: PropTypes.elementType,
+
+  /**
+   * Specify whether nothing should be rendered even if there are children
+   * in the content. Useful if there are some circumstances in which the
+   * component should not render at all. Note that if alwaysRender is also
+   * set to true then it will take precedence and the wrapper element and
+   * content will be rendered.
+   */
+  neverRender: PropTypes.bool,
+};
+
+Wrap.defaultProps = { element: 'div' };

--- a/packages/cloud-cognitive/src/global/js/utils/Wrap.test.js
+++ b/packages/cloud-cognitive/src/global/js/utils/Wrap.test.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import uuidv4 from './uuidv4';
+
+import { Wrap } from './Wrap';
+
+const componentName = Wrap.displayName;
+
+const nonemptyContent = `hello, world, ${uuidv4()}`;
+const emptyContent = '';
+const className = `class-${uuidv4()}`;
+const dataTestId = uuidv4();
+
+describe(componentName, () => {
+  it('renders non-empty content and passes through a ref', () => {
+    const ref = React.createRef();
+    render(<Wrap {...{ className, ref }}>{nonemptyContent}</Wrap>);
+    screen.getByText(nonemptyContent);
+    expect(ref.current).toHaveClass(className);
+  });
+
+  it('adds additional properties to the containing node', () => {
+    render(<Wrap data-testid={dataTestId}>{nonemptyContent}</Wrap>);
+    screen.getByTestId(dataTestId);
+  });
+
+  it("doesn't render empty content", () => {
+    const ref = React.createRef();
+    render(<Wrap ref={ref}>{emptyContent}</Wrap>);
+    expect(ref.current).toBeNull();
+  });
+
+  it('renders recursive non-empty content', () => {
+    const ref = React.createRef();
+    render(
+      <Wrap ref={ref}>
+        <Wrap>{nonemptyContent}</Wrap>
+      </Wrap>
+    );
+    screen.getByText(nonemptyContent);
+    expect(ref.current).not.toBeNull();
+  });
+
+  it("doesn't render recursive empty content", () => {
+    const ref = React.createRef();
+    render(
+      <Wrap ref={ref}>
+        <Wrap>{emptyContent}</Wrap>
+      </Wrap>
+    );
+    expect(ref.current).toBeNull();
+  });
+
+  const renderHierarchy = (props, results) => {
+    const refs = results.map(() => React.createRef());
+    render(
+      <Wrap {...props} ref={refs[0]}>
+        <Wrap {...props} ref={refs[1]}>
+          <Wrap {...props} ref={refs[2]}>
+            {emptyContent}
+          </Wrap>
+          <div></div>
+        </Wrap>
+        <Wrap {...props} ref={refs[3]}>
+          <Wrap {...props} ref={refs[4]}>
+            {emptyContent}
+          </Wrap>
+          <Wrap {...props} ref={refs[5]}>
+            <Wrap {...props} ref={refs[6]}>
+              {emptyContent}
+            </Wrap>
+          </Wrap>
+        </Wrap>
+        <Wrap {...props} ref={refs[7]}>
+          <Wrap {...props} ref={refs[8]}>
+            <div></div>
+          </Wrap>
+        </Wrap>
+      </Wrap>
+    );
+    refs.forEach((ref, i) =>
+      results[i]
+        ? expect(ref.current).not.toBeNull()
+        : expect(ref.current).toBeNull()
+    );
+  };
+
+  it('render recursive content only where non-empty', () => {
+    renderHierarchy({}, [
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+    ]);
+  });
+
+  it('responds to alwaysRender', () => {
+    renderHierarchy({ alwaysRender: true }, [
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+  it('responds to neverRender', () => {
+    renderHierarchy({ neverRender: true }, [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+});


### PR DESCRIPTION
Contributes to #546

Move the `DivIf` component out as a global utility component, as it may be useful more widely.

#### What did you change?

Created new component, and updated Tearsheet.

#### How did you test and verify your work?

ran build, tests, storybook.