### PR TITLE
PR for #691: side panel animate title prop updates

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -212,6 +212,25 @@ export let SidePanel = React.forwardRef(
             }
           });
       }
+      if (open && !animateTitle && animationComplete) {
+        const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
+        const sidePanelTitleElement = document.querySelector(
+          `.${blockClass}__title-container`
+        );
+        const sidePanelSubtitleElement = document.querySelector(
+          `.${blockClass}__subtitle-text`
+        );
+        const titleHeight = sidePanelTitleElement.offsetHeight;
+        const subtitleHeight = sidePanelSubtitleElement.offsetHeight;
+        sidePanelOuter.style.setProperty(
+          `--${blockClass}--title-container-height`,
+          `${titleHeight}px`
+        );
+        sidePanelOuter.style.setProperty(
+          `--${blockClass}--subtitle-container-height`,
+          `${subtitleHeight}px`
+        );
+      }
     }, [open, animateTitle, animationComplete]);
 
     // click outside functionality if `includeOverlay` prop is set
@@ -410,10 +429,21 @@ export let SidePanel = React.forwardRef(
                   />
                 </div>
                 {subtitle && subtitle.length && (
-                  <p className={`${blockClass}__subtitle-text`}>{subtitle}</p>
+                  <p
+                    className={cx(`${blockClass}__subtitle-text`, {
+                      [`${blockClass}__subtitle-text-no-animation`]: !animateTitle,
+                      [`${blockClass}__subtitle-text-no-animation-no-action-toolbar`]:
+                        !animateTitle &&
+                        (!actionToolbarButtons || !actionToolbarButtons.length),
+                    })}>
+                    {subtitle}
+                  </p>
                 )}
                 {actionToolbarButtons && actionToolbarButtons.length && (
-                  <div className={`${blockClass}__action-toolbar`}>
+                  <div
+                    className={cx(`${blockClass}__action-toolbar`, {
+                      [`${blockClass}__action-toolbar-no-animation`]: !animateTitle,
+                    })}>
                     {actionToolbarButtons.map((action) => (
                       <Button
                         key={action.label}

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -438,3 +438,36 @@ WithMinimalContent.args = {
   actions: 0,
   minimalContent: true,
 };
+
+export const WithStaticTitle = SlideOverTemplate.bind({});
+WithStaticTitle.args = {
+  ...defaultStoryProps,
+  actions: 0,
+  animateTitle: false,
+  includeOverlay: true,
+};
+
+export const WithStaticTitleAndActionToolbar = SlideOverTemplate.bind({});
+WithStaticTitleAndActionToolbar.args = {
+  ...defaultStoryProps,
+  actions: 0,
+  animateTitle: false,
+  includeOverlay: true,
+  actionToolbarButtons: [
+    {
+      label: 'Copy',
+      icon: Copy20,
+      onActionToolbarButtonClick: () => {},
+    },
+    {
+      label: 'Settings',
+      icon: Settings20,
+      onActionToolbarButtonClick: () => {},
+    },
+    {
+      label: 'Delete',
+      icon: Delete20,
+      onActionToolbarButtonClick: () => {},
+    },
+  ],
+};

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -34,10 +34,22 @@ const renderSidePanel = ({ ...rest }, children = <p>test</p>) =>
     </SidePanel>
   );
 
+const title = uuidv4();
+const subtitle = uuidv4();
+
 // eslint-disable-next-line react/prop-types
-const SlideIn = ({ placement, open }) => (
+const SlideIn = ({
+  placement,
+  open,
+  animateTitle = true,
+  actionToolbarButtons,
+}) => (
   <div>
     <SidePanel
+      actionToolbarButtons={actionToolbarButtons}
+      title={title}
+      subtitle={subtitle}
+      animateTitle={animateTitle}
       open={open}
       onRequestClose={onRequestCloseFn}
       slideIn
@@ -141,6 +153,32 @@ describe('SidePanel', () => {
     fireEvent.animationStart(outerElement);
     rerender(<SlideIn placement="right" open={false} />);
     fireEvent.animationEnd(outerElement);
+    const updatedStyles = getComputedStyle(pageContent);
+    expect(updatedStyles.marginRight).toBe('0px');
+  });
+
+  it('should render a right slide in panel version', async () => {
+    const { container, rerender } = render(
+      <SlideIn
+        animateTitle={false}
+        placement="right"
+        open
+        actionToolbarButtons={[]}
+      />
+    );
+    const pageContent = container.querySelector(
+      '#side-panel-test-page-content'
+    );
+    const style = getComputedStyle(pageContent);
+    expect(style.marginRight).toBe('30rem');
+    const closeIconButton = container.querySelector(
+      `.${blockClass}__close-button`
+    );
+    const outerElement = container.querySelector(`.${blockClass}`);
+    userEvent.click(closeIconButton);
+    fireEvent.animationStart(outerElement);
+    fireEvent.animationEnd(outerElement);
+    rerender(<SlideIn animateTitle={false} placement="right" open={false} />);
     const updatedStyles = getComputedStyle(pageContent);
     expect(updatedStyles.marginRight).toBe('0px');
   });

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /**
  * Copyright IBM Corp. 2020, 2021
  *
@@ -37,7 +38,6 @@ const renderSidePanel = ({ ...rest }, children = <p>test</p>) =>
 const title = uuidv4();
 const subtitle = uuidv4();
 
-// eslint-disable-next-line react/prop-types
 const SlideIn = ({
   placement,
   open,

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -105,6 +105,8 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
 
   .#{$block-class}__container {
     --#{$block-class}--subtitle-opacity: 1;
+    --#{$block-class}--title-container-height: 0;
+    --#{$block-class}--subtitle-container-height: 0;
     --#{$block-class}--divider-opacity: 0;
     --#{$block-class}--title-font-size: 1.25rem;
     --#{$block-class}--content-bottom-padding: #{$spacing-10};
@@ -212,6 +214,16 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       -webkit-line-clamp: 3;
       -webkit-box-orient: vertical;
     }
+    .#{$block-class}__subtitle-text.#{$block-class}__subtitle-text-no-animation {
+      position: sticky;
+      top: var(--#{$block-class}--title-container-height);
+      z-index: 2;
+      background-color: $ui-01;
+    }
+    .#{$block-class}__subtitle-text.#{$block-class}__subtitle-text-no-animation.#{$block-class}__subtitle-text-no-animation-no-action-toolbar {
+      margin-bottom: $spacing-05;
+      border-bottom: 1px solid $decorative-01;
+    }
     .#{$block-class}__label-text {
       @include carbon--type-style('label-01');
     }
@@ -240,6 +252,14 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
           margin-right: $spacing-03;
         }
       }
+    }
+    .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation {
+      // stylelint-disable-next-line carbon/layout-token-use
+      top: calc(
+        var(--#{$block-class}--title-container-height) +
+          var(--#{$block-class}--subtitle-container-height)
+      );
+      border-bottom: 1px solid $decorative-01;
     }
     .bx--btn.#{$block-class}__navigation-back-button,
     .bx--btn.#{$block-class}__close-button {


### PR DESCRIPTION
Contributes to #691 

This PR cleans up the side panel behavior when `animateTitle={false}` is provided to the component. The subtitle text becomes fixed, as well as the action toolbar buttons if they are provided.

#### What did you change?
`SidePanel.js`
`SidePanel.test.js`
`SidePanel.stories.js`
`_side-panel.scss`
#### How did you test and verify your work?
Storybook
Verified test coverage is still at 100%