### PR TITLE
fix(HTTPErrors): remove canary check on http error content component

### DIFF
--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorContent.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorContent.js
@@ -17,7 +17,7 @@ import { Link } from 'carbon-components-react';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--http-errors`;
-const componentName = 'HTTPErrors';
+const componentName = 'HTTPErrorContent';
 
 export let HTTPErrorContent = ({
   description,
@@ -49,9 +49,6 @@ export let HTTPErrorContent = ({
     </div>
   );
 };
-
-// Return a placeholder if not released and not enabled by feature flag
-HTTPErrorContent = pkg.checkComponentEnabled(HTTPErrorContent, componentName);
 
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.


### PR DESCRIPTION
Contributes to #899 

The HTTP error content component should not check if it is canary, this is used to render content and does not need to have a canary check since it is an internal component and is also never exported for end users to consume.

#### What did you change?
`HTTPErrorContent.js`
#### How did you test and verify your work?
Storybook