### PR TITLE
fix(CreateTearsheet): remove overflow styles

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -35,10 +35,6 @@
     display: block;
   }
 
-  .#{$block-class} .#{$pkg-prefix}--tearsheet__body {
-    overflow-y: hidden;
-  }
-
   .#{$block-class}
     .#{$block-class}__step--visible-step:not(.#{$block-class}__step--first-panel-step) {
     animation: $duration--slow-01 stepContentEntrance;


### PR DESCRIPTION
Contributes to #923 

Removed overflow styles that are preventing scrolling, this was temporarily added to fix an issue found with the styles from Carbon's radio button

https://github.com/carbon-design-system/carbon/issues/8932

#### What did you change?
`_create-tearsheet.scss`
#### How did you test and verify your work?
Storybook