### PR TITLE
Remove jest config package from root package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint-config-carbon": "^2.5.0",
     "husky": "^4.3.6",
     "jest": "^27.0.5",
-    "jest-config-ibm-cloud-cognitive": "^0.3.12",
     "lerna": "^4.0.0",
     "lint-staged": "^11.0.0",
     "npm-check-updates": "^11.7.1",


### PR DESCRIPTION
`lerna version` does not update versions of packages in the root package.json. I do not know why this is, but it appears to be a designed and intentional behaviour. This means that you cannot list one of the monorepo packages as a dependency in the root package.json, because if you do then this version becomes stale after the next version bump takes place.

#### What did you change?

Removed jest-config-ibm-cloud-cognitive from root package.json

#### How did you test and verify your work?

Ran `yarn install`