### PR TITLE
feat(PageHeader): back button to replace breadcrumbs on small viewport

### DIFF
--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -254,7 +254,9 @@ export let BreadcrumbWithOverflow = ({
   return (
     <ReactResizeDetector onResize={handleResize}>
       <div
-        className={cx([blockClass, className])}
+        className={cx(blockClass, className, {
+          [`${blockClass}__with-items`]: displayedBreadcrumbItems.length > 1,
+        })}
         ref={breadcrumbItemWithOverflow}>
         <div className={cx([`${blockClass}__space`])}>
           {/* This next element is purely here to measure the size of the breadcrumb items */}
@@ -288,7 +290,10 @@ export let BreadcrumbWithOverflow = ({
             />
           )}
           <Breadcrumb
-            className={`${blockClass}__breadcrumb-container`}
+            className={cx(`${blockClass}__breadcrumb-container`, {
+              [`${blockClass}__breadcrumb-container-with-items`]:
+                displayedBreadcrumbItems.length > 1,
+            })}
             noTrailingSlash={noTrailingSlash}
             {...other}>
             {displayedBreadcrumbItems}

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -11,8 +11,10 @@ import React, { useState, useEffect, useRef } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { Button } from 'carbon-components-react';
 import { pkg, carbon } from '../../settings';
 import ReactResizeDetector from 'react-resize-detector';
+import { ArrowLeft16 } from '@carbon/icons-react';
 
 // Carbon and package components we use.
 import {
@@ -243,6 +245,12 @@ export let BreadcrumbWithOverflow = ({
     checkFullyVisibleBreadcrumbItems();
   };
 
+  const buttonHrefValue =
+    displayedBreadcrumbItems[displayedBreadcrumbItems.length - 2]?.props.href;
+  const buttonTooltipValue =
+    displayedBreadcrumbItems[displayedBreadcrumbItems.length - 2]?.props
+      .children;
+
   return (
     <ReactResizeDetector onResize={handleResize}>
       <div
@@ -266,6 +274,19 @@ export let BreadcrumbWithOverflow = ({
             </div>
           </ReactResizeDetector>
 
+          {buttonHrefValue && buttonTooltipValue && (
+            <Button
+              className={`${blockClass}--breadcrumb-back-button`}
+              hasIconOnly
+              iconDescription={buttonTooltipValue}
+              kind="ghost"
+              href={buttonHrefValue || '#'}
+              renderIcon={ArrowLeft16}
+              size="field"
+              tooltipPosition="right"
+              type="button"
+            />
+          )}
           <Breadcrumb
             className={`${blockClass}__breadcrumb-container`}
             noTrailingSlash={noTrailingSlash}

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
@@ -34,8 +34,11 @@
     }
 
     .#{$block-class}__breadcrumb-container {
-      display: inline-flex; // needed to register a width
+      display: none;
       width: 100%;
+      @include carbon--breakpoint(md) {
+        display: inline-flex; // needed to register a width
+      }
     }
 
     .#{$block-class}__breadcrumb-container .#{$carbon-prefix}--breadcrumb {
@@ -56,6 +59,13 @@
 
     .#{$block-class}__displayed-breadcrumb {
       overflow: hidden;
+    }
+
+    .#{$block-class}--breadcrumb-back-button.#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
+      display: inline-flex;
+      @include carbon--breakpoint(md) {
+        display: none;
+      }
     }
   }
 }

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
@@ -33,7 +33,7 @@
       white-space: nowrap;
     }
 
-    .#{$block-class}__breadcrumb-container {
+    .#{$block-class}__breadcrumb-container.#{$block-class}__breadcrumb-container-with-items {
       display: none;
       width: 100%;
       @include carbon--breakpoint(md) {

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -186,7 +186,10 @@ $raised-z-index: 99;
 .#{$block-class}--breadcrumb {
   @include carbon--type-style('label-01');
 
-  padding-top: $spacing-04;
+  padding-top: 0;
+  @include carbon--breakpoint(md) {
+    padding-top: $spacing-04;
+  }
 }
 
 .#{$block-class}--breadcrumb .#{$carbon-prefix}--breadcrumb-item {

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -19,6 +19,7 @@
 @import '../BreadcrumbWithOverflow/index';
 
 $block-class: #{$pkg-prefix}-page-header;
+$breadcrumb-block-class: #{$pkg-prefix}--breadcrumb-with-overflow;
 $raised-z-index: 99;
 
 .#{$block-class} {
@@ -186,6 +187,10 @@ $raised-z-index: 99;
 .#{$block-class}--breadcrumb {
   @include carbon--type-style('label-01');
 
+  padding-top: $spacing-04;
+}
+
+.#{$block-class}--breadcrumb.#{$breadcrumb-block-class}__with-items {
   padding-top: 0;
   @include carbon--breakpoint(md) {
     padding-top: $spacing-04;


### PR DESCRIPTION
Contributes to #627 

This adds a back button on smaller viewports that replaces the breadcrumbs in the PageHeader. If no breadcrumbs are present, the bread

#### What did you change?
`BreadcrumbWithOverflow.js`
`_breadcrumb-with-overflow.scss`
`_page-header.scss`
#### How did you test and verify your work?
Storybook