### PR TITLE
Set correct widths for narrow tearsheets

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1817,7 +1817,6 @@ path:nth-of-type(1),
 
 .exp--tearsheet .exp--tearsheet__container {
   top: auto;
-  width: 100%;
   height: 100%;
   max-height: calc(100% - var(--cds-spacing-09, 3rem));
   transform: translate3d(0, min(95vh, 500px), 0);
@@ -1850,6 +1849,10 @@ path:nth-of-type(1),
 .exp--tearsheet.exp--tearsheet--stacked-3-of-3
 .exp--tearsheet__container--lower {
   max-height: calc( 100% - (var(--cds-spacing-09, 3rem) + var(--cds-spacing-08, 2.5rem) + (2 * var(--cds-spacing-05, 1rem))));
+}
+
+.exp--tearsheet.exp--tearsheet--wide .exp--tearsheet__container {
+  width: 100%;
 }
 
 @media (min-width: 66rem) {

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -116,11 +116,22 @@ const mainContent = (
     <Form>
       <p>Main content</p>
       <FormGroup legendText="">
-        <TextInput id="tss-ft1" labelText="Enter an important value here" />
+        <TextInput
+          id="tss-ft1"
+          labelText="Enter an important value here"
+          style={
+            // stylelint-disable-next-line carbon/layout-token-use
+            { marginBottom: '1em' }
+          }
+        />
         <TextInput
           id="tss-ft2"
           light
           labelText="Here is a light entry field:"
+          style={
+            // stylelint-disable-next-line carbon/layout-token-use
+            { marginBottom: '1em' }
+          }
         />
       </FormGroup>
     </Form>

--- a/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_storybook-styles.scss
@@ -8,18 +8,10 @@
 @import '../../global/styles/carbon-settings';
 
 .tearsheet-stories__dummy-content-block {
-  display: flex;
-  height: 100%;
-  align-items: top;
-  justify-content: flex-start;
   padding: $layout-02 $layout-03;
 }
 
 .tearsheet-stories__narrow-content-block {
-  display: flex;
-  height: 100%;
-  align-items: top;
-  justify-content: flex-start;
   padding: $layout-01;
 }
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -67,7 +67,6 @@
 
   .#{$block-class} .#{$block-class}__container {
     top: auto;
-    width: 100%;
     height: 100%;
     max-height: calc(100% - #{$spacing-09});
     // we want the enter/leave animation to run up most of the height of the
@@ -107,6 +106,10 @@
     max-height: calc(
       100% - (#{$spacing-09} + #{$spacing-08} + (2 * #{$spacing-05}))
     );
+  }
+
+  .#{$block-class}.#{$block-class}--wide .#{$block-class}__container {
+    width: 100%;
   }
 
   @include carbon--breakpoint(lg) {


### PR DESCRIPTION
closes #977

The default 100% width was being applied to all tearsheets, and should only have applied to wide tearsheets. Fixed this, and also tidied up a couple of story oddities.

#### What did you change?

Tearsheet styles and stories.

#### How did you test and verify your work?

Ran tests and storybook