### PR TITLE
fix(ActionSet): ensure action set buttons have max width none

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -29,11 +29,15 @@
     @include carbon--type-style('body-short-01');
 
     align-items: center;
-    max-width: none;
     height: $spacing-10;
     margin: 0;
     padding-top: $spacing-05;
     padding-bottom: $spacing-07;
+  }
+
+  .#{$block-class}.#{$carbon-prefix}--btn-set
+    .#{$block-class}__action-button.#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--expressive {
+    max-width: none;
   }
 
   // For row-single in medium,


### PR DESCRIPTION
Contributes to #858 

This makes sure that the ActionSet buttons do not receive a `max-width` as this will cause layout issues in larger scenarios, such as Tearsheets, CreateTearsheets, and max size side panels.

#### What did you change?
`_action-set.scss`
#### How did you test and verify your work?
Storybook