### PR TITLE
fix(SidePanel): add shadow only for slideOver panels without overlays

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -350,7 +350,8 @@ export let SidePanel = React.forwardRef(
         [`${blockClass}__container-left-placement`]: placement === 'left',
         [`${blockClass}__container-with-action-toolbar`]:
           actionToolbarButtons && actionToolbarButtons.length,
-        [`${blockClass}__container-without-overlay`]: !includeOverlay,
+        [`${blockClass}__container-without-overlay`]:
+          !includeOverlay && !slideIn,
       },
     ]);
 


### PR DESCRIPTION
Contributes to #719 

Received feedback from Kacie that shadows should only be applied to slideOver panels. Slide in panels only receive the border divider line (without the shadow).

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook