### PR TITLE
chore(SidePanel): add shadow to panels without overlay

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -350,6 +350,7 @@ export let SidePanel = React.forwardRef(
         [`${blockClass}__container-left-placement`]: placement === 'left',
         [`${blockClass}__container-with-action-toolbar`]:
           actionToolbarButtons && actionToolbarButtons.length,
+        [`${blockClass}__container-without-overlay`]: !includeOverlay,
       },
     ]);
 

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -178,7 +178,7 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
       }
     }
     &.#{$block-class}__container-without-overlay {
-      box-shadow: 0 $spacing-02 $spacing-04 $overlay-01;
+      box-shadow: 0 $spacing-01 $spacing-02 $overlay-01;
     }
     .#{$block-class}__title-container {
       position: sticky;

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -177,6 +177,9 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
         }
       }
     }
+    &.#{$block-class}__container-without-overlay {
+      box-shadow: 0 $spacing-02 $spacing-04 $overlay-01;
+    }
     .#{$block-class}__title-container {
       position: sticky;
       top: 0;


### PR DESCRIPTION
Contributes to #719

This PR adds a shadow to panels that do not have an overlay.

#### What did you change?
`SidePanel.js`
`_side-panel.scss`
#### How did you test and verify your work?
Storybook
