### PR TITLE
Tearsheet navigation buttons always right aligned

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1679,6 +1679,7 @@ path:nth-of-type(1),
 
 .exp--tearsheet .exp--tearsheet__body {
   display: flex;
+  flex-direction: row;
   flex-grow: 1;
   padding: 0;
   margin: 0;
@@ -1690,18 +1691,12 @@ path:nth-of-type(1),
 }
 
 .exp--tearsheet .exp--tearsheet__influencer {
-  width: 256px;
-  min-width: 256px;
+  flex: 0 0 256px;
   border-right: 1px solid var(--cds-ui-03, #e0e0e0);
 }
 
-.exp--tearsheet .exp--tearsheet__influencer--right {
-  order: 1;
-}
-
 .exp--tearsheet .exp--tearsheet__influencer--wide {
-  width: 320px;
-  min-width: 320px;
+  flex-basis: 320px;
 }
 
 .exp--tearsheet .exp--tearsheet__right {
@@ -1711,35 +1706,46 @@ path:nth-of-type(1),
 }
 
 .exp--tearsheet .exp--tearsheet__main {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+}
+
+.exp--tearsheet .exp--tearsheet__main .exp--tearsheet__influencer {
+  border-right: none;
+  border-left: 1px solid var(--cds-ui-03, #e0e0e0);
+}
+
+.exp--tearsheet .exp--tearsheet__content {
   overflow: auto;
   flex-grow: 1;
 }
 
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main {
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content {
   background: var(--cds-ui-background, #ffffff);
 }
 
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--pagination,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--pagination__control-buttons,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-area,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--search-input,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--select-input,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown-list,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--number input[type='number'],
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--date-picker__input {
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--pagination,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--pagination__control-buttons,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--text-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--text-area,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--search-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--select-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--dropdown,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--dropdown-list,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--number input[type='number'],
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--date-picker__input {
   background-color: var(--cds-field-01, #f4f4f4);
 }
 
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-input--light,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--text-area--light,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--search--light .bx--search-input,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--select--light .bx--select-input,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown--light,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--dropdown--light .bx--dropdown-list,
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--number--light input[type='number'],
-.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__main .bx--date-picker--light .bx--date-picker__input {
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--text-input--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--text-area--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--search--light .bx--search-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--select--light .bx--select-input,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--dropdown--light,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--dropdown--light .bx--dropdown-list,
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--number--light input[type='number'],
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__content .bx--date-picker--light .bx--date-picker__input {
   background-color: var(--cds-field-02, #ffffff);
 }
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
@@ -280,8 +280,9 @@ describe(componentName, () => {
 
   it('responds to influencerPosition', () => {
     render(<Tearsheet {...{ influencer }} influencerPosition="right" />);
-    const influencerElt = screen.getByText(influencerFragment).parentElement;
-    expect(influencerElt).toHaveClass(`${blockClass}__influencer--right`);
+    const influencerElt =
+      screen.getByText(influencerFragment).parentElement.parentElement;
+    expect(influencerElt).toHaveClass(`${blockClass}__main`);
   });
 
   it('responds to influencerWidth', () => {

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg, carbon } from '../../settings';
 import { deprecateProp } from '../../global/js/utils/props-helper';
+import pconsole from '../../global/js/utils/pconsole';
 
 // Carbon and package components we use.
 import {
@@ -217,14 +218,26 @@ export const TearsheetShell = React.forwardRef(
             <Wrap
               className={cx({
                 [`${bc}__influencer`]: true,
-                [`${bc}__influencer--right`]: influencerPosition === 'right',
                 [`${bc}__influencer--wide`]: influencerWidth === 'wide',
-              })}>
+              })}
+              neverRender={influencerPosition === 'right'}>
               {influencer}
             </Wrap>
             <Wrap className={`${bc}__right`}>
               <Wrap alwaysRender={includeActions} className={`${bc}__main`}>
-                {children}
+                <Wrap
+                  alwaysRender={influencer && influencerPosition === 'right'}
+                  className={`${bc}__content`}>
+                  {children}
+                </Wrap>
+                <Wrap
+                  className={cx({
+                    [`${bc}__influencer`]: true,
+                    [`${bc}__influencer--wide`]: influencerWidth === 'wide',
+                  })}
+                  neverRender={influencerPosition !== 'right'}>
+                  {influencer}
+                </Wrap>
               </Wrap>
               {includeActions && (
                 <ActionSet
@@ -240,7 +253,7 @@ export const TearsheetShell = React.forwardRef(
         </ComposedModal>
       );
     } else {
-      console.warn('Tearsheet not rendered: maximum stacking depth exceeded.');
+      pconsole.warn('Tearsheet not rendered: maximum stacking depth exceeded.');
       return null;
     }
   }

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -186,6 +186,7 @@
 
   .#{$block-class} .#{$block-class}__body {
     display: flex;
+    flex-direction: row;
     flex-grow: 1;
     padding: 0;
     margin: 0;
@@ -197,18 +198,12 @@
   }
 
   .#{$block-class} .#{$block-class}__influencer {
-    width: 256px;
-    min-width: 256px;
+    flex: 0 0 256px;
     border-right: 1px solid $ui-03;
   }
 
-  .#{$block-class} .#{$block-class}__influencer--right {
-    order: 1;
-  }
-
   .#{$block-class} .#{$block-class}__influencer--wide {
-    width: 320px;
-    min-width: 320px;
+    flex-basis: 320px;
   }
 
   .#{$block-class} .#{$block-class}__right {
@@ -218,11 +213,22 @@
   }
 
   .#{$block-class} .#{$block-class}__main {
+    display: flex;
+    flex-direction: row;
+    flex-grow: 1;
+  }
+
+  .#{$block-class} .#{$block-class}__main .#{$block-class}__influencer {
+    border-right: none;
+    border-left: 1px solid $ui-03;
+  }
+
+  .#{$block-class} .#{$block-class}__content {
     overflow: auto;
     flex-grow: 1;
   }
 
-  .#{$block-class}.#{$block-class}--wide .#{$block-class}__main {
+  .#{$block-class}.#{$block-class}--wide .#{$block-class}__content {
     background: $ui-background;
 
     // revert the background colour overridden by bx--modal styles


### PR DESCRIPTION
Contributes to #773

Per design, a right-aligned influencer should sit over the action buttons instead of pushing them in. This means a right-aligned influencer is structurally different from a left-aligned influencer, so they are rendered separately.

#### What did you change?

TearsheetShell and tearsheet SCSS

Note that this PR updates styles for released components.

#### How did you test and verify your work?

Ran storybook.