### PR TITLE
fix: remove wibble from example story

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -282,7 +282,7 @@ AllAttributesSet.args = {
   background: true,
   breadcrumbItems,
   actionBarItems,
-  title: { text: 'wibble' },
+  title,
   pageActions,
   subtitle,
   availableSpace: summaryDetails,


### PR DESCRIPTION
Contributes to #488 

Remove use of wibble in story sample

#### What did you change?

PageHeader.stories.js

#### How did you test and verify your work?

Storybook.