### PR TITLE
Fix Tearsheet navigation position in header

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1208,6 +1208,10 @@ path:nth-of-type(1),
   border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
 }
 
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header--with-nav {
+  padding-bottom: 0;
+}
+
 .exp--tearsheet.exp--tearsheet--narrow .exp--tearsheet__header {
   margin: 0;
   padding: var(--cds-spacing-05, 1rem);
@@ -1254,10 +1258,6 @@ path:nth-of-type(1),
 
 .exp--tearsheet .exp--tearsheet__header-navigation {
   margin: var(--cds-spacing-04, 0.75rem) 0 0;
-}
-
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header-navigation {
-  margin: var(--cds-spacing-04, 0.75rem) 0 calc(-1 * var(--cds-spacing-06, 1.5rem));
 }
 
 .exp--tearsheet .exp--tearsheet__body {

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -179,6 +179,7 @@ export const TearsheetShell = React.forwardRef(
             <ModalHeader
               className={cx(`${bc}__header`, {
                 [`${bc}__header--with-close-icon`]: hasCloseIcon,
+                [`${bc}__header--with-nav`]: navigation,
               })}
               closeClassName={cx({
                 [`${bc}__header--no-close-icon`]: !hasCloseIcon,

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -130,6 +130,10 @@
     border-bottom: 1px solid $ui-03;
   }
 
+  .#{$block-class}.#{$block-class}--wide .#{$block-class}__header--with-nav {
+    padding-bottom: 0;
+  }
+
   .#{$block-class}.#{$block-class}--narrow .#{$block-class}__header {
     margin: 0;
     padding: $spacing-05;
@@ -170,10 +174,6 @@
 
   .#{$block-class} .#{$block-class}__header-navigation {
     margin: $spacing-04 0 0;
-  }
-
-  .#{$block-class}.#{$block-class}--wide .#{$block-class}__header-navigation {
-    margin: $spacing-04 0 calc(-1 * #{$spacing-06});
   }
 
   .#{$block-class} .#{$block-class}__body {


### PR DESCRIPTION
Resolves #699 

The header bottom padding was being reversed by a negative margin on the navigation, to try to bring the navigation aligned with the bottom of the header. This was fragile, and broke, perhaps by a change in Carbon. Instead, just remove the bottom padding from the header when there is a navigation item. Fixed, and should be more robust.

#### What did you change?

TearsheetShell

NB this PR changes published styles for a released component.

#### How did you test and verify your work?

Storybook