### PR TITLE
Eliminate warnings in storybook

### DIFF
--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.mdx
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { DISPLAY_NAME } from '.';

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.mdx
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { APIKeyModal } from './APIKeyModal';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.mdx
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { AboutModal } from '.';

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.mdx
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { ButtonMenu } from '.';

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.mdx
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { CreateFullPage } from '.';

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.mdx
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.mdx
@@ -1,8 +1,8 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { CreateModal } from '.';
-import { ArgsTable } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from '@storybook/addon-docs';
 
 # CreateModal
 

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.mdx
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { CreateSidePanel } from '.';

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.mdx
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { CreateTearsheet } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { EmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { ErrorEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { NoDataEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { NoTagsEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { NotFoundEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { NotificationsEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../../settings';
 import { getStorybookSlug } from '../../../../config';
 import { UnauthorizedEmptyState } from '.';

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.mdx
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { ExampleComponent } from '.';

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.mdx
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { ExportModal } from '.';

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.mdx
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { ExpressiveCard } from '.';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -29,14 +29,14 @@ export default {
     columnSize: {
       control: {
         type: 'select',
-        options: [4, 8, 12, 16],
       },
+      options: [4, 8, 12, 16],
     },
     mediaRatio: {
       control: {
         type: 'select',
-        options: ['16x9', '9x16', '2x1', '1x2', '4x3', '3x4', '1x1'],
       },
+      options: ['16x9', '9x16', '2x1', '1x2', '4x3', '3x4', '1x1'],
     },
   },
   decorators: [

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -27,14 +27,12 @@ export default {
   },
   argTypes: {
     columnSize: {
-      defaultValue: 4,
       control: {
         type: 'select',
         options: [4, 8, 12, 16],
       },
     },
     mediaRatio: {
-      defaultValue: '1x1',
       control: {
         type: 'select',
         options: ['16x9', '9x16', '2x1', '1x2', '4x3', '3x4', '1x1'],
@@ -53,6 +51,8 @@ export default {
 const defaultProps = {
   label: 'Label',
   title: 'Title',
+  columnSize: 4,
+  mediaRatio: '1x1',
   children: (
     <p>
       expressive card body content block. description inviting the user to take

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.mdx
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 
 # HTTPError403
 

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.mdx
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 
 # HTTPError404
 

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.mdx
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 
 # HTTPErrorOther
 

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.mdx
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { ImportModal } from '.';

--- a/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.mdx
+++ b/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { LoadingBar } from '.';

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.mdx
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { NotificationsPanel } from '.';

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { PageHeader } from '.';

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.mdx
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { ProductiveCard } from '.';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -26,7 +26,6 @@ export default {
   },
   argTypes: {
     columnSize: {
-      defaultValue: 4,
       control: {
         type: 'select',
         options: [4, 8, 12, 16],
@@ -44,6 +43,7 @@ export default {
 
 const defaultProps = {
   title: 'Title',
+  columnSize: 4,
   children: (
     <>
       <div className="graph" />

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.mdx
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { RemoveModal } from '.';

--- a/packages/cloud-cognitive/src/components/Saving/Saving.mdx
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.mdx
@@ -1,6 +1,6 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { Saving } from '.';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';

--- a/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
@@ -26,7 +26,6 @@ export default {
   },
   argTypes: {
     successful: {
-      defaultValue: true,
       control: {
         type: 'boolean',
       },
@@ -39,6 +38,7 @@ const defaultProps = {
   defaultText: 'Save',
   failText: 'Failed to save',
   inProgressText: 'Saving...',
+  successful: true,
   successText: 'Saved',
 };
 

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.mdx
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { SidePanel } from '.';

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -49,16 +49,17 @@ export default {
     actions: {
       control: {
         type: 'select',
-        options: {
-          'One button': 0,
-          'One button (ghost)': 1,
-          'Two buttons': 2,
-          'Three buttons with ghost': 3,
-          'Three buttons': 4,
-          None: 5,
+        labels: {
+          0: 'One button',
+          1: 'One button (ghost)',
+          2: 'Two buttons',
+          3: 'Three buttons with ghost',
+          4: 'Three buttons',
+          5: 'None',
         },
         default: 0,
       },
+      options: [0, 1, 2, 3, 4],
     },
     slideIn: {
       table: {

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.mdx
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { StatusIcon } from '.';

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
@@ -39,14 +39,14 @@ export default {
     size: {
       control: {
         type: 'select',
-        options: ['sm', 'md', 'lg', 'xlg'],
       },
+      options: ['sm', 'md', 'lg', 'xlg'],
     },
     theme: {
       control: {
         type: 'radio',
-        options: ['light', 'dark'],
       },
+      options: ['light', 'dark'],
     },
   },
   parameters: {

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.mdx
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { TagSet } from '.';

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.mdx
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.mdx
@@ -1,4 +1,4 @@
-import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Story, Props, Source, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { Tearsheet, TearsheetNarrow } from '.';

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -70,6 +70,7 @@ export default {
         0: null,
         1: (
           <Dropdown
+            id="tss-had"
             label="Choose an option"
             items={['option 1', 'option 2', 'option 3', 'option 4']}
           />
@@ -114,9 +115,13 @@ const mainContent = (
   <div className="tearsheet-stories__dummy-content-block">
     <Form>
       <p>Main content</p>
-      <FormGroup>
-        <TextInput labelText="Enter an important value here" />
-        <TextInput light labelText="Here is a light entry field:" />
+      <FormGroup legendText="">
+        <TextInput id="tss-ft1" labelText="Enter an important value here" />
+        <TextInput
+          id="tss-ft2"
+          light
+          labelText="Here is a light entry field:"
+        />
       </FormGroup>
     </Form>
   </div>

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -69,8 +69,8 @@ const mainContent = (
   <div className="tearsheet-stories__narrow-content-block">
     <Form>
       <p>Main content</p>
-      <FormGroup>
-        <TextInput labelText="Enter an important value here" />
+      <FormGroup legendText="">
+        <TextInput id="tss-ft1" labelText="Enter an important value here" />
       </FormGroup>
     </Form>
   </div>

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.mdx
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.mdx
@@ -1,4 +1,4 @@
-import { Props, Preview, Story } from '@storybook/addon-docs/blocks';
+import { Props, Preview, Story } from '@storybook/addon-docs';
 
 ## User Profile Avatar
 

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
@@ -27,26 +27,26 @@ export default {
     backgroundColor: {
       control: {
         type: 'select',
-        options: ['light-cyan', 'dark-cyan'],
       },
+      options: ['light-cyan', 'dark-cyan'],
     },
     theme: {
       control: {
         type: 'select',
-        options: ['light', 'dark'],
       },
+      options: ['light', 'dark'],
     },
     kind: {
       control: {
         type: 'radio',
-        options: ['user', 'group'],
       },
+      options: ['user', 'group'],
     },
     size: {
       control: {
         type: 'radio',
-        options: ['xlg', 'lg', 'md'],
       },
+      options: ['xlg', 'lg', 'md'],
     },
   },
   parameters: {

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
@@ -1,4 +1,4 @@
-import { Story, ArgsTable, Preview } from '@storybook/addon-docs/blocks';
+import { Story, ArgsTable, Preview } from '@storybook/addon-docs';
 import { pkg } from '../../settings';
 import { getStorybookSlug } from '../../../config';
 import { WebTerminal } from '.';

--- a/packages/core/docs/getting-started.stories.mdx
+++ b/packages/core/docs/getting-started.stories.mdx
@@ -3,7 +3,7 @@
 This source code is licensed under the Apache-2.0 license found in the
 LICENSE file in the root directory of this source tree. -->
 
-import { Description, Meta } from '@storybook/addon-docs/blocks';
+import { Description, Meta } from '@storybook/addon-docs';
 
 import readme from '../../../README.md';
 


### PR DESCRIPTION
#### What did you change?

Fixed some missing props in tearsheet stories, eliminated imports from addon-docs/blocks, set default values in args sets instead of using deprecated `defaultValue` field, and set options directly on args.

#### How did you test and verify your work?

Ran storybook