### PR TITLE
Fix background of pagination inside wide tearsheet

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1332,6 +1332,8 @@ path:nth-of-type(1),
   background: var(--cds-ui-background, #ffffff);
 }
 
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--pagination,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--pagination__control-buttons,
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input,
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-area,
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--search-input,

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -226,6 +226,8 @@
     background: $ui-background;
 
     // revert the background colour overridden by bx--modal styles
+    .#{$prefix}--pagination,
+    .#{$prefix}--pagination__control-buttons,
     .#{$prefix}--text-input,
     .#{$prefix}--text-area,
     .#{$prefix}--search-input,


### PR DESCRIPTION
This is directly related to #339.

#### What did you change?

We added two missing classes to the list of selectors that need to be "un-overridden" to get back to the correct look inside the wide tearsheet main area. 

#### How did you test and verify your work?

Copied the list of selectors from https://github.com/carbon-design-system/carbon/blob/ce0662896cb8919f1f11b70a1f4351750b6d7e07/packages/components/src/components/modal/_modal.scss#L49-L50 to add the missing classes.