### PR TITLE
Move ButtonMenu and ComboButton into 'Internal' folder on Storybook

### DIFF
--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
@@ -8,12 +8,17 @@
 import CloudApp16 from '@carbon/icons-react/lib/cloud-app/16';
 import React from 'react';
 
+import { pkg } from '../../settings';
+import { getStorybookPrefix } from '../../../config';
+
 import { ComboButton, ComboButtonItem } from '..';
 
 import styles from './_combo-button.scss';
 
+const storybookPrefix = getStorybookPrefix(pkg, ComboButton.displayName);
+
 export default {
-  title: `Legacy/Security/${ComboButton.name}`,
+  title: `${storybookPrefix}/${ComboButton.displayName}`,
   component: ComboButton,
   subcomponents: {
     ComboButtonItem,

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -7,7 +7,6 @@
 
 export { AboutModal } from './AboutModal';
 export { ActionBarItem } from './ActionBar';
-export { ButtonMenu, ButtonMenuItem } from './ButtonMenu';
 export { ComboButton, ComboButtonItem } from './ComboButton';
 export { ContextHeader } from './ContextHeader';
 export {

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -37,8 +37,6 @@ const defaults = {
     ActionBarItem: false,
     APIKeyDownloader: false,
     APIKeyModal: false,
-    ButtonMenu: false,
-    ButtonMenuItem: false,
     CreateFullPage: false,
     CreateFullPageSection: false,
     CreateFullPageStep: false,

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -48,6 +48,7 @@ const decorators = [
 const order = [
   'Cloud & Cognitive/Released',
   'Cloud & Cognitive/Canary',
+  'Cloud & Cognitive/Internal',
   'Legacy',
 ];
 const toOrder = (value) => {


### PR DESCRIPTION
Contributes to #749

We're holding off deprecating ComboButton pending the outcome of the button pattern workgroup, and publishing ButtonMenu until a design is published, but in the mean time they are slightly randomly placed in our Storybook which may cause some confusion. ComboButton we have moved into C&CS package in order to remove the dependency on the legacy/security package, but this ComboButton is still showing in legacy/security in the storybook where it clashes with the component from the legacy/security package itself! MenuButton is causing some distraction by showing in our canary list, but it's only internal (used by PageHeader) for now pending the design outcome. This PR moves both components into the 'Internal' section of C&CS on storybook.

NB this leaves ComboButton as a slight anomaly, as it is exported from C&CS despite being 'internal', but this is a temporary status: if it is going to become a fully supported component/pattern it can move to 'canary' and eventually 'released', and if it is not then we can deprecate it and eventually remove it.

NB2 this leaves ComboButton as a double anomaly, as it will still appear under 'Legacy/Security' *as well as* under C&CS/Internal, but this too is temporary: when the security team replace the security package with their current code this will be replaced.

@SimonFinney @andrea-gm  FYI

#### What did you change?

ComboButton and ButtonMenu stories. Also removed ButtonMenu from the export which it should never have been in as it is only internal for the time being.

#### How did you test and verify your work?

Ran storybook.