### PR TITLE
feat(styles): export used Carbon style modules

### DIFF
--- a/packages/cloud-cognitive/src/global/styles/_imported-carbon-modules.scss
+++ b/packages/cloud-cognitive/src/global/styles/_imported-carbon-modules.scss
@@ -1,0 +1,25 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+/// List of Carbon style modules used.
+/// @type List
+/// @access public
+$imported-carbon-modules: 'css--reset' 'css--default-type' 'skeleton'
+  'helper-classes' 'css--font-face' 'css--helpers' 'css--body' 'grid' 'button'
+  'copy-button' 'form' 'loading' 'file-uploader' 'checkbox' 'list-box'
+  'combo-box' 'radio-button' 'toggle' 'search' 'select' 'text-input' 'text-area'
+  'number-input' 'link' 'lists' 'data-table-v2-action' 'data-table-v2-core'
+  'data-table-v2-expandable' 'data-table-sort' 'data-table-inline-edit'
+  'data-table-skeleton' 'structured-list' 'snippet' 'overflow-menu'
+  'content-switcher' 'context-menu' 'date-picker' 'dropdown' 'modal'
+  'multi-select' 'inline-notifications' 'toast-notifications' 'tooltip' 'tabs'
+  'tags' 'pagination' 'accordion' 'progress-indicator' 'breadcrumb' 'toolbar'
+  'time-picker' 'slider' 'tile' 'skeleton-text' 'skeleton-icon'
+  'skeleton-placeholder' 'inline-loading' 'pagination-nav' 'unstable_pagination'
+  'carbon-header' 'carbon-header-panel' 'product-switcher'
+  'carbon-header-switcher' 'carbon-side-nav' 'carbon-navigation'
+  'carbon-content' 'popover';

--- a/packages/cloud-cognitive/src/index-without-carbon-released-only.scss
+++ b/packages/cloud-cognitive/src/index-without-carbon-released-only.scss
@@ -5,21 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-$imported-modules: 'css--reset' 'css--default-type' 'skeleton' 'helper-classes'
-  'css--font-face' 'css--helpers' 'css--body' 'grid' 'button' 'copy-button'
-  'form' 'loading' 'file-uploader' 'checkbox' 'list-box' 'combo-box'
-  'radio-button' 'toggle' 'search' 'select' 'text-input' 'text-area'
-  'number-input' 'link' 'lists' 'data-table-v2-action' 'data-table-v2-core'
-  'data-table-v2-expandable' 'data-table-sort' 'data-table-inline-edit'
-  'data-table-skeleton' 'structured-list' 'snippet' 'overflow-menu'
-  'content-switcher' 'context-menu' 'date-picker' 'dropdown' 'modal'
-  'multi-select' 'inline-notifications' 'toast-notifications' 'tooltip' 'tabs'
-  'tags' 'pagination' 'accordion' 'progress-indicator' 'breadcrumb' 'toolbar'
-  'time-picker' 'slider' 'tile' 'skeleton-text' 'skeleton-icon'
-  'skeleton-placeholder' 'inline-loading' 'pagination-nav' 'unstable_pagination'
-  'carbon-header' 'carbon-header-panel' 'product-switcher'
-  'carbon-header-switcher' 'carbon-side-nav' 'carbon-navigation'
-  'carbon-content' 'popover';
+@import './global/styles/imported-carbon-modules';
+
+$imported-modules: $imported-carbon-modules;
 
 @import '@carbon/import-once/scss/import-once';
 @import './global/styles/carbon-settings';

--- a/packages/cloud-cognitive/src/index-without-carbon.scss
+++ b/packages/cloud-cognitive/src/index-without-carbon.scss
@@ -5,21 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-$imported-modules: 'css--reset' 'css--default-type' 'skeleton' 'helper-classes'
-  'css--font-face' 'css--helpers' 'css--body' 'grid' 'button' 'copy-button'
-  'form' 'loading' 'file-uploader' 'checkbox' 'list-box' 'combo-box'
-  'radio-button' 'toggle' 'search' 'select' 'text-input' 'text-area'
-  'number-input' 'link' 'lists' 'data-table-v2-action' 'data-table-v2-core'
-  'data-table-v2-expandable' 'data-table-sort' 'data-table-inline-edit'
-  'data-table-skeleton' 'structured-list' 'snippet' 'overflow-menu'
-  'content-switcher' 'context-menu' 'date-picker' 'dropdown' 'modal'
-  'multi-select' 'inline-notifications' 'toast-notifications' 'tooltip' 'tabs'
-  'tags' 'pagination' 'accordion' 'progress-indicator' 'breadcrumb' 'toolbar'
-  'time-picker' 'slider' 'tile' 'skeleton-text' 'skeleton-icon'
-  'skeleton-placeholder' 'inline-loading' 'pagination-nav' 'unstable_pagination'
-  'carbon-header' 'carbon-header-panel' 'product-switcher'
-  'carbon-header-switcher' 'carbon-side-nav' 'carbon-navigation'
-  'carbon-content' 'popover';
+@import './global/styles/imported-carbon-modules';
+
+$imported-modules: $imported-carbon-modules;
 
 // To generate the above values, compile the following SCSS, examine the output,
 // copy the content field from the :root section at the end of the file into the


### PR DESCRIPTION
#### Affected issue

Contributes to #839 

#### Proposed change

Separated `$imported-modules` into global partial for application team usage.

#### Testing and verification

No regressions running:

- `storybook`
- `test`