### PR TITLE
Ensure clear console during test runs

### DIFF
--- a/packages/cdai/src/components/IdeFilter/IdeFilter.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.js
@@ -250,7 +250,7 @@ IdeFilter.propTypes = {
   ).isRequired,
   placeholderText: PropTypes.string,
   searchForText: PropTypes.string,
-  searchIcon: PropTypes.element,
+  searchIcon: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   value: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/packages/cdai/src/components/IdeFilter/IdeFilter.spec.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.spec.js
@@ -25,6 +25,8 @@ describe('IdeFilter', () => {
     expect(wrapper.find('.ide-filter--select').at(0).text()).toBe('Search...');
   });
   it('Renders options with filter tags by default', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
     const wrapper = mount(
       <IdeFilter
         options={untypedOptions}
@@ -41,6 +43,14 @@ describe('IdeFilter', () => {
     expect(wrapper.find('.ide-filter--tag').at(0).props().type).toEqual(
       'filter'
     );
+
+    // Known issue with invalid prop being passed to Tag component
+    expect(error).toBeCalledWith(
+      expect.stringContaining(
+        'Invalid prop `type` of value `filter` supplied to `Tag`'
+      )
+    );
+    error.mockRestore();
   });
   it('Renders options in menu', () => {
     const wrapper = mount(
@@ -190,7 +200,7 @@ describe('IdeFilter', () => {
         light
         onChange={() => {}}
         placeholderText="Search..."
-        searchIcon={(className) => (
+        searchIcon={({ className }) => (
           <span className="custom-icon">
             <Idea16 className={className} />
           </span>
@@ -198,7 +208,7 @@ describe('IdeFilter', () => {
       />
     );
     expect(wrapper).toBeDefined();
-    expect(wrapper.find('.ide-filter--search-icon')).toHaveLength(1);
+    expect(wrapper.find('svg.ide-filter--search-icon')).toHaveLength(1);
     expect(wrapper.find('.custom-icon')).toHaveLength(1);
   });
   it('Triggers on input change', () => {

--- a/packages/cdai/src/components/IdeImporting/IdeImporting.js
+++ b/packages/cdai/src/components/IdeImporting/IdeImporting.js
@@ -188,7 +188,9 @@ export default class IdeImporting extends React.Component {
       };
     });
     for (let fileToUpload of mappedFiles) {
-      this.handleFileAdded(fileToUpload);
+      this.handleFileAdded(fileToUpload).catch((err) => {
+        console.warn(err);
+      });
     }
   }
   handleUrlAdded(addedFiles) {

--- a/packages/cdai/src/components/IdeImporting/IdeImporting.test.js
+++ b/packages/cdai/src/components/IdeImporting/IdeImporting.test.js
@@ -13,6 +13,7 @@ import {
   validateFileAdded,
 } from './helpers';
 import { FileUploaderItem, TextInput } from 'carbon-components-react';
+import { waitFor } from '@testing-library/react';
 
 import React from 'react';
 // import {act} from 'react-dom/test-utils';
@@ -151,7 +152,8 @@ describe('IdeImporting unit tests', () => {
     wrapper.unmount();
   });
 
-  it('should handle errors thrown by onFileAdded', () => {
+  it('should handle errors thrown by onFileAdded', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const props = {
       validExtensions: ['png'],
       onFileAdded: jest.fn(() => {
@@ -162,7 +164,13 @@ describe('IdeImporting unit tests', () => {
     wrapper.simulateDropFiles([{ name: 'test-file.png' }]);
     expect(props.onFileAdded).toBeCalled();
     expect(props.onFileAdded).toThrow();
+    await waitFor(() => {
+      expect(warn).toBeCalledWith(
+        expect.objectContaining({ message: 'Subject: message' })
+      );
+    });
     wrapper.unmount();
+    warn.mockRestore();
   });
 
   it('should handle removing a file', () => {

--- a/packages/cloud-cognitive/src/components/APIKeyDownloader/APIKeyDownloader.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyDownloader/APIKeyDownloader.test.js
@@ -17,7 +17,7 @@ const defaultProps = {
   linkText: 'download',
 };
 
-global.URL.createObjectURL = jest.fn(() => Promise.resolve('download-link'));
+URL.createObjectURL = jest.fn(() => Promise.resolve('download-link'));
 
 describe(name, () => {
   test('renders with minimal setup', async () => {

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { APIKeyModal } from '.';
 
@@ -58,6 +58,8 @@ const standardProps = {
   open: true,
 };
 
+URL.createObjectURL = jest.fn(() => Promise.resolve('download-link'));
+
 describe(name, () => {
   it('renders with minimal setup', () => {
     const { click } = fireEvent;
@@ -67,7 +69,7 @@ describe(name, () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('123-456-789');
   });
 
-  it('renders with standard setup', () => {
+  it('renders with standard setup', async () => {
     const { click, change } = fireEvent;
     const { fn } = jest;
     const onRequestSubmit = fn();
@@ -90,6 +92,7 @@ describe(name, () => {
     rerender(<APIKeyModal {...props} loading />);
     expect(getByText(props.loadingMessage)).toBeVisible();
     rerender(<APIKeyModal {...props} apiKey="444-444-444-444" />);
+    await waitFor(() => getByText(props.downloadLinkText));
     const copyBtn = getByText('Copy');
     click(copyBtn);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(


### PR DESCRIPTION
resolves #741

Clean up some of the CDAI tests, and in a couple of places adjust the component itself, to ensure the tests run cleanly with no noise in the console log.

#### What did you change?

Selected CDAI components.

#### How did you test and verify your work?

Ran the tests. None of these changes should functionally affect the components themselves.
