### PR TITLE
fix: add fallback selector for focus trap (CDAI Legacy IdeSlideOverPanel)

### DIFF
--- a/packages/cdai/src/components/IdeSlideOverPanel/IdeSlideOverPanel.js
+++ b/packages/cdai/src/components/IdeSlideOverPanel/IdeSlideOverPanel.js
@@ -178,6 +178,7 @@ IdeSlideOverPanel.defaultProps = {
   closeButtonIconDescription: 'Close',
   focusTrapOptions: {
     initialFocus: '.ide-slide-over-panel--close',
+    fallbackFocus: '.ide-slide-over-panel--close',
   },
 };
 


### PR DESCRIPTION
Contributes to #848

This fixes the CDAI `IdeSlideOverPanel.js` component. In the recent package updates, the `fallbackFocus` value needs to be provided. Previously, the story named `With state manager` was breaking, with this changed everything works as expected again.

#### What did you change?
`IdeSlideOverPanel.js`
#### How did you test and verify your work?
Storybook