### PR TITLE
Alternative PR for #840: action button styling issue

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -48,6 +48,7 @@ const ActionSetButton = React.forwardRef(
         { [`${blockClass}__action-button--ghost`]: kind === 'ghost' },
       ])}
       disabled={disabled || loading || false}
+      isExpressive
       {...{ kind, onClick, ref, size }}>
       {label}
       {loading && <InlineLoading />}


### PR DESCRIPTION
Contributes to #840 

This fixes issues we've seen lately with the action buttons not receiving the expected width. In the latest carbon version, if you add `isExpressive` the max-width will not get applied which is what we need.

#### What did you change?
`ActionSet.js` 

#### How did you test and verify your work?
Storybook
