### PR TITLE
fix: breadcrumb styling

### DIFF
--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -265,14 +265,16 @@ export let BreadcrumbWithOverflow = ({
               className={`${blockClass}__breadcrumb-container ${blockClass}__breadcrumb-container--hidden`}
               aria-hidden={true}
               ref={sizingContainerRef}>
-              <BreadcrumbItem
-                key={`${blockClass}-hidden-overflow-${internalId}`}>
-                <OverflowMenu
-                  ariaLabel={overflowAriaLabel}
-                  renderIcon={OverflowMenuHorizontal32}
-                />
-              </BreadcrumbItem>
-              {children}
+              <Breadcrumb>
+                <BreadcrumbItem
+                  key={`${blockClass}-hidden-overflow-${internalId}`}>
+                  <OverflowMenu
+                    ariaLabel={overflowAriaLabel}
+                    renderIcon={OverflowMenuHorizontal32}
+                  />
+                </BreadcrumbItem>
+                {children}
+              </Breadcrumb>
             </div>
           </ReactResizeDetector>
 

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
@@ -43,6 +43,7 @@
 
     .#{$block-class}__breadcrumb-container .#{$carbon-prefix}--breadcrumb {
       flex-wrap: nowrap;
+      align-items: flex-start;
       width: 100%;
     }
 
@@ -57,12 +58,20 @@
       pointer-events: none;
     }
 
-    .#{$block-class}__displayed-breadcrumb {
+    .#{$block-class}__displayed-breadcrumb:last-child,
+    .#{$block-class}__displayed-breadcrumb:last-child .#{$carbon-prefix}--link {
       overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .#{$carbon-prefix}--link {
+      max-height: 18px; // to match breadcrumb - overflow button is 20 by default
     }
 
     .#{$block-class}--breadcrumb-back-button.#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
       display: inline-flex;
+      margin-top: calc(-1 * #{$spacing-04});
+
       @include carbon--breakpoint(md) {
         display: none;
       }

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -232,30 +232,10 @@ $raised-z-index: 99;
       }
     }
 
-    .#{$block-class}__breadcrumb-container
-      .#{$block-class}__breadcrumb-title.#{$prefix}--breadcrumb-item {
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
     .#{$block-class}__breadcrumb-container--hidden
       .#{$block-class}__breadcrumb-title.#{$block-class}__breadcrumb-title {
       overflow: initial;
     }
-
-    .#{$block-class}__breadcrumb-title.#{$prefix}--breadcrumb-item
-      .#{$prefix}--link {
-      width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    // .#{$block-class}__breadcrumb-row::before {
-    //   display: inline-block;
-    //   width: 0;
-    //   height: calc(#{$layout-03} + #{$spacing-04});
-    //   content: '';
-    // }
 
     .#{$block-class}__action-bar {
       flex: 1 1 var(--#{$block-class}--max-action-bar-width-px);


### PR DESCRIPTION
Contributes to #488 

The padding above the back arrow was causing the breadcrumb row to grow in height.
The overflow button in the breadcrumb was 2 pixels taller than the specified breadcrumb size and center alignment was causing a small jump when the overflow appeared.
The breadcrumb storybook was not showing the / contained in the ::after

#### What did you change?
- Fixed page header width measurement
- Removed some breadcrumb styling from PageHeader component
- Fixed breadcrumb responsive behavior.

#### How did you test and verify your work?
- In the breadcrumb storybook check following slash shown.
- In the breadcrumb storybook check the width based behaviour
- In the page header storybook check the breadcrumb responsive behaviour down to showing of back arrow.