### PR TITLE
Page header refactor uses draft

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -36,7 +36,10 @@ const blockClass = `${pkg.prefix}--page-header`;
 
 import {
   useActionBar,
+  useHasBreadcrumbRow,
+  usePageActionsInBreadcrumbRow,
   usePageActionsItemArray,
+  useSpacingBelowTitle,
   useTitleShape,
 } from './usesPageHeader';
 
@@ -66,7 +69,25 @@ export let PageHeader = React.forwardRef(
     ref
   ) => {
     const { hasActionBar, actionBarItemArray } = useActionBar(actionBarItems);
+    const hasBreadcrumbRow = useHasBreadcrumbRow(
+      actionBarItems,
+      breadcrumbItems
+    );
+    const pageActionsInBreadcrumbRow = usePageActionsInBreadcrumbRow(
+      hasActionBar,
+      metrics.breadcrumbRowSpaceBelow,
+      metrics.titleRowSpaceAbove,
+      preCollapseTitleRow,
+      scrollYValue
+    );
     const pageActionsItemArray = usePageActionsItemArray(pageActions);
+    const spacingBelowTitle = useSpacingBelowTitle(
+      availableSpace,
+      tags,
+      navigation,
+      subtitle,
+      pageActions
+    );
     /* Title shape is used to allow title to be string or shape */
     const titleShape = useTitleShape(
       title,
@@ -77,12 +98,6 @@ export let PageHeader = React.forwardRef(
     const [metrics, setMetrics] = useState({});
     const [scrollYValue, setScrollYValue] = useState(0);
     const [componentCssCustomProps, setComponentCssCustomProps] = useState({});
-    const [hasBreadcrumbRow, setHasBreadcrumbRow] = useState(false);
-    const [spacingBelowTitle, setSpacingBelowTitle] = useState('06');
-    const [
-      pageActionsInBreadcrumbRow,
-      setPageActionsInBreadcrumbRow,
-    ] = useState(false);
     const [backgroundOpacity, setBackgroundOpacity] = useState(0);
     const [hasCollapseButton, setHasCollapseButton] = useState(false);
     const [spaceForCollapseButton, setSpaceForCollapseButton] = useState(false);
@@ -275,20 +290,6 @@ export let PageHeader = React.forwardRef(
     ]);
 
     useEffect(() => {
-      // Determine the location of the pageAction buttons
-      setPageActionsInBreadcrumbRow(
-        preCollapseTitleRow ||
-          (scrollYValue > metrics.titleRowSpaceAbove && hasActionBar)
-      );
-    }, [
-      hasActionBar,
-      metrics.breadcrumbRowSpaceBelow,
-      metrics.titleRowSpaceAbove,
-      preCollapseTitleRow,
-      scrollYValue,
-    ]);
-
-    useEffect(() => {
       // Updates custom CSS props used to manage scroll behaviour
       setComponentCssCustomProps((prevCSSProps) => {
         return {
@@ -399,33 +400,6 @@ export let PageHeader = React.forwardRef(
       tags,
       title,
     ]);
-
-    useEffect(() => {
-      // Breadcrumb row only rendered if true
-      // eslint-disable-next-line
-      setHasBreadcrumbRow(
-        !(breadcrumbItems === undefined && actionBarItems === undefined)
-      );
-    }, [actionBarItems, breadcrumbItems]);
-
-    useEffect(() => {
-      // Determines the amount of space needed below the title
-      let belowTitleSpace = 'default';
-
-      if (
-        pageActions !== undefined &&
-        navigation !== undefined &&
-        subtitle === undefined &&
-        availableSpace === undefined
-      ) {
-        belowTitleSpace = '06';
-      } else if (subtitle !== undefined || availableSpace !== undefined) {
-        belowTitleSpace = '03';
-      } else if (navigation === undefined && tags !== undefined) {
-        belowTitleSpace = '05';
-      }
-      setSpacingBelowTitle(belowTitleSpace);
-    }, [availableSpace, tags, navigation, subtitle, pageActions]);
 
     useEffect(() => {
       // Determines if the background should be one based on the header height or scroll

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -68,6 +68,7 @@ export let PageHeader = React.forwardRef(
     },
     ref
   ) => {
+    const [metrics, setMetrics] = useState({});
     const { hasActionBar, actionBarItemArray } = useActionBar(actionBarItems);
     const hasBreadcrumbRow = useHasBreadcrumbRow(
       actionBarItems,
@@ -75,7 +76,6 @@ export let PageHeader = React.forwardRef(
     );
     const pageActionsInBreadcrumbRow = usePageActionsInBreadcrumbRow(
       hasActionBar,
-      metrics.breadcrumbRowSpaceBelow,
       metrics.titleRowSpaceAbove,
       preCollapseTitleRow,
       scrollYValue
@@ -95,7 +95,6 @@ export let PageHeader = React.forwardRef(
       PageHeader.defaultProps.title
     );
 
-    const [metrics, setMetrics] = useState({});
     const [scrollYValue, setScrollYValue] = useState(0);
     const [componentCssCustomProps, setComponentCssCustomProps] = useState({});
     const [backgroundOpacity, setBackgroundOpacity] = useState(0);

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -28,12 +28,17 @@ import { ChevronUp16 } from '@carbon/icons-react';
 import {
   deprecateProp,
   deprecatePropUsage,
-  extractShapesArray,
   prepareProps,
 } from '../../global/js/utils/props-helper';
 
 const componentName = 'PageHeader';
 const blockClass = `${pkg.prefix}--page-header`;
+
+import {
+  useActionBar,
+  usePageActionsItemArray,
+  useTitleShape,
+} from './usesPageHeader';
 
 export let PageHeader = React.forwardRef(
   (
@@ -60,9 +65,15 @@ export let PageHeader = React.forwardRef(
     },
     ref
   ) => {
-    const [hasActionBar, setHasActionBar] = useState(false);
-    const [actionBarItemArray, setActionBarItemArray] = useState([]);
-    const [pageActionsItemArray, setPageActionsItemArray] = useState([]);
+    const { hasActionBar, actionBarItemArray } = useActionBar(actionBarItems);
+    const pageActionsItemArray = usePageActionsItemArray(pageActions);
+    /* Title shape is used to allow title to be string or shape */
+    const titleShape = useTitleShape(
+      title,
+      titleIcon,
+      PageHeader.defaultProps.title
+    );
+
     const [metrics, setMetrics] = useState({});
     const [scrollYValue, setScrollYValue] = useState(0);
     const [componentCssCustomProps, setComponentCssCustomProps] = useState({});
@@ -91,29 +102,6 @@ export let PageHeader = React.forwardRef(
     ] = useState(0);
     const [actionBarColumnWidth, setActionBarColumnWidth] = useState(0);
     const [fullyCollapsed, setFullyCollapsed] = useState(false);
-
-    /**
-     * * Title shape is used to allow title to be string or shape
-     */
-    const [titleShape, setTitleShape] = useState({});
-    useEffect(() => {
-      let newShape = { ...PageHeader.defaultProps.title };
-
-      if (title?.text) {
-        // title is in shape format
-        newShape = Object.assign(newShape, { ...title });
-      } else {
-        // title is a string
-        newShape.text = title;
-      }
-
-      if (!newShape.icon && titleIcon) {
-        // if no icon use titleIcon if supplied
-        newShape.icon = titleIcon;
-      }
-
-      setTitleShape(newShape);
-    }, [title, titleIcon]);
 
     useEffect(() => {
       let newActionBarWidth = 'initial';
@@ -419,19 +407,6 @@ export let PageHeader = React.forwardRef(
         !(breadcrumbItems === undefined && actionBarItems === undefined)
       );
     }, [actionBarItems, breadcrumbItems]);
-
-    useEffect(() => {
-      const newShapes = extractShapesArray(actionBarItems);
-      setHasActionBar(newShapes.length);
-      setActionBarItemArray(newShapes);
-    }, [actionBarItems]);
-
-    useEffect(() => {
-      const shapes = extractShapesArray(pageActions);
-      setPageActionsItemArray(
-        shapes?.map((shape) => ({ label: shape.children, ...shape }))
-      );
-    }, [pageActions]);
 
     useEffect(() => {
       // Determines the amount of space needed below the title

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -282,7 +282,7 @@ AllAttributesSet.args = {
   background: true,
   breadcrumbItems,
   actionBarItems,
-  title: { text: 'wibble' },
+  title,
   pageActions,
   subtitle,
   availableSpace: summaryDetails,

--- a/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { extractShapesArray } from '../../global/js/utils/props-helper';
+
+export const useActionBar = (actionBarItems) => {
+  const [hasActionBar, setHasActionBar] = useState(false);
+  const [actionBarItemArray, setActionBarItemArray] = useState([]);
+
+  useEffect(() => {
+    const newShapes = extractShapesArray(actionBarItems);
+    setHasActionBar(newShapes.length);
+    setActionBarItemArray(newShapes);
+  }, [actionBarItems]);
+
+  return { hasActionBar, actionBarItemArray };
+};
+
+export const usePageActionsItemArray = (pageActions) => {
+  const [pageActionsItemArray, setPageActionsItemArray] = useState([]);
+
+  useEffect(() => {
+    const shapes = extractShapesArray(pageActions);
+    setPageActionsItemArray(
+      shapes?.map((shape) => ({ label: shape.children, ...shape }))
+    );
+  }, [pageActions]);
+
+  return pageActionsItemArray;
+};
+
+export const useTitleShape = (title, titleIcon, defaultTitle) => {
+  /**
+   * * Title shape is used to allow title to be string or shape
+   */
+  const [titleShape, setTitleShape] = useState({});
+
+  useEffect(() => {
+    let newShape = { ...defaultTitle };
+
+    if (title?.text) {
+      // title is in shape format
+      newShape = Object.assign(newShape, { ...title });
+    } else {
+      // title is a string
+      newShape.text = title;
+    }
+
+    if (!newShape.icon && titleIcon) {
+      // if no icon use titleIcon if supplied
+      newShape.icon = titleIcon;
+    }
+
+    setTitleShape(newShape);
+  }, [defaultTitle, title, titleIcon, titleShape]);
+
+  return titleShape;
+};

--- a/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
@@ -14,6 +14,40 @@ export const useActionBar = (actionBarItems) => {
   return { hasActionBar, actionBarItemArray };
 };
 
+export const useHasBreadcrumbRow = (actionBarItems, breadcrumbItems) => {
+  const [hasBreadcrumbRow, setHasBreadcrumbRow] = useState(false);
+
+  useEffect(() => {
+    // Breadcrumb row only rendered if true
+    // eslint-disable-next-line
+    setHasBreadcrumbRow(
+      !(breadcrumbItems === undefined && actionBarItems === undefined)
+    );
+  }, [actionBarItems, breadcrumbItems]);
+
+  return hasBreadcrumbRow;
+};
+
+export const usePageActionsInBreadcrumbRow = (
+  hasActionBar,
+  titleRowSpaceAbove,
+  preCollapseTitleRow,
+  scrollYValue
+) => {
+  const [pageActionsInBreadcrumbRow, setPageActionsInBreadcrumbRow] = useState(
+    false
+  );
+
+  useEffect(() => {
+    // Determine the location of the pageAction buttons
+    setPageActionsInBreadcrumbRow(
+      preCollapseTitleRow || (scrollYValue > titleRowSpaceAbove && hasActionBar)
+    );
+  }, [hasActionBar, titleRowSpaceAbove, preCollapseTitleRow, scrollYValue]);
+
+  return pageActionsInBreadcrumbRow;
+};
+
 export const usePageActionsItemArray = (pageActions) => {
   const [pageActionsItemArray, setPageActionsItemArray] = useState([]);
 
@@ -25,6 +59,37 @@ export const usePageActionsItemArray = (pageActions) => {
   }, [pageActions]);
 
   return pageActionsItemArray;
+};
+
+export const useSpacingBelowTitle = (
+  availableSpace,
+  tags,
+  navigation,
+  subtitle,
+  pageActions
+) => {
+  const [spacingBelowTitle, setSpacingBelowTitle] = useState('06');
+
+  useEffect(() => {
+    // Determines the amount of space needed below the title
+    let belowTitleSpace = 'default';
+
+    if (
+      pageActions !== undefined &&
+      navigation !== undefined &&
+      subtitle === undefined &&
+      availableSpace === undefined
+    ) {
+      belowTitleSpace = '06';
+    } else if (subtitle !== undefined || availableSpace !== undefined) {
+      belowTitleSpace = '03';
+    } else if (navigation === undefined && tags !== undefined) {
+      belowTitleSpace = '05';
+    }
+    setSpacingBelowTitle(belowTitleSpace);
+  }, [availableSpace, tags, navigation, subtitle, pageActions]);
+
+  return spacingBelowTitle;
 };
 
 export const useTitleShape = (title, titleIcon, defaultTitle) => {

--- a/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/usesPageHeader.js
@@ -1,6 +1,19 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 import { useEffect, useState } from 'react';
 import { extractShapesArray } from '../../global/js/utils/props-helper';
 
+/* Reactive code extracted from the page header to to reduce the content of the page header. */
+
+/**
+ * Check actionBarItems
+ * @param {*} actionBarItems
+ * @returns {{hasActionBar, actionBarItemArray}}
+ */
 export const useActionBar = (actionBarItems) => {
   const [hasActionBar, setHasActionBar] = useState(false);
   const [actionBarItemArray, setActionBarItemArray] = useState([]);
@@ -10,6 +23,9 @@ export const useActionBar = (actionBarItems) => {
     setHasActionBar(newShapes.length);
     setActionBarItemArray(newShapes);
   }, [actionBarItems]);
+
+  // const actionBarItemArray = extractShapesArray(actionBarItems);
+  // const hasActionBar = actionBarItemArray.length;
 
   return { hasActionBar, actionBarItemArray };
 };
@@ -115,7 +131,7 @@ export const useTitleShape = (title, titleIcon, defaultTitle) => {
     }
 
     setTitleShape(newShape);
-  }, [defaultTitle, title, titleIcon, titleShape]);
+  }, [defaultTitle, title, titleIcon]);
 
   return titleShape;
 };


### PR DESCRIPTION
Contributes to #488 

Maybe move uses out of PageHeader?

Probably better to refactor parts of the header to components first.

#### What did you change?

Moved some useEffect/useState code out of page header into a file of it's own

#### How did you test and verify your work?

Storybook.