### PR TITLE
chore(SidePanel): form fields receive default background color now

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -328,6 +328,18 @@ $max-panel-size: 75%; // set max-width on max panels to 75%
     }
   }
 
+  // form fields should receive correct background color
+  .#{$block-class}__container .bx--text-input,
+  .#{$block-class}__container .bx--text-area,
+  .#{$block-class}__container .bx--search-input,
+  .#{$block-class}__container .bx--select-input,
+  .#{$block-class}__container .bx--dropdown,
+  .#{$block-class}__container .bx--dropdown-list,
+  .#{$block-class}__container .bx--number input[type='number'],
+  .#{$block-class}__container .bx--date-picker__input {
+    background-color: $field-02;
+  }
+
   @keyframes sidePanelOverlayEntrance {
     0% {
       opacity: 0;

--- a/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
@@ -18,10 +18,6 @@ $story-prefix: side-panel-stories__;
   .#{$story-prefix}text-inputs #side-panel-story-text-input-c {
     margin-right: $spacing-05;
   }
-  .#{$story-prefix}text-inputs .#{$story-prefix}text-input,
-  .#{$story-prefix}text-area {
-    background-color: $field-02;
-  }
   .#{$story-prefix}text-area-container {
     position: relative;
   }


### PR DESCRIPTION
Contributes to #727 

Side panel now gives form fields a background color by default.

#### What did you change?
`_side-panel.scss`
`_storybook-styles.scss`
#### How did you test and verify your work?
Storybook