### PR TITLE
chore(SidePanel): remove required from onRequestClose prop

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -268,7 +268,8 @@ export let SidePanel = React.forwardRef(
         if (
           sidePanelRef.current &&
           sidePanelOverlayRef.current &&
-          sidePanelOverlayRef.current.contains(e.target)
+          sidePanelOverlayRef.current.contains(e.target) &&
+          onRequestClose
         ) {
           onRequestClose();
         }
@@ -642,7 +643,7 @@ SidePanel.propTypes = {
    * Specify a handler for closing the side panel.
    * This handler closes the modal, e.g. changing `open` prop.
    */
-  onRequestClose: PropTypes.func.isRequired,
+  onRequestClose: PropTypes.func,
 
   /**
    * Determines whether the side panel should render or not


### PR DESCRIPTION
Contributes to #734 

Change `onRequestClose` prop from required to not required.

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook and all tests still pass with 100% coverage