### PR TITLE
feat: breadcrumb overflow title and href updates

### DIFF
--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
@@ -35,7 +35,7 @@ export default {
   parameters: { styles },
 };
 
-const breadcrumbItems = (lastCurrent) => [
+const breadcrumbItems = [
   <BreadcrumbItem key="1">
     <a
       href="/#"
@@ -70,19 +70,23 @@ const breadcrumbItems = (lastCurrent) => [
     }}>
     <a href="/#">Breadcrumb 4</a>
   </BreadcrumbItem>,
-  <BreadcrumbItem
-    key="5"
-    onClick={(ev) => {
-      ev.preventDefault();
-      action('Breadcrumb 5 click')();
-    }}
-    isCurrentPage={lastCurrent}>
-    <a href="/#">
-      Breadcrumb 5 is a longer breadcrumb it could go on for much longer than
-      expected
-    </a>
-  </BreadcrumbItem>,
 ];
+
+const stdBreadcrumbItems = (current) =>
+  breadcrumbItems.concat([
+    <BreadcrumbItem
+      key="5"
+      onClick={(ev) => {
+        ev.preventDefault();
+        action('Breadcrumb 5 click')();
+      }}
+      isCurrentPage={current}>
+      <a href="/#">
+        Breadcrumb 5 is a longer breadcrumb it could go on for much longer than
+        expected
+      </a>
+    </BreadcrumbItem>,
+  ]);
 
 const Template = (argsIn) => {
   const { children, containerWidth, ...args } = { ...argsIn };
@@ -96,12 +100,52 @@ const Template = (argsIn) => {
 
 export const BreadcrumbLastCurrent = Template.bind({});
 BreadcrumbLastCurrent.args = {
-  children: breadcrumbItems(true),
+  children: stdBreadcrumbItems(true),
   containerWidth: 500,
 };
 
 export const BreadcrumbLastNotCurrent = Template.bind({});
 BreadcrumbLastNotCurrent.args = {
-  children: breadcrumbItems(false),
+  children: stdBreadcrumbItems(false),
+  containerWidth: 500,
+};
+
+export const BreadcrumbWithDataTitle = Template.bind({});
+BreadcrumbWithDataTitle.args = {
+  children: breadcrumbItems.concat([
+    <BreadcrumbItem
+      key="5"
+      onClick={(ev) => {
+        ev.preventDefault();
+        action('Breadcrumb 5 click')();
+      }}
+      data-title="An alternative title"
+      isCurrentPage={true}>
+      <a href="/#">
+        Breadcrumb 5 is a longer breadcrumb it could go on for much longer than
+        expected
+      </a>
+    </BreadcrumbItem>,
+  ]),
+  containerWidth: 500,
+};
+
+export const BreadcrumbWithTitle = Template.bind({});
+BreadcrumbWithTitle.args = {
+  children: breadcrumbItems.concat([
+    <BreadcrumbItem
+      key="5"
+      onClick={(ev) => {
+        ev.preventDefault();
+        action('Breadcrumb 5 click')();
+      }}
+      title="A use of the standard title attribute"
+      isCurrentPage={true}>
+      <a href="/#">
+        Breadcrumb 5 is a longer breadcrumb it could go on for much longer than
+        expected
+      </a>
+    </BreadcrumbItem>,
+  ]),
   containerWidth: 500,
 };


### PR DESCRIPTION
Closes to #882

Simplify breadcrumb title and href access and add the option of supplying a value via title or data-title.

#### What did you change?

BreadcrumbWithOverflwo.js and story

#### How did you test and verify your work?
Storybook.