### PR TITLE
Reduce deprecation warnings from stylelint

### DIFF
--- a/packages/cloud-cognitive/src/components/StatusIcon/_status-icon.scss
+++ b/packages/cloud-cognitive/src/components/StatusIcon/_status-icon.scss
@@ -109,8 +109,8 @@ $block-class: #{$pkg-prefix}--status-icon;
           @media (prefers-reduced-motion: reduce) {
             animation: none;
           }
-          // stylelint-disable-next-line carbon/motion-token-use, declaration-property-unit-whitelist
-          animation: rotating 8s infinite linear;
+          // stylelint-disable-next-line carbon/motion-token-use
+          animation: rotating 8000ms infinite linear;
           // stylelint-disable-next-line carbon/theme-token-use
           fill: clr($icon, $theme);
         } @else if $icon == running {


### PR DESCRIPTION
This won't actually remove the warnings yet, because Carbon are also using the deprecated rules, but at least the warnings will now go as and when Carbon fix that, and I'm about to put a PR in to Carbon to do that :-)