### PR TITLE
feat: update page header sticky again

### DIFF
--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
@@ -187,7 +187,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
 
     const visibleBreadcrumbs = screen.getAllByRole('listitem');
     // not enough room
-    expect(visibleBreadcrumbs.length).toEqual(4); // 3 + overflow
+    expect(visibleBreadcrumbs.length).toEqual(4);
 
     // last item is last breadcrumb
     expect(visibleBreadcrumbs[3]).toHaveTextContent(breadcrumbContent[4]);
@@ -206,7 +206,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
 
     const visibleBreadcrumbs = screen.getAllByRole('listitem');
     // not enough room
-    expect(visibleBreadcrumbs.length).toEqual(2); // 1 + overflow
+    expect(visibleBreadcrumbs.length).toEqual(2);
 
     // last item is last breadcrumb
     expect(visibleBreadcrumbs[1]).toHaveTextContent(breadcrumbContent[4]);

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -38,7 +38,6 @@ import {
   blockClass,
   utilCheckUpdateVerticalSpace,
   utilGetTitleShape,
-  utilCalcSpacingBelowTitle,
   utilSetCustomCSSProps,
 } from './PageHeaderUtils';
 
@@ -74,14 +73,6 @@ export let PageHeader = React.forwardRef(
     const headerRef = ref || localHeaderRef;
 
     // utility functions
-    const calcSpacingBelowTitle = () =>
-      utilCalcSpacingBelowTitle(
-        availableSpace,
-        tags,
-        navigation,
-        subtitle,
-        pageActions
-      );
     // Title shape is used to allow title to be string or shape
     const getTitleShape = () =>
       utilGetTitleShape(title, titleIcon, PageHeader.defaultProps.title);
@@ -106,8 +97,6 @@ export let PageHeader = React.forwardRef(
         ...shape,
       })
     );
-
-    const spacingBelowTitle = calcSpacingBelowTitle();
 
     /* Title shape is used to allow title to be string or shape */
     const titleShape = getTitleShape();
@@ -517,22 +506,18 @@ export let PageHeader = React.forwardRef(
               {!preCollapseTitleRow &&
               !(title === undefined && pageActions === undefined) ? (
                 <Row
-                  className={cx(
-                    `${blockClass}__title-row`,
-                    `${blockClass}__title-row--spacing-below-${spacingBelowTitle}`,
-                    {
-                      [`${blockClass}__title-row--no-breadcrumb-row`]:
-                        !hasBreadcrumbRow,
-                      [`${blockClass}__title-row--under-action-bar`]:
-                        hasActionBar,
-                      [`${blockClass}__title-row--has-page-actions`]:
-                        pageActions !== undefined,
-                      [`${blockClass}__title-row--sticky`]:
-                        pageActions !== undefined &&
-                        actionBarItems === undefined &&
-                        hasBreadcrumbRow,
-                    }
-                  )}>
+                  className={cx(`${blockClass}__title-row`, {
+                    [`${blockClass}__title-row--no-breadcrumb-row`]:
+                      !hasBreadcrumbRow,
+                    [`${blockClass}__title-row--under-action-bar`]:
+                      hasActionBar,
+                    [`${blockClass}__title-row--has-page-actions`]:
+                      pageActions !== undefined,
+                    [`${blockClass}__title-row--sticky`]:
+                      pageActions !== undefined &&
+                      actionBarItems === undefined &&
+                      hasBreadcrumbRow,
+                  })}>
                   <Column className={`${blockClass}__title-column`}>
                     {/* keeps page actions right even if empty */}
                     {title !== undefined ? (

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -22,7 +22,7 @@ import {
 import { CheckmarkFilled16 } from '@carbon/icons-react';
 import { Lightning16, Bee24 } from '@carbon/icons-react';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
 import { ActionBarItem } from '../ActionBar';
 import { PageHeader } from '.';
@@ -269,6 +269,7 @@ const longTitle = {
 const Template = (args) => {
   return (
     <>
+      <style>{`.${carbon.prefix}--modal { opacity: 0; }`};</style>
       <PageHeader className={className} {...args} />
       {dummyPageContent}
     </>
@@ -504,26 +505,31 @@ AllAttributesWithSwitches.args = {
 
 const TemplatePageHeaderWithCarbonHeader = (args) => {
   return (
-    <div className={`${storyClass}__app`}>
-      <Header aria-label="IBM Platform Name">
-        <HeaderName href="#" prefix="IBM">
-          [Platform]
-        </HeaderName>
-      </Header>
-      <div
-        className={`${storyClass}__content-container`}
-        style={{
-          // stylelint-disable-next-line carbon/layout-token-use
-          marginTop: '48px',
-        }}>
-        <PageHeader
-          className="example-class-name"
-          {...includeTheseArgs(args)}
-          pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
-        />
-        <div className={`${storyClass}__inner-content`}>{dummyPageContent}</div>
+    <>
+      <style>{`.${carbon.prefix}--modal { opacity: 0; }`};</style>
+      <div className={`${storyClass}__app`}>
+        <Header aria-label="IBM Platform Name">
+          <HeaderName href="#" prefix="IBM">
+            [Platform]
+          </HeaderName>
+        </Header>
+        <div
+          className={`${storyClass}__content-container`}
+          style={{
+            // stylelint-disable-next-line carbon/layout-token-use
+            marginTop: '48px',
+          }}>
+          <PageHeader
+            className="example-class-name"
+            {...includeTheseArgs(args)}
+            pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
+          />
+          <div className={`${storyClass}__inner-content`}>
+            {dummyPageContent}
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -486,7 +486,12 @@ describe('PageHeader', () => {
     render(<PageHeader {...{ title, pageActions, navigation }} />);
 
     expect(
-      document.querySelectorAll(`.${blockClass}__title-row--spacing-below-06`)
+      document.querySelectorAll(
+        `.${blockClass}__title-row .${blockClass}__title`
+      )
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll(`.${blockClass}__navigation-row`)
     ).toHaveLength(1);
   });
 

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeaderDemo.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeaderDemo.stories.js
@@ -32,7 +32,7 @@ import {
   VolumeMute16,
 } from '@carbon/icons-react';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
 import { ActionBarItem } from '../ActionBar';
 import { PageHeader } from '.';
@@ -771,109 +771,112 @@ const demoTableHeaders = Object.keys(demoTableData[0]);
 
 const TemplateDemo = () => {
   return (
-    <div className={`${storyClass}__app`}>
-      <Header aria-label="IBM Platform Name">
-        <HeaderName href="#" prefix="IBM">
-          Cloud Cognitive application
-        </HeaderName>
-      </Header>
-      <div
-        className={`${storyClass}__content-container`}
-        style={{
-          // stylelint-disable-next-line carbon/layout-token-use
-          marginTop: '48px',
-        }}>
-        <PageHeader
-          breadcrumbItems={
-            <>
-              <BreadcrumbItem href="../../../hompepage">
-                Homepage
-              </BreadcrumbItem>
-              <BreadcrumbItem href="../../Reports">Reports</BreadcrumbItem>
-              <BreadcrumbItem href="../June2021">June 2021</BreadcrumbItem>
-            </>
-          }
-          actionBarItems={[
-            { renderIcon: Printer16, iconDescription: `Print` },
-            { renderIcon: Settings16, iconDescription: `Settings` },
-            { renderIcon: VolumeMute16, iconDescription: `Mute` },
-          ]}
-          title={{
-            text: 'Authentication activity',
-            loading: false,
-            icon: Security24,
-          }}
-          preventBreadcrumbScroll
-          pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
-          pageActions={[
-            {
-              kind: 'secondary',
-              label: 'Acknowledge',
-              onClick: () => {},
-            },
-            {
-              kind: 'primary',
-              label: 'Escalate',
-              onClick: () => {},
-            },
-          ]}
-          subtitle="This report details the monthly authentication failures"
-          availableSpace={
-            <>
-              <p>Severity 1: 0</p>
-              <p>Severity 1: 814</p>
-              <p>Severity 3: 3,108</p>
-            </>
-          }
-          navigation={
-            <Tabs>
-              <Tab label="Summary" />
-              <Tab label="Region 1" />
-              <Tab label="Region 2" />
-              <Tab label="Region 3" />
-            </Tabs>
-          }
-          tags={[
-            <Tag type="cyan" key="Not urgent">
-              Not urgent
-            </Tag>,
-            <Tag type="red" key="Security">
-              Security
-            </Tag>,
-          ]}
-        />
-        {
-          <Grid className={`${storyClass}__dummy-content`} narrow={true}>
-            <Row>
-              <Column
-                sm={2}
-                md={4}
-                lg={{ span: 16, offset: 0 }}
-                className={`${storyClass}__dummy-content-block`}>
-                <Table>
-                  <TableHead>
-                    <TableRow>
-                      {demoTableHeaders.map((header) => (
-                        <TableHeader key={header}>{header}</TableHeader>
-                      ))}
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {demoTableData.map((row) => (
-                      <TableRow key={row.Index}>
-                        {Object.keys(row).map((key) => {
-                          return <TableCell key={key}>{row[key]}</TableCell>;
-                        })}
+    <>
+      <style>{`.${carbon.prefix}--modal { opacity: 0; }`};</style>
+      <div className={`${storyClass}__app`}>
+        <Header aria-label="IBM Platform Name">
+          <HeaderName href="#" prefix="IBM">
+            Cloud Cognitive application
+          </HeaderName>
+        </Header>
+        <div
+          className={`${storyClass}__content-container`}
+          style={{
+            // stylelint-disable-next-line carbon/layout-token-use
+            marginTop: '48px',
+          }}>
+          <PageHeader
+            breadcrumbItems={
+              <>
+                <BreadcrumbItem href="../../../hompepage">
+                  Homepage
+                </BreadcrumbItem>
+                <BreadcrumbItem href="../../Reports">Reports</BreadcrumbItem>
+                <BreadcrumbItem href="../June2021">June 2021</BreadcrumbItem>
+              </>
+            }
+            actionBarItems={[
+              { renderIcon: Printer16, iconDescription: `Print` },
+              { renderIcon: Settings16, iconDescription: `Settings` },
+              { renderIcon: VolumeMute16, iconDescription: `Mute` },
+            ]}
+            title={{
+              text: 'Authentication activity',
+              loading: false,
+              icon: Security24,
+            }}
+            preventBreadcrumbScroll
+            pageHeaderOffset={48} // 48px is the size of the global header. A more elegant way of passing this could be found.
+            pageActions={[
+              {
+                kind: 'secondary',
+                label: 'Acknowledge',
+                onClick: () => {},
+              },
+              {
+                kind: 'primary',
+                label: 'Escalate',
+                onClick: () => {},
+              },
+            ]}
+            subtitle="This report details the monthly authentication failures"
+            availableSpace={
+              <>
+                <p>Severity 1: 0</p>
+                <p>Severity 1: 814</p>
+                <p>Severity 3: 3,108</p>
+              </>
+            }
+            navigation={
+              <Tabs>
+                <Tab label="Summary" />
+                <Tab label="Region 1" />
+                <Tab label="Region 2" />
+                <Tab label="Region 3" />
+              </Tabs>
+            }
+            tags={[
+              <Tag type="cyan" key="Not urgent">
+                Not urgent
+              </Tag>,
+              <Tag type="red" key="Security">
+                Security
+              </Tag>,
+            ]}
+          />
+          {
+            <Grid className={`${storyClass}__dummy-content`} narrow={true}>
+              <Row>
+                <Column
+                  sm={4}
+                  md={8}
+                  lg={16}
+                  className={`${storyClass}__dummy-content-block`}>
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        {demoTableHeaders.map((header) => (
+                          <TableHeader key={header}>{header}</TableHeader>
+                        ))}
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>{' '}
-              </Column>
-            </Row>
-          </Grid>
-        }
+                    </TableHead>
+                    <TableBody>
+                      {demoTableData.map((row) => (
+                        <TableRow key={row.Index}>
+                          {Object.keys(row).map((key) => {
+                            return <TableCell key={key}>{row[key]}</TableCell>;
+                          })}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>{' '}
+                </Column>
+              </Row>
+            </Grid>
+          }
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeaderUtils.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeaderUtils.js
@@ -132,30 +132,6 @@ export const utilGetTitleShape = (title, titleIcon, defaultTitle) => {
   return newShape;
 };
 
-export const utilCalcSpacingBelowTitle = (
-  availableSpace,
-  tags,
-  navigation,
-  subtitle,
-  pageActions
-) => {
-  let belowTitleSpace = 'default';
-
-  if (
-    pageActions !== undefined &&
-    navigation !== undefined &&
-    subtitle === undefined &&
-    availableSpace === undefined
-  ) {
-    belowTitleSpace = '06';
-  } else if (subtitle !== undefined || availableSpace !== undefined) {
-    belowTitleSpace = '03';
-  } else if (navigation === undefined && tags !== undefined) {
-    belowTitleSpace = '05';
-  }
-  return belowTitleSpace;
-};
-
 // Set css style values directly onto a node. Note that this is effective
 // immediately, rather than using the React `style` prop which goes through
 // the React DOM update optimisation.

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -78,18 +78,10 @@ $raised-z-index: 99;
       }
     }
 
-    // .#{$block-class}__breadcrumb-row:not(.#{$block-class}__breadcrumb-row--has-action-bar) {
-    //   margin-bottom: calc(-1 * #{$spacing-03});
-    // }
-
-    // .#{$block-class}__breadcrumb-row:not(.#{$block-class}__breadcrumb-row--has-action-bar)
-    //   + .#{$block-class}__title-row {
-    //   // Using transform and margin-bottom as -ve margin top affects scroll opacity
-    //   // An alternative of making breadcrumb row min-height 32px. 0 causes it to be too small on scroll.
-    //   margin-bottom: calc(-1 * #{$spacing-03});
-    //   // stylelint-disable-next-line carbon/layout-token-use
-    //   transform: translateY(calc(-1 * #{$spacing-03}));
-    // }
+    .#{$block-class}__breadcrumb-row:not(.#{$block-class}__breadcrumb-row--has-action-bar) {
+      // lifts up page title when there is no action bar
+      margin-bottom: calc(-1 * #{$spacing-03});
+    }
 
     .#{$block-class}__breadcrumb-row--container {
       display: flex;
@@ -314,7 +306,13 @@ $raised-z-index: 99;
     &.#{$block-class}--has-navigation
       .#{$block-class}__title-row
       + .#{$block-class}__last-row-buffer--active {
-      height: calc(#{$spacing-05} + #{$spacing-02});
+      height: calc(#{$spacing-06});
+    }
+
+    &.#{$block-class}--has-navigation-tags-only
+      .#{$block-class}__title-row
+      + .#{$block-class}__last-row-buffer--active {
+      height: calc(#{$spacing-05});
     }
 
     .#{$block-class}__title-row--sticky {
@@ -437,6 +435,10 @@ $raised-z-index: 99;
       + .#{$block-class}__last-row-buffer--active {
         height: $spacing-05;
       }
+    }
+
+    .#{$block-class}__title-row + .#{$block-class}__available-row {
+      margin-top: $spacing-05;
     }
 
     .#{$block-class}__available-row * {

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -49,11 +49,15 @@ $raised-z-index: 99;
       /* custom props */
       --#{$block-class}--breadcrumb-title-visibility: hidden;
       --#{$block-class}--breadcrumb-title-opacity: 1;
-      --#{$block-class}--breadcrumb-top: 0;
-      --#{$block-class}--breadcrumb-position: 0;
+      --#{$block-class}--breadcrumb-top: 0; //1
       --#{$block-class}--background-opacity: 1;
       --#{$block-class}--breadcrumb-title-top: initial;
       --#{$block-class}--button-set-in-breadcrumb-width-px: initial;
+      --#{$block-class}--navigation-buffer-top: $spacing-06;
+    }
+
+    &.#{$block-class}--has-navigation-tags-only {
+      --#{$block-class}--navigation-buffer-top: $spacing-04;
     }
 
     &.#{$block-class}--show-background::before {
@@ -64,9 +68,9 @@ $raised-z-index: 99;
     }
 
     .#{$block-class}__breadcrumb-row {
-      position: var(--#{$block-class}--breadcrumb-position);
+      position: sticky;
       z-index: $raised-z-index;
-      top: var(--#{$block-class}--breadcrumb-top);
+      top: var(--#{$block-class}--breadcrumb-top); //2
       min-height: $spacing-08;
 
       + .#{$block-class}__last-row-buffer--active {
@@ -74,14 +78,18 @@ $raised-z-index: 99;
       }
     }
 
-    :not(.#{$block-class}__breadcrumb-row--has-action-bar)
-      + .#{$block-class}__title-row {
-      // Using transform and margin-bottom as -ve margin top affects scroll opacity
-      // An alternative of making breadcrumb row min-height 32px. 0 causes it to be too small on scroll.
-      margin-bottom: calc(-1 * #{$spacing-03});
-      // stylelint-disable-next-line carbon/layout-token-use
-      transform: translateY(calc(-1 * #{$spacing-03}));
-    }
+    // .#{$block-class}__breadcrumb-row:not(.#{$block-class}__breadcrumb-row--has-action-bar) {
+    //   margin-bottom: calc(-1 * #{$spacing-03});
+    // }
+
+    // .#{$block-class}__breadcrumb-row:not(.#{$block-class}__breadcrumb-row--has-action-bar)
+    //   + .#{$block-class}__title-row {
+    //   // Using transform and margin-bottom as -ve margin top affects scroll opacity
+    //   // An alternative of making breadcrumb row min-height 32px. 0 causes it to be too small on scroll.
+    //   margin-bottom: calc(-1 * #{$spacing-03});
+    //   // stylelint-disable-next-line carbon/layout-token-use
+    //   transform: translateY(calc(-1 * #{$spacing-03}));
+    // }
 
     .#{$block-class}__breadcrumb-row--container {
       display: flex;
@@ -183,8 +191,7 @@ $raised-z-index: 99;
       }
     }
 
-    .#{$block-class}__breadcrumb-row--has-action-bar
-      .#{$block-class}__breadcrumb-column {
+    .#{$block-class}__breadcrumb-row .#{$block-class}__breadcrumb-column {
       // back button displayed only
       max-width: 25%;
       flex: 0 1 25%;
@@ -270,7 +277,6 @@ $raised-z-index: 99;
     }
 
     .#{$block-class}__title-row {
-      z-index: $raised-z-index + 1;
       margin-top: 0;
       margin-bottom: 0;
 
@@ -283,7 +289,6 @@ $raised-z-index: 99;
       }
 
       + .#{$block-class}__last-row-buffer--active {
-        // only used when nothing below title
         height: $spacing-07;
       }
 
@@ -293,7 +298,6 @@ $raised-z-index: 99;
 
       &.#{$block-class}__title-row--spacing-below-05 {
         + .#{$block-class}__last-row-buffer--active {
-          // only used when nothing below title
           height: $spacing-05;
         }
       }
@@ -307,19 +311,24 @@ $raised-z-index: 99;
       }
     }
 
+    &.#{$block-class}--has-navigation
+      .#{$block-class}__title-row
+      + .#{$block-class}__last-row-buffer--active {
+      height: calc(#{$spacing-05} + #{$spacing-02});
+    }
+
     .#{$block-class}__title-row--sticky {
       position: sticky;
-      top: var(--#{$block-class}--breadcrumb-top);
     }
 
     .#{$block-class}__breadcrumb-row--has-breadcrumbs
       + .#{$block-class}__title-row--sticky {
-      // stylelint-disable-next-line carbon/layout-token-use
-      top: calc(#{$spacing-03} + var(--#{$block-class}--breadcrumb-top));
+      top: 0;
     }
 
     .#{$block-class}__title-column {
       overflow: hidden; /* required for ellipsis in title */
+      min-height: 40px;
       flex: 0 0 100%;
 
       @include carbon--breakpoint-up('md') {
@@ -437,21 +446,12 @@ $raised-z-index: 99;
 
     .#{$block-class}__navigation-row {
       flex-wrap: wrap-reverse;
-      margin-top: $spacing-04;
+      margin-top: 0;
 
       .#{$carbon-prefix}--content-switcher {
         box-sizing: content-box;
         padding-bottom: $spacing-05;
       }
-    }
-
-    .#{$block-class}__last-row-buffer--active
-      + .#{$block-class}__navigation-row {
-      margin-top: 0;
-    }
-
-    .#{$block-class}__navigation-row--spacing-above-06 {
-      margin-top: $spacing-06;
     }
 
     .#{$block-class}__navigation-row .#{$carbon-prefix}--tab-content {

--- a/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
@@ -33,7 +33,7 @@ $story-class: 'page-header-stories';
 }
 
 .#{$story-class}__dummy-content-block {
-  height: 120vh;
+  min-height: 120vh;
   background: $ui-01;
   background-clip: content-box;
 }
@@ -50,7 +50,7 @@ $story-class: 'page-header-stories';
 .#{$story-class}__app {
   position: relative;
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
   flex-direction: column;
 }
 


### PR DESCRIPTION
Contributes to #488 
Closes #890 

Simplifies sticky scroll behaviour based on https://codepen.io/lee-chase/pen/rNyZrRm

Also makes a couple of story updates to remove modal glitch.

Replaces space below title with use of margin above available row or last row buffer.

I'd recommend turning off whitespace for diff.

#### What did you change?

PageHeader.js structure to allow breadcrumb row and navigation row to scroll, this includes scrolling off the tags when there is no navigation.

#### How did you test and verify your work?
Storybook