### PR TITLE
chore(CreateTearsheet): add divider line render logic

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -460,37 +460,35 @@ export let CreateTearsheet = forwardRef(
             if (!isTearsheetSection(child)) {
               return child;
             }
-            if (isTearsheetSection(child)) {
-              // Needed to be able to not render the divider
-              // line on the last section of the last step
-              const isLastSectionOfLastStep =
-                isLastTearsheetStep &&
-                tearsheetStepComponents.length - 1 === index;
-              return React.cloneElement(
-                child,
-                {
-                  className: cx(child.props.className, {
-                    [`${blockClass}__step--hidden-section`]:
-                      child.props.viewAllOnly && !shouldViewAll,
-                    [`${blockClass}__step--visible-section`]:
-                      !child.props.viewAllOnly ||
-                      (child.props.viewAllOnly && shouldViewAll),
-                  }),
-                  key: `key_${index}`,
-                },
-                <>
-                  {shouldViewAll && (
-                    <h4 className={`${blockClass}__step--heading`}>
-                      {child.props.title}
-                    </h4>
-                  )}
-                  {child}
-                  {shouldViewAll && !isLastSectionOfLastStep && (
-                    <span className={`${blockClass}__section--divider`} />
-                  )}
-                </>
-              );
-            }
+            // Needed to be able to not render the divider
+            // line on the last section of the last step
+            const isLastSectionOfLastStep =
+              isLastTearsheetStep &&
+              tearsheetStepComponents.length - 1 === index;
+            return React.cloneElement(
+              child,
+              {
+                className: cx(child.props.className, {
+                  [`${blockClass}__step--hidden-section`]:
+                    child.props.viewAllOnly && !shouldViewAll,
+                  [`${blockClass}__step--visible-section`]:
+                    !child.props.viewAllOnly ||
+                    (child.props.viewAllOnly && shouldViewAll),
+                }),
+                key: `key_${index}`,
+              },
+              <>
+                {shouldViewAll && (
+                  <h4 className={`${blockClass}__step--heading`}>
+                    {child.props.title}
+                  </h4>
+                )}
+                {child}
+                {shouldViewAll && !isLastSectionOfLastStep && (
+                  <span className={`${blockClass}__section--divider`} />
+                )}
+              </>
+            );
           })}
         </>
       );

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -405,7 +405,7 @@ export let CreateTearsheet = forwardRef(
         ? childrenElements
         : [childrenElements];
       const indexOfLastTearsheetStep = childrenArray
-        .map((el) => el.props.type)
+        .map((el) => el?.props?.type)
         .lastIndexOf(CREATE_TEARSHEET_STEP);
       return (
         <>

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -398,12 +398,15 @@ export let CreateTearsheet = forwardRef(
       );
     };
 
-    // renders all children (CreateTearsheetSteps and regular children elements)
+    // renders all children (CreateTearsheetSteps and regular child elements)
     const renderChildren = (childrenElements) => {
       let step = 0;
       const childrenArray = Array.isArray(childrenElements)
         ? childrenElements
         : [childrenElements];
+      const indexOfLastTearsheetStep = childrenArray
+        .map((el) => el.props.type)
+        .lastIndexOf(CREATE_TEARSHEET_STEP);
       return (
         <>
           {' '}
@@ -433,7 +436,10 @@ export let CreateTearsheet = forwardRef(
                     {renderStepTitle(stepIndex)}
                   </h4>
                 )}
-                {renderStepChildren(child.props.children)}
+                {renderStepChildren(
+                  child.props.children,
+                  indexOfLastTearsheetStep === step - 1
+                )}
               </>
             );
           })}
@@ -441,40 +447,50 @@ export let CreateTearsheet = forwardRef(
       );
     };
 
-    const renderStepChildren = (stepChildren) => {
-      const childrenArray = Array.isArray(stepChildren)
-        ? stepChildren
-        : [stepChildren];
+    const renderStepChildren = (
+      tearsheetStepComponent,
+      isLastTearsheetStep
+    ) => {
+      const tearsheetStepComponents = Array.isArray(tearsheetStepComponent)
+        ? tearsheetStepComponent
+        : [tearsheetStepComponent];
       return (
         <>
-          {childrenArray.map((child, index) => {
+          {tearsheetStepComponents.map((child, index) => {
             if (!isTearsheetSection(child)) {
               return child;
             }
-            return React.cloneElement(
-              child,
-              {
-                className: cx(child.props.className, {
-                  [`${blockClass}__step--hidden-section`]:
-                    child.props.viewAllOnly && !shouldViewAll,
-                  [`${blockClass}__step--visible-section`]:
-                    !child.props.viewAllOnly ||
-                    (child.props.viewAllOnly && shouldViewAll),
-                }),
-                key: `key_${index}`,
-              },
-              <>
-                {shouldViewAll && (
-                  <h4 className={`${blockClass}__step--heading`}>
-                    {child.props.title}
-                  </h4>
-                )}
-                {child}
-                {shouldViewAll && (
-                  <span className={`${blockClass}__section--divider`} />
-                )}
-              </>
-            );
+            if (isTearsheetSection(child)) {
+              // Needed to be able to not render the divider
+              // line on the last section of the last step
+              const isLastSectionOfLastStep =
+                isLastTearsheetStep &&
+                tearsheetStepComponents.length - 1 === index;
+              return React.cloneElement(
+                child,
+                {
+                  className: cx(child.props.className, {
+                    [`${blockClass}__step--hidden-section`]:
+                      child.props.viewAllOnly && !shouldViewAll,
+                    [`${blockClass}__step--visible-section`]:
+                      !child.props.viewAllOnly ||
+                      (child.props.viewAllOnly && shouldViewAll),
+                  }),
+                  key: `key_${index}`,
+                },
+                <>
+                  {shouldViewAll && (
+                    <h4 className={`${blockClass}__step--heading`}>
+                      {child.props.title}
+                    </h4>
+                  )}
+                  {child}
+                  {shouldViewAll && !isLastSectionOfLastStep && (
+                    <span className={`${blockClass}__section--divider`} />
+                  )}
+                </>
+              );
+            }
           })}
         </>
       );


### PR DESCRIPTION
Contributes to #991 

Adds logic to prevent the bottom divider line between CreateTearsheetSection components from rendering on the last section of the last step component. See screenshot in #991 

#### What did you change?
`CreateTearsheet.js`
#### How did you test and verify your work?
Storybook