### PR TITLE
Fix proptypes one-of-type for Card

### DIFF
--- a/packages/cloud-cognitive/src/components/Card/CardFooter.js
+++ b/packages/cloud-cognitive/src/components/Card/CardFooter.js
@@ -54,7 +54,7 @@ export let CardFooter = ({
 };
 
 CardFooter.propTypes = {
-  actions: PropTypes.oneOf(PropTypes.array, PropTypes.node),
+  actions: PropTypes.oneOfType([PropTypes.array, PropTypes.node]),
   hasActions: PropTypes.bool,
   hasButton: PropTypes.bool,
   onPrimaryButtonClick: PropTypes.func,


### PR DESCRIPTION
Card prop `action` has a prop-types declaration that looks wrong and generates warnings. I think what was meant might be `PropTypes.oneOfType([PropTypes.array, PropTypes.node])`. @davidmenendez fyi

#### What did you change?

prop-types declaration for Card prop `action`.

#### How did you test and verify your work?

Ran storybook.