### PR TITLE
feat(SidePanel): add optional onUnmount prop for cleanup

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -45,6 +45,7 @@ export let SidePanel = React.forwardRef(
       navigationBackIconDescription,
       onNavigationBack,
       onRequestClose,
+      onUnmount,
       open,
       pageContentSelector,
       placement,
@@ -289,7 +290,10 @@ export let SidePanel = React.forwardRef(
 
     // initialize the side panel to close
     const onAnimationEnd = () => {
-      if (!open) setRender(false);
+      if (!open) {
+        onUnmount && onUnmount();
+        setRender(false);
+      }
       sidePanelRef.current.style.overflow = 'auto';
       sidePanelRef.current.style.overflowX = 'hidden';
       setAnimationComplete(true);
@@ -644,6 +648,12 @@ SidePanel.propTypes = {
    * This handler closes the modal, e.g. changing `open` prop.
    */
   onRequestClose: PropTypes.func,
+
+  /**
+   * Optional function called when the side panel exit animation is complete.
+   * This handler can be used for any state cleanup needed before the panel is removed from the DOM.
+   */
+  onUnmount: PropTypes.func,
 
   /**
    * Determines whether the side panel should render or not

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -22,6 +22,7 @@ const sizes = ['xs', 'sm', 'md', 'lg', 'max'];
 const dataTestId = uuidv4();
 
 const onRequestCloseFn = jest.fn();
+const onUnmountFn = jest.fn();
 const renderSidePanel = ({ ...rest }, children = <p>test</p>) =>
   render(
     <SidePanel
@@ -53,7 +54,8 @@ const SlideIn = ({
       onRequestClose={onRequestCloseFn}
       slideIn
       pageContentSelector="#side-panel-test-page-content"
-      placement={placement}>
+      placement={placement}
+      onUnmount={onUnmountFn}>
       Content
     </SidePanel>
     <div id="side-panel-test-page-content" />
@@ -154,6 +156,7 @@ describe('SidePanel', () => {
     fireEvent.animationEnd(outerElement);
     const updatedStyles = getComputedStyle(pageContent);
     expect(updatedStyles.marginRight).toBe('0px');
+    expect(onUnmountFn).toHaveBeenCalled();
   });
 
   it('should render a right slide in panel version', async () => {


### PR DESCRIPTION
Contributes to #490 

Adds an optional `onUnmount` function prop that is called after the side panel exit animation but before the panel is removed from the DOM that can be used for any necessary cleanup.

#### What did you change?
`SidePanel.js`
`SidePanel.test.js`
#### How did you test and verify your work?
Storybook and updated tests
`jest /SidePanel/ --coverage`