### PR TITLE
fix: prevent collapse button over action bar items

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -70,6 +70,8 @@ export let PageHeader = React.forwardRef(
       setPageActionsInBreadcrumbRow,
     ] = useState(false);
     const [backgroundOpacity, setBackgroundOpacity] = useState(0);
+    const [hasCollapseButton, setHasCollapseButton] = useState(false);
+    const [spaceForCollapseButton, setSpaceForCollapseButton] = useState(false);
     const [lastRowBufferActive, setLastRowBufferActive] = useState(false);
     const dynamicRefs = useRef({});
     const localHeaderRef = useRef(null);
@@ -430,15 +432,13 @@ export let PageHeader = React.forwardRef(
           );
         }
       }
-      // if (!result) {
-      // This exists in the design if > title, breadcrumb and status turn on background left off as has responsive issues
-      //   result = headerHeight > layout07;
-      // }
+
       setComponentCssCustomProps((prevCSSProps) => ({
         ...prevCSSProps,
         [`--${blockClass}--background-opacity`]: result,
       }));
       setBackgroundOpacity(result);
+      setHasCollapseButton(result > 0);
     }, [
       actionBarItems,
       background,
@@ -449,6 +449,12 @@ export let PageHeader = React.forwardRef(
       scrollYValue,
       tags,
     ]);
+
+    useEffect(() => {
+      setSpaceForCollapseButton(
+        hasCollapseButton && !(navigation || tags) && metrics.headerHeight
+      );
+    }, [hasCollapseButton, navigation, tags, metrics.headerHeight]);
 
     const handleResize = () => {
       // receives width and height parameters if needed
@@ -547,6 +553,7 @@ export let PageHeader = React.forwardRef(
                       `${blockClass}__action-bar-column ${blockClass}__action-bar-column--background`,
                       {
                         [`${blockClass}__action-bar-column--has-page-actions`]: pageActions,
+                        [`${blockClass}__action-bar-column--influenced-by-collapse-button`]: spaceForCollapseButton,
                       },
                     ])}>
                     <ReactResizeDetector
@@ -698,7 +705,7 @@ export let PageHeader = React.forwardRef(
               </Row>
             ) : null}
           </Grid>
-          {backgroundOpacity > 0 ? (
+          {hasCollapseButton ? (
             <Button
               className={cx(`${blockClass}__collapse-expand-toggle`, {
                 [`${blockClass}__collapse-expand-toggle--collapsed`]: fullyCollapsed,

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -486,14 +486,19 @@ const TemplatePageHeaderWithCarbonHeader = (args) => {
           [Platform]
         </HeaderName>
       </Header>
-      <Content className={`${storyClass}__content-container`}>
+      <div
+        className={`${storyClass}__content-container`}
+        style={{
+          // stylelint-disable-next-line carbon/layout-token-use
+          marginTop: '48px',
+        }}>
         <PageHeader
           className="example-class-name"
           {...includeTheseArgs(args)}
           pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
         />
         <div className={`${storyClass}__inner-content`}>{dummyPageContent}</div>
-      </Content>
+      </div>
     </div>
   );
 };

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -11,7 +11,6 @@ import React from 'react';
 import {
   BreadcrumbItem,
   Column,
-  Content,
   Grid,
   Header,
   HeaderName,
@@ -147,7 +146,12 @@ const longSubtitle =
   'Optional subtitle if necessary, which is very long in this case, but will need to be handled somehow';
 const summaryDetails = (
   <div style={{ display: 'flex' }}>
-    <p style={{ marginRight: '50px', maxWidth: '400px' }}>
+    <p
+      style={{
+        // stylelint-disable-next-line carbon/layout-token-use
+        marginRight: '50px',
+        maxWidth: '400px',
+      }}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor <strong>incididunt ut labore</strong> et dolore magna aliqua. Ut
       enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -155,11 +155,6 @@ $raised-z-index: 99;
       opacity: 1;
     }
 
-    .#{$block-class}__breadcrumb-row
-      .#{$block-class}__button-set--in-breadcrumb {
-      // display: inline-block;
-    }
-
     .#{$block-class}__breadcrumb-column {
       flex: 0 0 100%;
       max-width: 100%;
@@ -178,16 +173,15 @@ $raised-z-index: 99;
       background-color: $ui-background;
     }
 
-    // .#{$block-class}__breadcrumb-column--background,
-    // .#{$block-class}__action-bar-column--background {
-    //   background-color: $ui-background;
-    // }
-
     &.#{$block-class}--show-background
       .#{$block-class}__breadcrumb-column--background::before,
     &.#{$block-class}--show-background
       .#{$block-class}__action-bar-column--background::before {
       @include appearingBackground();
+    }
+
+    .#{$block-class}__action-bar-column--influenced-by-collapse-button {
+      padding-right: $spacing-08;
     }
 
     .#{$block-class}__breadcrumb {


### PR DESCRIPTION
Contributes to #630

Adds space to the right of the actionBarItems column when there are no tags or navigation. This prevents the collapse button from covering the action bar items.

#### What did you change?

Page Header

#### How did you test and verify your work?

Storybook and ci-check