### PR TITLE
fix(EmptyStates): update stories and rename size prop

### DIFF
--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
@@ -28,10 +28,10 @@ export let EmptyState = React.forwardRef(
       customIllustrationAltText,
       title,
       illustration,
-      illustrationSize,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       ...rest
     },
@@ -44,7 +44,7 @@ export let EmptyState = React.forwardRef(
           alt={customIllustrationAltText}
           className={cx([
             `${blockClass}__illustration`,
-            `${blockClass}__illustration--${illustrationSize}`,
+            `${blockClass}__illustration--${size}`,
           ])}
         />
       );
@@ -66,6 +66,7 @@ export let EmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -103,10 +104,6 @@ export const EmptyStateProps = {
    */
   illustration: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state link text
    */
   linkText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -119,6 +116,10 @@ export const EmptyStateProps = {
    */
   onActionEvent: PropTypes.func,
   /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
+  /**
    * Empty state subtext
    */
   subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
@@ -129,7 +130,7 @@ export const EmptyStateProps = {
 };
 
 export const EmptyStateDefaultProps = {
-  illustrationSize: 'lg',
+  size: 'lg',
 };
 
 EmptyState.propTypes = EmptyStateProps;

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStateContent.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStateContent.js
@@ -11,6 +11,7 @@ import React from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import { pkg } from '../../settings';
+import cx from 'classnames';
 
 // Carbon and package components we use.
 import { Button, Link } from 'carbon-components-react';
@@ -26,6 +27,7 @@ export const EmptyStateContent = ({
   linkText,
   linkUrl,
   onActionEvent,
+  size,
   subtitle,
   title,
 }) => {
@@ -34,12 +36,22 @@ export const EmptyStateContent = ({
       {typeof title !== 'string' ? (
         title
       ) : (
-        <h3 className={`${blockClass}__header`}>{title}</h3>
+        <h3
+          className={cx(`${blockClass}__header`, {
+            [`${blockClass}__header--small`]: size === 'sm',
+          })}>
+          {title}
+        </h3>
       )}
       {typeof subtitle !== 'string' ? (
         subtitle
       ) : (
-        <p className={`${blockClass}__subtext`}>{subtitle}</p>
+        <p
+          className={cx(`${blockClass}__subtitle`, {
+            [`${blockClass}__subtitle--small`]: size === 'sm',
+          })}>
+          {subtitle}
+        </p>
       )}
       {actionText && onActionEvent && (
         <Button
@@ -91,6 +103,10 @@ EmptyStateContent.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
@@ -47,6 +47,11 @@ export default {
   },
 };
 
+const emptyStateCommonProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
   return (
     <EmptyState
@@ -62,15 +67,19 @@ const Template = (args) => {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...emptyStateCommonProps,
+};
 
 export const WithCustomIllustration = Template.bind({});
 WithCustomIllustration.args = {
+  ...emptyStateCommonProps,
   illustration: CustomIllustration,
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...emptyStateCommonProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -78,6 +87,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...emptyStateCommonProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -86,12 +96,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...emptyStateCommonProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...emptyStateCommonProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
@@ -27,11 +27,11 @@ export let ErrorEmptyState = React.forwardRef(
       actionType,
       actionIcon,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,7 +46,7 @@ export let ErrorEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <ErrorIllustration theme={illustrationTheme} size={illustrationSize} />
+        <ErrorIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           actionText={actionText}
           actionType={actionType}
@@ -54,6 +54,7 @@ export let ErrorEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -90,10 +91,6 @@ ErrorEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -112,6 +109,10 @@ ErrorEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -30,12 +30,8 @@ export default {
 };
 
 const defaultStoryProps = {
-  title: 'Start by adding data assets',
-  subtitle: (
-    <p>
-      Click <span>Upload assets</span> to upload your data
-    </p>
-  ),
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
 };
 
 const Template = (args) => {

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
@@ -27,11 +27,11 @@ export let NoDataEmptyState = React.forwardRef(
       actionType,
       actionIcon,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,7 +46,7 @@ export let NoDataEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <NoDataIllustration theme={illustrationTheme} size={illustrationSize} />
+        <NoDataIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           actionText={actionText}
           actionType={actionType}
@@ -54,6 +54,7 @@ export let NoDataEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -90,10 +91,6 @@ NoDataEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -112,6 +109,10 @@ NoDataEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -29,30 +29,29 @@ export default {
   },
 };
 
+const defaultStoryProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
-  return (
-    <NoDataEmptyState
-      title="Start by adding data assets"
-      subtitle={
-        <p>
-          Click <span>Upload assets</span> to upload your data
-        </p>
-      }
-      {...args}
-    />
-  );
+  return <NoDataEmptyState {...args} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...defaultStoryProps,
+};
 
 export const WithDarkModeIllustration = Template.bind({});
 WithDarkModeIllustration.args = {
+  ...defaultStoryProps,
   illustrationTheme: 'dark',
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -60,6 +59,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -68,12 +68,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...defaultStoryProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
@@ -27,11 +27,11 @@ export let NoTagsEmptyState = React.forwardRef(
       actionType,
       actionIcon,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,7 +46,7 @@ export let NoTagsEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <NoTagsIllustration theme={illustrationTheme} size={illustrationSize} />
+        <NoTagsIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           actionText={actionText}
           actionType={actionType}
@@ -54,6 +54,7 @@ export let NoTagsEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -90,10 +91,6 @@ NoTagsEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -112,6 +109,10 @@ NoTagsEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -29,30 +29,29 @@ export default {
   },
 };
 
+const defaultStoryProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
-  return (
-    <NoTagsEmptyState
-      title="Start by adding data assets"
-      subtitle={
-        <p>
-          Click <span>Upload assets</span> to upload your data
-        </p>
-      }
-      {...args}
-    />
-  );
+  return <NoTagsEmptyState {...args} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...defaultStoryProps,
+};
 
 export const WithDarkModeIllustration = Template.bind({});
 WithDarkModeIllustration.args = {
+  ...defaultStoryProps,
   illustrationTheme: 'dark',
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -60,6 +59,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -68,12 +68,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...defaultStoryProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
@@ -27,11 +27,11 @@ export let NotFoundEmptyState = React.forwardRef(
       actionType,
       actionIcon,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,10 +46,7 @@ export let NotFoundEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <NotFoundIllustration
-          theme={illustrationTheme}
-          size={illustrationSize}
-        />
+        <NotFoundIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           actionText={actionText}
           actionType={actionType}
@@ -57,6 +54,7 @@ export let NotFoundEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -96,10 +94,6 @@ NotFoundEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -118,6 +112,10 @@ NotFoundEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -28,30 +28,29 @@ export default {
   },
 };
 
+const defaultStoryProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
-  return (
-    <NotFoundEmptyState
-      title="Start by adding data assets"
-      subtitle={
-        <p>
-          Click <span>Upload assets</span> to upload your data
-        </p>
-      }
-      {...args}
-    />
-  );
+  return <NotFoundEmptyState {...args} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...defaultStoryProps,
+};
 
 export const WithDarkModeIllustration = Template.bind({});
 WithDarkModeIllustration.args = {
+  ...defaultStoryProps,
   illustrationTheme: 'dark',
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -59,6 +58,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -67,12 +67,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...defaultStoryProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
@@ -27,11 +27,11 @@ export let NotificationsEmptyState = React.forwardRef(
       actionText,
       actionType,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,10 +46,7 @@ export let NotificationsEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <NotificationsIllustration
-          size={illustrationSize}
-          theme={illustrationTheme}
-        />
+        <NotificationsIllustration size={size} theme={illustrationTheme} />
         <EmptyStateContent
           actionIcon={actionIcon}
           actionText={actionText}
@@ -57,6 +54,7 @@ export let NotificationsEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -96,10 +94,6 @@ NotificationsEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -118,6 +112,10 @@ NotificationsEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -31,30 +31,29 @@ export default {
   },
 };
 
+const defaultStoryProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
-  return (
-    <NotificationsEmptyState
-      title="Start by adding data assets"
-      subtitle={
-        <p>
-          Click <span>Upload assets</span> to upload your data
-        </p>
-      }
-      {...args}
-    />
-  );
+  return <NotificationsEmptyState {...args} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...defaultStoryProps,
+};
 
 export const WithDarkModeIllustration = Template.bind({});
 WithDarkModeIllustration.args = {
+  ...defaultStoryProps,
   illustrationTheme: 'dark',
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -62,6 +61,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -70,12 +70,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...defaultStoryProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
@@ -27,11 +27,11 @@ export let UnauthorizedEmptyState = React.forwardRef(
       actionType,
       actionIcon,
       className,
-      illustrationSize,
       illustrationTheme,
       linkText,
       linkUrl,
       onActionEvent,
+      size,
       subtitle,
       title,
       ...rest
@@ -46,10 +46,7 @@ export let UnauthorizedEmptyState = React.forwardRef(
         }
         className={cx(blockClass, className)}
         ref={ref}>
-        <UnauthorizedIllustration
-          size={illustrationSize}
-          theme={illustrationTheme}
-        />
+        <UnauthorizedIllustration size={size} theme={illustrationTheme} />
         <EmptyStateContent
           actionIcon={actionIcon}
           actionText={actionText}
@@ -57,6 +54,7 @@ export let UnauthorizedEmptyState = React.forwardRef(
           linkText={linkText}
           linkUrl={linkUrl}
           onActionEvent={onActionEvent}
+          size={size}
           subtitle={subtitle}
           title={title}
         />
@@ -96,10 +94,6 @@ UnauthorizedEmptyState.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Empty state illustration size
-   */
-  illustrationSize: PropTypes.oneOf(['lg', 'sm']),
-  /**
    * Empty state illustration theme variations.
    * To ensure you use the correct themed illustrations, you can conditionally specify light or dark
    * based on your app's current theme value. Example:
@@ -118,6 +112,10 @@ UnauthorizedEmptyState.propTypes = {
    * Empty state action button handler
    */
   onActionEvent: PropTypes.func,
+  /**
+   * Empty state size
+   */
+  size: PropTypes.oneOf(['lg', 'sm']),
   /**
    * Empty state subtitle
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -31,30 +31,29 @@ export default {
   },
 };
 
+const defaultStoryProps = {
+  title: 'Empty state title',
+  subtitle: 'Description text explaining why this section is empty.',
+};
+
 const Template = (args) => {
-  return (
-    <UnauthorizedEmptyState
-      title="Start by adding data assets"
-      subtitle={
-        <p>
-          Click <span>Upload assets</span> to upload your data
-        </p>
-      }
-      {...args}
-    />
-  );
+  return <UnauthorizedEmptyState {...args} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  ...defaultStoryProps,
+};
 
 export const WithDarkModeIllustration = Template.bind({});
 WithDarkModeIllustration.args = {
+  ...defaultStoryProps,
   illustrationTheme: 'dark',
 };
 
 export const withAction = Template.bind({});
 withAction.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -62,6 +61,7 @@ withAction.args = {
 
 export const withActionIconButton = Template.bind({});
 withActionIconButton.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),
@@ -70,12 +70,14 @@ withActionIconButton.args = {
 
 export const withLink = Template.bind({});
 withLink.args = {
+  ...defaultStoryProps,
   linkText: 'View documentation',
   linkUrl: 'https://www.carbondesignsystem.com',
 };
 
 export const withActionAndLink = Template.bind({});
 withActionAndLink.args = {
+  ...defaultStoryProps,
   actionText: 'Create new',
   actionType: 'tertiary',
   onActionEvent: action('actionHandler'),

--- a/packages/cloud-cognitive/src/components/EmptyStates/_empty-state.scss
+++ b/packages/cloud-cognitive/src/components/EmptyStates/_empty-state.scss
@@ -19,10 +19,16 @@
 
   .#{$block-class} {
     .#{$block-class}__header,
-    .#{$block-class}__subtext,
+    .#{$block-class}__subtitle,
     p {
       margin: 0;
       padding-bottom: $spacing-02;
+    }
+    .#{$block-class}__header--small {
+      @include carbon--type-style('productive-heading-03');
+    }
+    .#{$block-class}__subtitle--small {
+      @include carbon--type-style('body-short-01');
     }
   }
 


### PR DESCRIPTION
Contributes to #752 

I updated stories for EmptyState components so that a title / subtitle always display. I also renamed the `illustrationSize` prop to just `size` because there are typography changes when the smaller size version is used which have also been added in now too.

#### What did you change?
Empty state components and story files
#### How did you test and verify your work?
Storybook
All tests still pass and coverage is still at 100%