### PR TITLE
fix: page header performance glitches

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -162,7 +162,7 @@ $raised-z-index: 99;
       max-width: var(--#{$block-class}--button-set-in-breadcrumb-width-px);
       flex: 1 1 var(--#{$block-class}--button-set-in-breadcrumb-width-px);
       opacity: 0;
-      transition: all $duration--moderate-02
+      transition: opacity $duration--moderate-02
         carbon--motion('entrance', 'productive');
       visibility: hidden;
       white-space: nowrap;

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -199,14 +199,16 @@ export let TagSet = React.forwardRef(
             </div>
           </div>
 
-          <TagSetModal
-            allTags={allTags}
-            open={showAllModalOpen}
-            heading={showAllModalHeading}
-            onClose={handleModalClose}
-            searchLabel={showAllSearchLabel}
-            searchPlaceholder={showAllSearchPlaceHolderText}
-          />
+          {displayCount < allTags.length ? (
+            <TagSetModal
+              allTags={allTags}
+              open={showAllModalOpen}
+              heading={showAllModalHeading}
+              onClose={handleModalClose}
+              searchLabel={showAllSearchLabel}
+              searchPlaceholder={showAllSearchPlaceHolderText}
+            />
+          ) : null}
         </div>
       </ReactResizeDetector>
     );


### PR DESCRIPTION
Contributes to #59 

Possibly due to the weight of CSS or storybook we get some CSS load glitches. This looks at the modal shown by the page header tag set and the button set when shown in the action bar area.

#### What did you change?
- Only renders TagSet modal if required removing storybook glitch showing briefly showing the modal on 'long-values-many-items'
- Only animates opacity removing a positional artefact.

#### How did you test and verify your work?

Storybook.
