### PR TITLE
Add a deprecation warning to ComboButton

### DIFF
--- a/packages/security/src/ComboButton/ComboButton.js
+++ b/packages/security/src/ComboButton/ComboButton.js
@@ -40,6 +40,10 @@ const ComboButton = ({ children, className, overflowMenu, ...rest }) => {
       ),
     }));
 
+  console.warn(
+    'Component ComboButton is deprecated and will shortly be removed. Consider using ButtonMenu instead.'
+  );
+
   return (
     <div
       {...rest}


### PR DESCRIPTION
Contributes to #749

Add a deprecation warning to ComboButton, which we'll shortly remove in favour of ButtonMenu.

#### What did you change?

ComboButton.js

#### How did you test and verify your work?

Ran storybook and test.