### PR TITLE
feat: add closeIconDescription required prop to AboutModal

### DIFF
--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
@@ -41,6 +41,7 @@ export let AboutModal = React.forwardRef(
     {
       additionalInfo,
       className,
+      closeIconDescription,
       content,
       copyrightText,
       legalText,
@@ -71,6 +72,7 @@ export let AboutModal = React.forwardRef(
       <div className={`${blockClass}__logo`}>{logo}</div>
       <ModalHeader
         className={`${blockClass}__header`}
+        iconDescription={closeIconDescription}
         label={title}
         labelClassName={`${blockClass}__title`}
       />
@@ -149,6 +151,11 @@ AboutModal.propTypes = {
    * Provide an optional class to be applied to the modal root node.
    */
   className: PropTypes.string,
+
+  /**
+   * The accessibility title for the close icon.
+   */
+  closeIconDescription: PropTypes.string.isRequired,
 
   /**
    * A summary that appears immediately beneath the title, and might

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
@@ -144,9 +144,17 @@ const Template = (storyName, storyInitiallyOpen, props) => {
 Template.propTypes = AboutModal.propTypes;
 
 const commonArgs = {
+  closeIconDescription: 'Close',
   title: (
     <>
-      IBM <span style={{ fontWeight: '600' }}>Watson AI Ops</span>
+      IBM{' '}
+      <span
+        style={
+          // stylelint-disable-next-line carbon/type-token-use
+          { fontWeight: '600' }
+        }>
+        Watson AI Ops
+      </span>
     </>
   ),
   content: <>This is example content for an About Modal.</>,

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
@@ -52,6 +52,7 @@ const additionalInfo = [
   },
 ];
 const className = `class-${uuidv4()}`;
+const closeIconDescription = `close ${uuidv4()}`;
 const content = `This is example content: ${uuidv4()}`;
 const copyrightText = `Copyright test text ${uuidv4()}`;
 const dataTestId = uuidv4();
@@ -82,7 +83,9 @@ const versionNumber = `1.3.${uuidv4()}`;
 
 // render an AboutModal with content, logo, title, and any other required props
 const renderComponent = ({ ...rest }) =>
-  render(<AboutModal {...{ content, logo, title, ...rest }} />);
+  render(
+    <AboutModal {...{ closeIconDescription, content, logo, title, ...rest }} />
+  );
 
 describe(componentName, () => {
   it('renders a component AboutModal', () => {
@@ -96,14 +99,11 @@ describe(componentName, () => {
     await expect(container).toHaveNoAxeViolations();
   });
 
-  it('renders title and content', () => {
+  it('renders closeIconDescription, title, logo, and content', () => {
     renderComponent();
+    screen.getByRole('button', { name: closeIconDescription });
     screen.getByText(titleText);
     screen.getByText(content);
-  });
-
-  it('renders product logo', () => {
-    renderComponent();
     screen.getByAltText(logoAltText);
   });
 
@@ -157,7 +157,9 @@ describe(componentName, () => {
   it('calls onClose() when modal is closed', () => {
     renderComponent({ open: true, onClose: onCloseReturnsTrue });
     const aboutModal = screen.getByRole('presentation');
-    const closeButton = screen.getByRole('button', { name: 'Close' });
+    const closeButton = screen.getByRole('button', {
+      name: closeIconDescription,
+    });
     expect(aboutModal).toHaveClass('is-visible');
     expect(onCloseReturnsTrue).toHaveBeenCalledTimes(0);
     userEvent.click(closeButton);
@@ -168,7 +170,9 @@ describe(componentName, () => {
   it('allows veto when modal is closed', () => {
     renderComponent({ open: true, onClose: onCloseReturnsFalse });
     const aboutModal = screen.getByRole('presentation');
-    const closeButton = screen.getByRole('button', { name: 'Close' });
+    const closeButton = screen.getByRole('button', {
+      name: closeIconDescription,
+    });
     expect(aboutModal).toHaveClass('is-visible');
     expect(onCloseReturnsFalse).toHaveBeenCalledTimes(0);
     userEvent.click(closeButton);


### PR DESCRIPTION
closes #663 

Add a `closeIconDescription` prop to AboutModal and make it required, to ensure users provide all translatable text.

#### What did you change?

AboutModal, tests and stories.

#### How did you test and verify your work?

Ran storybook.
