### PR TITLE
Use Button propTypes to creating matching prop shapes

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -55,13 +55,10 @@ const ActionSetButton = React.forwardRef(
 );
 
 ActionSetButton.propTypes = {
-  className: PropTypes.string,
-  disabled: PropTypes.bool,
+  ...Button.PropTypes,
   kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
   label: PropTypes.string,
   loading: PropTypes.bool,
-  onClick: PropTypes.func,
-  size: Button.propTypes.size,
 };
 
 const defaultKind = Button.defaultProps.kind;
@@ -228,11 +225,10 @@ ActionSet.propTypes = {
     ActionSet.validateActions(),
     PropTypes.arrayOf(
       PropTypes.shape({
-        disabled: PropTypes.bool,
+        ...Button.propTypes,
         kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
         label: PropTypes.string,
         loading: PropTypes.bool,
-        onClick: PropTypes.func,
       })
     ),
   ]),

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -168,18 +168,8 @@ ButtonSetWithOverflow.propTypes = {
    */
   buttons: PropTypes.arrayOf(
     PropTypes.shape({
-      kind: PropTypes.oneOf([
-        'primary',
-        'secondary',
-        'danger',
-        'ghost',
-        'danger--primary',
-        'danger--ghost',
-        'danger--tertiary',
-        'tertiary',
-      ]),
+      ...Button.propTypes,
       label: PropTypes.node,
-      onClick: PropTypes.func,
     })
   ),
   /**
@@ -208,7 +198,7 @@ ButtonSetWithOverflow.propTypes = {
    * Specify the size of the button, from a list of available sizes.
    * For `default` buttons, this prop can remain unspecified.
    */
-  size: PropTypes.oneOf(['default', 'field', 'small', 'sm', 'lg', 'xl']),
+  size: Button.propTypes.size,
 };
 
 ButtonSetWithOverflow.defaultProps = {

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
@@ -14,6 +14,7 @@ import { pkg } from '../../settings';
 import { prepareProps } from '../../global/js/utils/props-helper';
 
 // Carbon and package components we use.
+import { Button } from 'carbon-components-react';
 import { ActionSet } from '../ActionSet';
 
 import { TearsheetShell } from './TearsheetShell';
@@ -67,10 +68,9 @@ Tearsheet.propTypes = {
     ActionSet.validateActions(() => 'max'),
     PropTypes.arrayOf(
       PropTypes.shape({
-        label: PropTypes.string,
-        onPrimaryActionClick: PropTypes.func,
+        ...Button.propTypes,
         kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
-        disabled: PropTypes.bool,
+        label: PropTypes.string,
         loading: PropTypes.bool,
       })
     ),

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.js
@@ -14,6 +14,7 @@ import { pkg } from '../../settings';
 import { prepareProps } from '../../global/js/utils/props-helper';
 
 // Carbon and package components we use.
+import { Button } from 'carbon-components-react';
 import { ActionSet } from '../ActionSet';
 
 import {
@@ -66,10 +67,9 @@ TearsheetNarrow.propTypes = {
     ActionSet.validateActions(() => 'lg'),
     PropTypes.arrayOf(
       PropTypes.shape({
-        label: PropTypes.string,
-        onPrimaryActionClick: PropTypes.func,
+        ...Button.propTypes,
         kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
-        disabled: PropTypes.bool,
+        label: PropTypes.string,
         loading: PropTypes.bool,
       })
     ),

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -14,7 +14,12 @@ import cx from 'classnames';
 import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.
-import { ComposedModal, ModalHeader, ModalBody } from 'carbon-components-react';
+import {
+  Button,
+  ComposedModal,
+  ModalHeader,
+  ModalBody,
+} from 'carbon-components-react';
 import { ActionSet } from '../ActionSet';
 import { Wrap } from '../../global/js/utils/Wrap';
 
@@ -250,10 +255,9 @@ TearsheetShell.propTypes = {
     // NB we don't include the validator here, as the component wrapping this
     // one should ensure appropriate validation is done.
     PropTypes.shape({
-      label: PropTypes.string,
-      onPrimaryActionClick: PropTypes.func,
+      ...Button.propTypes,
       kind: PropTypes.oneOf(['ghost', 'secondary', 'primary']),
-      disabled: PropTypes.bool,
+      label: PropTypes.string,
       loading: PropTypes.bool,
     })
   ),


### PR DESCRIPTION
Use Button propTypes as the basis for button-shaped array props in ActionSet, Tearsheet, ButtonSetWithOverflow. This makes a more complete set of type constraints, and is less error-prone and ensures we stay in sync with Button props if/when they change.

#### What did you change?

ActionSet, Tearsheet files, ButtonSetWithOverflow

#### How did you test and verify your work?

ran build, tests, storybook