### PR TITLE
Fix issue #925 re scrolling in tearsheets

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1805,7 +1805,6 @@ path:nth-of-type(1),
 .exp--tearsheet .exp--tearsheet__body {
   display: flex;
   flex-direction: row;
-  flex-grow: 1;
   padding: 0;
   margin: 0;
 }
@@ -1816,24 +1815,27 @@ path:nth-of-type(1),
 }
 
 .exp--tearsheet .exp--tearsheet__influencer {
-  flex: 0 0 256px;
+  flex: 0 0 257px;
   border-right: 1px solid var(--cds-ui-03, #e0e0e0);
+  overflow-y: auto;
 }
 
 .exp--tearsheet .exp--tearsheet__influencer--wide {
-  flex-basis: 320px;
+  flex-basis: 321px;
 }
 
 .exp--tearsheet .exp--tearsheet__right {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   flex-grow: 1;
+  grid-template-columns: 100%;
+  grid-template-rows: 1fr auto;
 }
 
 .exp--tearsheet .exp--tearsheet__main {
   display: flex;
   flex-direction: row;
-  flex-grow: 1;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
 }
 
 .exp--tearsheet .exp--tearsheet__main .exp--tearsheet__influencer {
@@ -1876,6 +1878,8 @@ path:nth-of-type(1),
 
 .exp--tearsheet .exp--tearsheet__buttons {
   border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+  grid-column: 1 / -1;
+  grid-row: -1 / -1;
 }
 
 .exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__buttons {

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -270,50 +270,54 @@ export let CreateTearsheet = forwardRef(
       });
       if (shouldViewAll) {
         return (
-          <SideNav expanded isFixedNav>
-            <SideNavItems>
-              {sectionChildElements?.length &&
-                sectionChildElements.map((sectionChild, sectionIndex) => (
-                  <SideNavLink
-                    href="javascript:void(0)"
-                    key={sectionIndex}
-                    isActive={activeSectionIndex === sectionIndex}
-                    onClick={() => {
-                      setActiveSectionIndex(sectionIndex);
-                      if (sectionChild.props.id) {
-                        const scrollTarget = document.querySelector(
-                          `#${sectionChild.props.id}`
-                        );
-                        const scrollContainer = document.querySelector(
-                          `.${pkg.prefix}--tearsheet__main`
-                        );
-                        scrollContainer.scrollTo({
-                          top: scrollTarget.offsetTop,
-                          behavior: 'smooth',
-                        });
-                      } else {
-                        console.warn(
-                          `${componentName}: CreateTearsheetSection is missing a required prop of 'id'`
-                        );
-                      }
-                    }}>
-                    {sectionChild.props.title}
-                  </SideNavLink>
-                ))}
-            </SideNavItems>
-          </SideNav>
+          <div className={`${blockClass}__left-nav`}>
+            <SideNav expanded isFixedNav>
+              <SideNavItems>
+                {sectionChildElements?.length &&
+                  sectionChildElements.map((sectionChild, sectionIndex) => (
+                    <SideNavLink
+                      href="javascript:void(0)"
+                      key={sectionIndex}
+                      isActive={activeSectionIndex === sectionIndex}
+                      onClick={() => {
+                        setActiveSectionIndex(sectionIndex);
+                        if (sectionChild.props.id) {
+                          const scrollTarget = document.querySelector(
+                            `#${sectionChild.props.id}`
+                          );
+                          const scrollContainer = document.querySelector(
+                            `.${pkg.prefix}--tearsheet__main`
+                          );
+                          scrollContainer.scrollTo({
+                            top: scrollTarget.offsetTop,
+                            behavior: 'smooth',
+                          });
+                        } else {
+                          console.warn(
+                            `${componentName}: CreateTearsheetSection is missing a required prop of 'id'`
+                          );
+                        }
+                      }}>
+                      {sectionChild.props.title}
+                    </SideNavLink>
+                  ))}
+              </SideNavItems>
+            </SideNav>
+          </div>
         );
       }
       return (
-        <ProgressIndicator
-          currentIndex={currentStep - 1}
-          spaceEqually
-          vertical
-          className={`${blockClass}__progress-indicator`}>
-          {stepChildren.map((child, stepIndex) => (
-            <ProgressStep label={child.props.title} key={stepIndex} />
-          ))}
-        </ProgressIndicator>
+        <div className={`${blockClass}__left-nav`}>
+          <ProgressIndicator
+            currentIndex={currentStep - 1}
+            spaceEqually
+            vertical
+            className={`${blockClass}__progress-indicator`}>
+            {stepChildren.map((child, stepIndex) => (
+              <ProgressStep label={child.props.title} key={stepIndex} />
+            ))}
+          </ProgressIndicator>
+        </div>
       );
     };
 

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -55,6 +55,18 @@
     padding: $spacing-06 $spacing-07;
   }
 
+  .#{$block-class} .#{$pkg-prefix}--tearsheet__influencer {
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 1fr auto;
+  }
+
+  .#{$block-class} .#{$block-class}__left-nav {
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
+    overflow-y: auto;
+  }
+
   .#{$block-class} .#{$block-class}__progress-indicator {
     padding: $spacing-05;
   }
@@ -74,11 +86,9 @@
   }
 
   .#{$block-class} .#{$block-class}__view-all-toggle {
-    position: absolute;
-    z-index: 8001; // UI shell side nav has z-index of 8000 and the toggle needs receive the highest stacking order
-    bottom: 0;
-    left: 0;
     padding: $spacing-05;
+    grid-column: 1 / -1;
+    grid-row: -1 / -1;
   }
 
   .#{$block-class} .#{$carbon-prefix}--side-nav--ux {

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -187,7 +187,6 @@
   .#{$block-class} .#{$block-class}__body {
     display: flex;
     flex-direction: row;
-    flex-grow: 1;
     padding: 0;
     margin: 0;
   }
@@ -198,24 +197,27 @@
   }
 
   .#{$block-class} .#{$block-class}__influencer {
-    flex: 0 0 256px;
+    flex: 0 0 257px; // influencer width 256px plus 1px border
     border-right: 1px solid $ui-03;
+    overflow-y: auto;
   }
 
   .#{$block-class} .#{$block-class}__influencer--wide {
-    flex-basis: 320px;
+    flex-basis: 321px; // influencer width 320px plus 1px border
   }
 
   .#{$block-class} .#{$block-class}__right {
-    display: flex;
-    flex-direction: column;
+    display: grid;
     flex-grow: 1;
+    grid-template-columns: 100%;
+    grid-template-rows: 1fr auto;
   }
 
   .#{$block-class} .#{$block-class}__main {
     display: flex;
     flex-direction: row;
-    flex-grow: 1;
+    grid-column: 1 / -1;
+    grid-row: 1 / -1;
   }
 
   .#{$block-class} .#{$block-class}__main .#{$block-class}__influencer {
@@ -260,6 +262,8 @@
 
   .#{$block-class} .#{$block-class}__buttons {
     border-top: 1px solid $ui-03;
+    grid-column: 1 / -1;
+    grid-row: -1 / -1;
   }
 
   .#{$block-class}.#{$block-class}--wide .#{$block-class}__buttons {


### PR DESCRIPTION
Closes #925 

Repair main content scroll behaviour for tearsheets. Also fix the influencers which were 1px too narrow.

Also fix the scroll behaviour on create tearsheet when the viewport is too short to display the full side nav.

#### What did you change?

Tearsheet and CreateTearsheet styles.

NB this PR changes styles for released components.

#### How did you test and verify your work?

In Storybook.
