### PR TITLE
fix: title and subtitle row responsivity

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
@@ -245,9 +245,6 @@ ActionBar.propTypes = {
    * align tags to right of available space
    */
   rightAlign: PropTypes.bool,
-  /**
-   * heading for the show all modal
-   */
 };
 
 ActionBar.defaultProps = {

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -28,6 +28,7 @@ export const ButtonSetWithOverflow = ({
   className,
   onWidthChange,
   pageActionsLabel,
+  rightAlign,
   size,
 }) => {
   const [showAsOverflow, setShowAsOverflow] = useState(false);
@@ -123,7 +124,13 @@ export const ButtonSetWithOverflow = ({
 
   return (
     <ReactResizeDetector handleWidth={true} onResize={handleResize}>
-      <div className={cx([blockClass, className])} ref={spaceAvailableRef}>
+      <div
+        className={cx([
+          blockClass,
+          className,
+          { [`${blockClass}--right`]: rightAlign },
+        ])}
+        ref={spaceAvailableRef}>
         <ReactResizeDetector onResize={handleButtonResize}>
           <div
             className={`${blockClass}__button-container ${blockClass}__button-container--hidden`}>
@@ -196,6 +203,10 @@ ButtonSetWithOverflow.propTypes = {
    * pageActionsLabel - used when button set is shown as combo button
    */
   pageActionsLabel: PropTypes.node,
+  /**
+   * align buttons to right of available space
+   */
+  rightAlign: PropTypes.bool,
   /**
    * Specify the size of the button, from a list of available sizes.
    * For `default` buttons, this prop can remain unspecified.

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_button-set-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_button-set-with-overflow.scss
@@ -16,7 +16,7 @@ $block-class: #{$pkg-prefix}--button-set-with-overflow;
 @mixin button-set-with-overflow {
   @include block-wrap($block-class) {
     &.#{$block-class} {
-      display: block;
+      display: flex;
     }
 
     .#{$block-class}__space {
@@ -39,6 +39,10 @@ $block-class: #{$pkg-prefix}--button-set-with-overflow;
       overflow: hidden;
       visibility: hidden;
       pointer-events: none;
+    }
+
+    .#{$block-class}--right {
+      justify-content: flex-end;
     }
   }
 }

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -628,20 +628,11 @@ export let PageHeader = React.forwardRef(
                     className={cx(`${blockClass}__page-actions`, {
                       [`${blockClass}__page-actions--in-breadcrumb`]: pageActionsInBreadcrumbRow,
                     })}>
-                    <ButtonSet
-                      className={`${blockClass}__page-actions-container`}>
-                      {pageActionsItemArray.map(
-                        ({ kind, label, onClick, ...rest }, index) => (
-                          <Button
-                            {...rest}
-                            kind={kind}
-                            onClick={onClick}
-                            key={index}>
-                            {label}
-                          </Button>
-                        )
-                      )}
-                    </ButtonSet>
+                    <ButtonSetWithOverflow
+                      className={`${blockClass}__page-actions-container`}
+                      onWidthChange={handleButtonSetWidthChange}
+                      buttons={pageActionsItemArray}
+                    />
                   </Column>
                 ) : null}
               </Row>

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -16,7 +16,6 @@ import {
   Grid,
   Column,
   Row,
-  ButtonSet,
   Button,
 } from 'carbon-components-react';
 import { ActionBar } from '../ActionBar/';

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -143,7 +143,7 @@ const statusIndicator = (
 );
 const subtitle = 'Optional subtitle if necessary';
 const longSubtitle =
-  'Optional subtitle if necessary, which is very long in this case, but will need to be handled somehow';
+  'Optional subtitle if necessary, which is very long in this case, but will need to be handled somehow. It just keeps going on and on and on and on and on.';
 const summaryDetails = (
   <div style={{ display: 'flex' }}>
     <p

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -115,54 +115,59 @@ import { prepareProps } from '../../global/js/utils/props-helper';
 jest.mock('../../global/js/utils/uuidv4');
 
 const sizes = {
-  'bx--btn': {
+  [`${carbon.prefix}--btn`]: {
     get offsetWidth() {
       return 200;
     },
   },
-  'exp--page-header': {
+  [`${blockClass}`]: {
     get offsetWidth() {
       return window.innerWidth;
     },
   },
-  'exp--page-header__breadcrumb-row': {
+  [`${blockClass}__breadcrumb-row`]: {
     get offsetWidth() {
       return window.innerWidth;
     },
   },
-  'exp--breadcrumb-with-overflow': {
+  [`${pkg.prefix}--breadcrumb-with-overflow`]: {
     get offsetWidth() {
       return window.innerWidth * 0.6;
     },
   },
-  'exp--tag-set': {
+  [`${pkg.prefix}--tag-set`]: {
     get offsetWidth() {
       return window.innerWidth * 0.25;
     },
   },
-  'exp--tag-set__sizing-tag': {
+  [`${pkg.prefix}--tag-set__sizing-tag`]: {
     get offsetWidth() {
       return window.innerWidth * 0.05;
     },
   },
-  'exp--button-set-with-overflow__button-container': {
+  [`${pkg.prefix}--button-set-with-overflow__button-container`]: {
     get offsetWidth() {
       return window.innerWidth * 0.4;
     },
   },
-  'exp--button-set-with-overflow': {
+  [`${pkg.prefix}--button-set-with-overflow`]: {
     get offsetWidth() {
       return window.innerWidth * 0.4;
     },
   },
-  'bx--breadcrumb-item': {
+  [`${carbon.prefix}--breadcrumb-item`]: {
     get offsetWidth() {
       return 200;
     },
   },
-  'exp--action-bar__displayed-items': {
+  [`${pkg.prefix}--action-bar__displayed-items`]: {
     get offsetWidth() {
       return window.innerWidth * 0.3;
+    },
+  },
+  [`${blockClass}__breadcrumb-title`]: {
+    get offsetWidth() {
+      return window.innerWidth * 0.2;
     },
   },
 };
@@ -175,7 +180,7 @@ const testSizes = (el, property) => {
       return val;
     }
   }
-  console.log(property, el.outerHTML);
+  console.log('xxx', property, el.outerHTML);
   return -1;
 };
 
@@ -207,7 +212,6 @@ describe('PageHeader', () => {
           let width = testSizes(this, 'offsetWidth');
 
           if (width < 0) {
-            console.log(this.outerHTML);
             width = window.innerWidth;
           }
 
@@ -342,7 +346,9 @@ describe('PageHeader', () => {
 
     render(<PageHeader pageActions={pageActionsDepTest} />);
 
-    screen.getByText('Primary button');
+    screen.getByText('Primary button', {
+      selector: `.${blockClass}__page-actions .${pkg.prefix}--button-set-with-overflow__button-container:not(.${pkg.prefix}--button-set-with-overflow__button-container--hidden) .${carbon.prefix}--btn`,
+    });
 
     expect(warn).toBeCalledWith(
       "The usage of prop 'pageActions' of 'PageHeader' has been changed and you should update. Expects an array of objects with the following properties: label and onClick."
@@ -356,7 +362,9 @@ describe('PageHeader', () => {
 
     render(<PageHeader pageActions={pageActionsDepTest2} />);
 
-    screen.getByText('Primary button');
+    screen.getByText('Primary button', {
+      selector: `.${blockClass}__page-actions .${pkg.prefix}--button-set-with-overflow__button-container:not(.${pkg.prefix}--button-set-with-overflow__button-container--hidden) .${carbon.prefix}--btn`,
+    });
 
     expect(warn).toBeCalledWith(
       "The usage of prop 'pageActions' of 'PageHeader' has been changed and you should update. Expects an array of objects with the following properties: label and onClick."

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -289,7 +289,8 @@ $raised-z-index: 99;
       overflow: hidden; /* required for ellipsis in title */
 
       @include carbon--breakpoint-up('md') {
-        flex: 0 1 60%;
+        flex: 1 0 60%;
+        max-width: 60%;
       }
     }
 
@@ -315,9 +316,16 @@ $raised-z-index: 99;
       white-space: nowrap;
 
       @include carbon--breakpoint-up('md') {
-        flex: 1 1 40%;
+        flex: 0 1 40%;
+        max-width: 40%;
         margin-top: 0;
       }
+    }
+
+    .#{$block-class}__page-actions
+      .#{$carbon-prefix}--btn-set
+      .#{$carbon-prefix}--btn {
+      width: initial;
     }
 
     .#{$block-class}__action-bar-column .#{$block-class}__page-actions {
@@ -346,7 +354,17 @@ $raised-z-index: 99;
     }
 
     .#{$block-class}__subtitle-row {
+      display: -webkit-box;
+      max-width: 100%;
       margin-top: $spacing-03;
+
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+
+      @include carbon--breakpoint-up('md') {
+        max-width: 60%;
+      }
 
       + .#{$block-class}__last-row-buffer--active {
         height: $layout-01;


### PR DESCRIPTION
Closes #658

- Fixed subtitle to max 60% from the medium breakpoint up (as per title) and clamp at two lines.
- Addressed responsivity of pageActcions by using ButtonSetWithOverflow. To persist with the pageActions in 40% width when space is restricted causes either the page to be too wide or wrap. Neither sit well with the move into the breadcrumb row.
- Added a right alight property to the ButtonSetWithOverflow to keep the buttons on the right.

#### How did you test and verify your work?

Ran tests and storybook.
