### PR TITLE
fix(SidePanel): allow animation to complete when scroll length is short

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -149,9 +149,28 @@ export let SidePanel = React.forwardRef(
         const sidePanelSubtitleElement = document.querySelector(
           `.${`${blockClass}__subtitle-text`}`
         );
-        const sidePanelSubtitleElementHeight = sidePanelSubtitleElement
-          ? sidePanelSubtitleElement.offsetHeight
-          : 52; // set default subtitle height if a subtitle is not provided to enable scrolling animation
+        let sidePanelSubtitleElementHeight =
+          sidePanelSubtitleElement?.offsetHeight || 0; // set default subtitle height if a subtitle is not provided to enable scrolling animation
+
+        const panelOuterHeight = sidePanelOuter?.offsetHeight;
+        const scrollSectionHeight = document.querySelector(
+          `.${blockClass}__body-content`
+        )?.offsetHeight;
+        const titleHeight = document.querySelector(
+          `.${blockClass}__title-container`
+        )?.offsetHeight;
+        const totalScrollingContentHeight =
+          titleHeight + sidePanelSubtitleElementHeight + scrollSectionHeight;
+        // if the difference between the total scrolling height and the panel height is less than
+        // the subtitleElement height OR if the subtitle element height is 0, use that difference
+        // as the length of the scroll animation (otherwise the animation will not be able to complete
+        // because there is not enough scrolling distance to complete it).
+        sidePanelSubtitleElementHeight =
+          totalScrollingContentHeight - panelOuterHeight <
+            sidePanelSubtitleElementHeight ||
+          sidePanelSubtitleElementHeight === 0
+            ? totalScrollingContentHeight - panelOuterHeight
+            : sidePanelSubtitleElementHeight;
         /* istanbul ignore next */
         sidePanelOuter &&
           sidePanelOuter.addEventListener('scroll', () => {
@@ -263,9 +282,8 @@ export let SidePanel = React.forwardRef(
         const sidePanelSubtitleElement = document.querySelector(
           `.${blockClass}__subtitle-text`
         );
-        const sidePanelSubtitleElementHeight = sidePanelSubtitleElement
-          ? sidePanelSubtitleElement.offsetHeight
-          : 0;
+        const sidePanelSubtitleElementHeight =
+          sidePanelSubtitleElement?.offsetHeight || 0;
         const titleHeight = sidePanelTitleElement?.offsetHeight + 24;
         sidePanelOuter?.style.setProperty(
           `--${blockClass}--title-container-height`,

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -46,24 +46,32 @@ const SlideIn = ({
   animateTitle = true,
   actionToolbarButtons,
   selectorPageContent = pageContentSelectorValue,
-}) => (
-  <div>
-    <SidePanel
-      actionToolbarButtons={actionToolbarButtons}
-      title={title}
-      subtitle={subtitle}
-      animateTitle={animateTitle}
-      open={open}
-      onRequestClose={onRequestCloseFn}
-      slideIn
-      selectorPageContent={selectorPageContent}
-      placement={placement}
-      onUnmount={onUnmountFn}>
-      Content
-    </SidePanel>
-    <div id={pageContentSelectorValue.slice(1)} />
-  </div>
-);
+  usePageContentSelector = false,
+}) => {
+  return (
+    <div>
+      <SidePanel
+        actionToolbarButtons={actionToolbarButtons}
+        title={title}
+        subtitle={subtitle}
+        animateTitle={animateTitle}
+        open={open}
+        onRequestClose={onRequestCloseFn}
+        slideIn
+        selectorPageContent={
+          usePageContentSelector ? null : selectorPageContent
+        }
+        pageContentSelector={
+          usePageContentSelector ? selectorPageContent : null
+        }
+        placement={placement}
+        onUnmount={onUnmountFn}>
+        Content
+      </SidePanel>
+      <div id={pageContentSelectorValue.slice(1)} />
+    </div>
+  );
+};
 
 describe('SidePanel', () => {
   const { ResizeObserver } = window;
@@ -462,17 +470,20 @@ describe('SidePanel', () => {
   });
 
   it('should throw a custom prop type error when pageContentSelector is missing', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const warningSpy = jest.spyOn(console, 'warn').mockImplementation();
     try {
       render(
-        <SlideIn placement="left" open={false} selectorPageContent={null}>
+        <SlideIn placement="left" open={false} usePageContentSelector>
           Content
         </SlideIn>
       );
     } catch (e) {
-      expect(spy).toBeCalled();
+      expect(errorSpy).toBeCalled();
+      expect(warningSpy).toBeCalled();
     } finally {
-      spy.mockRestore();
+      errorSpy.mockRestore();
+      warningSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
Contributes to #849 

Addresses issue in side panel title animation where if the amount of scrollable area is smaller than the length of the scrolling animation, the animation would not complete (you could potentially see the initial title and collapsed title at the same time). With this change, the length of the scroll animation is shortened to avoid this issue.

_To see this bug see the second screen recording [here](https://ibm-casdesign.slack.com/archives/CQGR0HC05/p1624050878118800)_

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook and ran tests