### PR TITLE
Fix Tearsheet heading padding

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1204,7 +1204,7 @@ path:nth-of-type(1),
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__header {
   margin: 0;
-  padding: var(--cds-spacing-07, 2rem);
+  padding: var(--cds-spacing-06, 1.5rem) var(--cds-spacing-07, 2rem);
   border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
 }
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -126,7 +126,7 @@
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__header {
     margin: 0;
-    padding: $spacing-07;
+    padding: $spacing-06 $spacing-07;
     border-bottom: 1px solid $ui-03;
   }
 


### PR DESCRIPTION
Resolves #701

The header for a wide Tearsheet should have a 24px padding top and bottom, 32px left and right. A narrow Tearsheet should have 16px all round. Fixed.

#### What did you change?

Tearsheet styles

NB this PR changes published styles for a released component.

#### How did you test and verify your work?

Storybook