### PR TITLE
Fix Tearsheet header action button spacing

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1228,6 +1228,13 @@ path:nth-of-type(1),
   padding-left: var(--cds-spacing-06, 1.5rem);
 }
 
+.exp--tearsheet
+.exp--tearsheet__header-actions
+.bx--btn-set
+.bx--btn:not(:first-of-type) {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+}
+
 .exp--tearsheet .exp--tearsheet__header--no-close-icon {
   display: none;
 }

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -150,6 +150,14 @@
     padding-left: $spacing-06;
   }
 
+  // buttons inside button sets in the header action area have 8px gap
+  .#{$block-class}
+    .#{$block-class}__header-actions
+    .#{$carbon-prefix}--btn-set
+    .#{$carbon-prefix}--btn:not(:first-of-type) {
+    margin-left: $spacing-03;
+  }
+
   .#{$block-class} .#{$block-class}__header--no-close-icon {
     display: none;
   }


### PR DESCRIPTION
Resolves #700

The header action buttons should have an 8px gap. Fixed.

#### What did you change?

Tearsheet styles

NB this PR changes published styles for a released component.

#### How did you test and verify your work?

Storybook