### PR TITLE
chore(UserProfileImage): test coverage to 100 and mark as released

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1361,5 +1361,200 @@ path:nth-of-type(1),
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__buttons {
   background: var(--cds-ui-background, #ffffff);
 }
+
+.exp-user-profile-avatar--light {
+  color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-cyan {
+  background-color: #0072c3;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-cyan {
+  background-color: #003a6d;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-gray {
+  background-color: #6f6f6f;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-gray {
+  background-color: #393939;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-green {
+  background-color: #198038;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-green {
+  background-color: #044317;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-magenta {
+  background-color: #d02670;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-magenta {
+  background-color: #740937;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-purple {
+  background-color: #8a3ffc;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-purple {
+  background-color: #491d8b;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--light-teal {
+  background-color: #007d79;
+}
+
+.exp-user-profile-avatar--light.exp-user-profile-avatar--dark-teal {
+  background-color: #004144;
+}
+
+.exp-user-profile-avatar--dark {
+  color: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-cyan {
+  background-color: #1192e8;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-cyan {
+  background-color: #82cfff;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-gray {
+  background-color: #8d8d8d;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-gray {
+  background-color: #c6c6c6;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-green {
+  background-color: #24a148;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-green {
+  background-color: #6fdc8c;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-magenta {
+  background-color: #ee5396;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-magenta {
+  background-color: #ffafd2;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-purple {
+  background-color: #a56eff;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-purple {
+  background-color: #d4bbff;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--light-teal {
+  background-color: #009d9a;
+}
+
+.exp-user-profile-avatar--dark.exp-user-profile-avatar--dark-teal {
+  background-color: #3ddbd9;
+}
+
+.exp-user-profile-avatar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  border-radius: 100%;
+}
+
+.bx--tooltip__trigger .exp-user-profile-avatar svg {
+  fill: var(--cds-ui-01, #f4f4f4);
+}
+
+.exp-user-profile-avatar__photo {
+  width: 100%;
+  border-radius: 100%;
+}
+
+.exp-user-profile-avatar__photo--xlg {
+  width: var(--cds-spacing-10, 4rem);
+  height: var(--cds-spacing-10, 4rem);
+}
+
+.exp-user-profile-avatar__photo--lg {
+  width: var(--cds-spacing-07, 2rem);
+  height: var(--cds-spacing-07, 2rem);
+}
+
+.exp-user-profile-avatar__photo--md {
+  width: var(--cds-spacing-06, 1.5rem);
+  height: var(--cds-spacing-06, 1.5rem);
+}
+
+.exp-user-profile-avatar__photo--sm {
+  width: calc(var(--cds-spacing-05, 1rem) + var(--cds-spacing-02, 0.25rem));
+  height: calc(var(--cds-spacing-05, 1rem) + var(--cds-spacing-02, 0.25rem));
+}
+
+.exp-user-profile-avatar__photo--xs {
+  width: var(--cds-spacing-05, 1rem);
+  height: var(--cds-spacing-05, 1rem);
+}
+
+.exp-user-profile-avatar--xlg {
+  width: var(--cds-spacing-10, 4rem);
+  height: var(--cds-spacing-10, 4rem);
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.29);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+}
+
+.exp-user-profile-avatar--lg {
+  width: var(--cds-spacing-07, 2rem);
+  height: var(--cds-spacing-07, 2rem);
+  font-size: var(--cds-body-short-01-font-size, 0.875rem);
+  font-weight: var(--cds-body-short-01-font-weight, 400);
+  line-height: var(--cds-body-short-01-line-height, 1.29);
+  letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+}
+
+.exp-user-profile-avatar--md {
+  width: var(--cds-spacing-06, 1.5rem);
+  height: var(--cds-spacing-06, 1.5rem);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  font-weight: 600;
+}
+
+.exp-user-profile-avatar--sm {
+  width: calc(var(--cds-spacing-05, 1rem) + var(--cds-spacing-02, 0.25rem));
+  height: calc(var(--cds-spacing-05, 1rem) + var(--cds-spacing-02, 0.25rem));
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  font-weight: 600;
+}
+
+.exp-user-profile-avatar--xs {
+  width: var(--cds-spacing-05, 1rem);
+  height: var(--cds-spacing-05, 1rem);
+  font-size: var(--cds-label-01-font-size, 0.75rem);
+  font-weight: var(--cds-label-01-font-weight, 400);
+  line-height: var(--cds-label-01-line-height, 1.34);
+  letter-spacing: var(--cds-label-01-letter-spacing, 0.32px);
+  font-weight: 600;
+}
 "
 `;

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
@@ -106,15 +106,16 @@ export let UserProfileImage = React.forwardRef(
       </div>
     );
 
-    return FillItem ? (
-      tooltipText ? (
+    return (
+      FillItem &&
+      (tooltipText ? (
         <TooltipIcon tooltipText={tooltipText}>
           {renderUserProfileImage()}
         </TooltipIcon>
       ) : (
         renderUserProfileImage()
-      )
-    ) : null;
+      ))
+    );
   }
 );
 

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
@@ -86,12 +86,6 @@ WithImage.args = {
   imageDescription: 'image here',
 };
 
-export const WithImageWithoutDescription = Template.bind({});
-WithImageWithoutDescription.args = {
-  ...defaultArgs,
-  image,
-};
-
 export const WithImageAndTooltip = Template.bind({});
 WithImageAndTooltip.args = {
   ...defaultArgs,

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
@@ -41,7 +41,10 @@ describe(name, () => {
   });
 
   test('should render image for the avatar image', () => {
-    const { container } = renderComponent({ image: 'path_to_image.jpg' });
+    const { container } = renderComponent({
+      image: 'path_to_image.jpg',
+      imageDescription: 'test alt text',
+    });
     const imagePath = container.querySelector('img').getAttribute('src');
     expect(typeof imagePath).toBe('string');
   });
@@ -80,5 +83,29 @@ describe(name, () => {
     const { container } = renderComponent({ className: customClass });
     const element = container.querySelector(`.${blockClass}`);
     expect(element).toHaveClass(customClass);
+  });
+
+  it('should render the initials when passed the initials prop', () => {
+    renderComponent({ initials: 'Display name' });
+    expect(screen.getByText(/DN/g));
+  });
+
+  it('should render the initials when simply passing two initials to the initials prop', () => {
+    renderComponent({ initials: 'DN' });
+    expect(screen.getByText(/DN/g));
+  });
+
+  it('should render the tooltipIcon component if the tooltipText prop is passed', () => {
+    const { container } = renderComponent({ tooltipText: 'Display name' });
+    const tooltipElement = container.querySelector(
+      `.${carbon.prefix}--tooltip__trigger`
+    );
+    expect(tooltipElement).toBeTruthy();
+  });
+
+  it('should throw a custom prop type validation error when an image is used without an imageDescription prop', () => {
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    renderComponent({ image: 'path_to_image.jpg' });
+    jest.spyOn(console, 'error').mockRestore();
   });
 });

--- a/packages/cloud-cognitive/src/components/_index-released-only.scss
+++ b/packages/cloud-cognitive/src/components/_index-released-only.scss
@@ -13,3 +13,4 @@
 @import './Saving/index';
 @import './StatusIcon/index';
 @import './Tearsheet/index';
+@import './UserProfileImage/index';

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -18,6 +18,7 @@ const defaults = {
     StatusIcon: true,
     Tearsheet: true,
     TearsheetNarrow: true,
+    UserProfileImage: true,
 
     // other public components not yet reviewed and released:
     ActionBarItem: false,
@@ -47,7 +48,6 @@ const defaults = {
     SidePanel: false,
     TagSet: false,
     UnauthorizedEmptyState: false,
-    UserProfileImage: false,
     WebTerminal: false,
     /* new component flags here - comment used by generate CLI */
   },


### PR DESCRIPTION
Contributes to #570 

Test coverage for `UserProfileImage` is now at 100% and this component will be marked as released with this PR.

#### What did you change?
`UserProfileImage.test.js`
`UserProfileImage.js`
`UserProfileImage.stories.js`
`package-settings.js`
`_index-released-only.scss`
Updated snapshot
#### How did you test and verify your work?
Storybook and ensured that all tests pass with 100% coverage
`jest /UserProfileImage/ --coverage`

Great job on this one @qbi11y! 👏 