### PR TITLE
Don't use deprecated Tab prop href

### DIFF
--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.js
@@ -46,7 +46,6 @@ export let ModifiedTabs = ({
     <Tabs className="modified-tabs" ref={tabsRef}>
       {tabs.map((tab) => (
         <Tab
-          href="#"
           id={tab.id}
           key={tab.id}
           label={
@@ -60,7 +59,6 @@ export let ModifiedTabs = ({
         </Tab>
       ))}
       <Tab
-        href="#"
         id="modified-tabs__tab-new"
         label={<ModifiedTabLabelNew label={newTabLabel} />}
         onClick={handleNewTab}


### PR DESCRIPTION
ModifiedTabs is setting a deprecated prop `href` on carbon-react Tab component, and this is causing console noise during test runs. As it is only setting the prop to its default value, removing these should not make any functional difference and will help clean up the test runs.

#### What did you change?

Just ModifiedTabs.js

#### How did you test and verify your work?

Ran all ModifiedTabs tests. There aren't any, so that didn't take long.