### PR TITLE
Generalise prepareProps a bit further

### DIFF
--- a/packages/cloud-cognitive/src/global/js/utils/props-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/props-helper.js
@@ -7,34 +7,49 @@
 
 import PropTypes from 'prop-types';
 
-// helpers functions for component props
+// helper functions for component props
 
-// Prepare a set of props to pass through to another component. The parameters
-// are as follows:
-//  * props - The starting set of props, as an object containing key-value
-//     pairs. This object is not changed by this function, but a new object is
-//     returned containing some of the values from this object as specified by
-//     the remaining parameters.
-//  * blockList - An array of prop names that should not be passed through.
-//  * overrides - An object containing key-value pairs that will always be
-//     included in the returned object, overriding any values that might have
-//     appeared with those keys in the props parameter. Note that this object
-//     also overrides the blockList: if a key is included in the blockList
-//     then any value in the props parameter with that key will be discarded
-//     but if that key appears in the override parameter it will be included.
-//  * defaults - An object containing key-value pairs that will only be
-//     included in the returned object if the key does not appear in the props
-//     parameter and is not excluded by the blockList parameter.
-// The order of processing is: (1) start with the defaults, (2) apply the props
-// (replacing any defaults with matching keys), (3) discard any keys in the
-// blockList, (4) add override values (replacing any values with matching keys).
-export const prepareProps = (props, blockList, overrides, defaults) => {
-  const defaultedProps = Object.assign({}, defaults, props);
-  const desiredProps = Object.keys(defaultedProps).reduce((acc, cur) => {
-    if (!blockList.includes(cur)) acc[cur] = defaultedProps[cur];
-    return acc;
+/**
+ * Prepare a set of props, or prop types or default props, merging values
+ * from one or more sets and optionally blocking keys which should not be
+ * passed. Returns the prepared set of props. Does not modify any of the
+ * objects passed.
+ *
+ * @param {{} | '' | ['']} values One or more sets of keys and values to be
+ * merged, or names of keys to be blocked. Each parameter that is an object is
+ * treated as keys and values to be merged, and each parameter that is a string
+ * or an array of strings is treated as keys to be blocked.
+ *
+ * Examples:
+ *   const props = { a: 3, c: 4, d: 5 };
+ *
+ *   * prepareProps(props) -> { a: 3, c: 4, d: 5 }
+ *   * prepareProps(props, 'c') -> { a: 3, d: 5 }
+ *   * prepareProps(props, ['a', 'c', 'e']) -> { d: 5 }
+ *
+ *   * prepareProps({ a: 1, b: 2 }, props) -> { a: 3, b: 2, c: 4, d: 5 }
+ *   * prepareProps({ a: 1, b: 2 }, props, ['a', 'c']) -> { b: 2, d: 5 }
+ *
+ *   * prepareProps(props, { c: 6 }) -> { a: 3, c: 6, d: 5 }
+ *   * prepareProps(props, 'a', { c: 6 }) -> { c: 6, d: 5 }
+ */
+export const prepareProps = (...values) => {
+  // Convert any string or array arg into an object with nulls as values
+  const toNulls = (arg) =>
+    typeof arg === 'string'
+      ? { [arg]: null }
+      : Array.isArray(arg)
+      ? Object.fromEntries(arg.map((key) => [key, null]))
+      : arg;
+
+  // Merge all the args from left to right
+  const merged = Object.assign({}, ...values.map(toNulls));
+
+  // Now strip any keys whose final value is null
+  return Object.entries(merged).reduce((result, [key, value]) => {
+    if (value !== null) result[key] = value;
+    return result;
   }, {});
-  return Object.assign(desiredProps, overrides);
 };
 
 const deprecatePropInner = (validator, messageFunction, additionalInfo) => {

--- a/packages/cloud-cognitive/src/global/js/utils/props-helper.test.js
+++ b/packages/cloud-cognitive/src/global/js/utils/props-helper.test.js
@@ -3,11 +3,11 @@ import { prepareProps } from './props-helper';
 const defaults = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 };
 const props = { e: 9, f: 10, g: 11, h: 12, i: 13, j: 14, k: 15, l: 16 };
 const overrides = { c: 17, d: 18, g: 19, h: 20, k: 21, l: 22, o: 23, p: 24 };
-const blockList = ['b', 'd', 'f', 'h', 'j', 'l', 'n', 'p'];
+const block = ['b', 'd', 'f', 'h', 'n', 'p'];
 
 describe('prepareProps', () => {
-  it('applied correct overrides and blocks values', () => {
-    const result = prepareProps(props, blockList, overrides, defaults);
+  it('applies correct defaults and overrides and blocks values', () => {
+    const result = prepareProps(defaults, props, block, 'j', 'l', overrides);
 
     // defaulted
     expect(result.a).toEqual(1);


### PR DESCRIPTION
Simplifies the signature of prepareProps, and makes it more general -- any sequence of objects and blocklists can be provided to merge and block as required. All existing calls and arguments work as before.

#### What did you change?

props-helpers.js and the tests

#### How did you test and verify your work?

Ran tests