### PR TITLE
Enable react strict mode in storybook

### DIFF
--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -24,6 +24,11 @@ module.exports = {
     '@carbon/storybook-addon-theme/register',
   ],
 
+  reactOptions: {
+    //fastRefresh: true, -- this option would be nice, but seems to cause errors, see https://github.com/storybookjs/storybook/issues/13745
+    strictMode: true,
+  },
+
   stories: sync(resolve(__dirname, '..', '..', '**/*.stories.*')).filter(
     (story) =>
       !story.includes('node_modules') && !story.includes('DISPLAY_NAME')


### PR DESCRIPTION
Contributes to #1004

This will enable us to use storybook to check for react strict mode warnings and deprecations.

#### What did you change?

storybook main.js

#### How did you test and verify your work?

Ran storybook, selected SidePanel story, opened the side panel, and verified the following warning now appears in the console:
![image](https://user-images.githubusercontent.com/6385315/125713178-4fc40fae-e1da-415d-b4dd-8b7c48562cb4.png)

