### PR TITLE
switch ResizeDetector in ButtonSetWithOverflow to hook pattern

### DIFF
--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -83,7 +83,7 @@ export const ButtonSetWithOverflow = ({
       <ButtonSet {...rest} ref={ref}>
         {buttons.map(({ label, key, kind, ...other }) => (
           <Button
-            key={`button-set-${key}`}
+            key={key && `button-set-${key}`}
             kind={kind || 'primary'}
             {...other}
             size={buttonSize}
@@ -100,7 +100,7 @@ export const ButtonSetWithOverflow = ({
         {buttons
           .map(({ label, key, kind, ...other }) => (
             <ButtonMenuItem
-              key={`button-menu-${key}`}
+              key={key && `button-menu-${key}`}
               isDelete={kind?.startsWith('danger')}
               itemText={label}
               {...prepareProps(other, ['iconDescription', 'renderIcon'])}

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -124,6 +124,7 @@ export const ButtonSetWithOverflow = ({
   useResizeDetector({
     onResize: checkFullyVisibleItems,
     targetRef: spaceAvailableRef,
+    handleWidth: true,
   });
 
   return (

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -9,7 +9,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import cx from 'classnames';
-import ReactResizeDetector from 'react-resize-detector';
+import { useResizeDetector } from 'react-resize-detector';
 import { ButtonSet, Button } from 'carbon-components-react';
 import { ButtonMenu, ButtonMenuItem } from '../ButtonMenu';
 
@@ -78,20 +78,6 @@ export const ButtonSetWithOverflow = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buttons]);
 
-  /* istanbul ignore next */ // not sure how to test resize
-  const handleResize = () => {
-    // width is the space available for all action bar items horizontally
-    // the action bar items are squares so the height should be one item wide
-    /* istanbul ignore next */ // not sure how to test resize
-    checkFullyVisibleItems();
-  };
-
-  /* istanbul ignore next */ // not sure how to test resize
-  const handleButtonResize = () => {
-    /* istanbul ignore next */ // not sure how to test resize
-    checkFullyVisibleItems();
-  };
-
   const AButtonSet = React.forwardRef(({ buttons, ...rest }, ref) => {
     return (
       <ButtonSet {...rest} ref={ref}>
@@ -125,53 +111,61 @@ export const ButtonSetWithOverflow = ({
     );
   });
 
-  return (
-    <ReactResizeDetector handleWidth={true} onResize={handleResize}>
-      <div
-        className={cx([
-          blockClass,
-          className,
-          { [`${blockClass}--right`]: rightAlign },
-        ])}
-        ref={spaceAvailableRef}>
-        <ReactResizeDetector onResize={handleButtonResize}>
-          {/* Hidden button set use to determine if space is available for a button set */}
-          <div
-            className={`${blockClass}__button-container ${blockClass}__button-container--hidden`}>
-            <AButtonSet
-              aria-hidden={true}
-              ref={sizingContainerRefSet}
-              size={buttonSize}
-              buttons={buttons}
-            />
-          </div>
-        </ReactResizeDetector>
-        <ReactResizeDetector onResize={handleButtonResize}>
-          {/* Hidden ButtonMenu used to report min size to host via onWidthChange
-           */}
-          <div
-            className={`${blockClass}__button-container ${blockClass}__button-container--hidden`}
-            aria-hidden={true}>
-            <AButtonMenu
-              ref={sizingContainerRefCombo}
-              buttons={buttons}
-              size={buttonSize}
-            />
-          </div>
-        </ReactResizeDetector>
+  useResizeDetector({
+    onResize: checkFullyVisibleItems,
+    targetRef: sizingContainerRefSet,
+  });
 
-        {/* The displayed components */}
-        {showAsOverflow ? (
-          <AButtonMenu buttons={buttons} size={buttonSize} />
-        ) : (
-          <AButtonSet
-            className={`${blockClass}__button-container`}
-            size={buttonSize}
-            buttons={buttons}
-          />
-        )}
+  useResizeDetector({
+    onResize: checkFullyVisibleItems,
+    targetRef: sizingContainerRefCombo,
+  });
+
+  useResizeDetector({
+    onResize: checkFullyVisibleItems,
+    targetRef: spaceAvailableRef,
+  });
+
+  return (
+    <div
+      className={cx([
+        blockClass,
+        className,
+        { [`${blockClass}--right`]: rightAlign },
+      ])}
+      ref={spaceAvailableRef}>
+      {/* Hidden button set used to determine if space is available for a button set */}
+      <div
+        className={`${blockClass}__button-container ${blockClass}__button-container--hidden`}>
+        <AButtonSet
+          aria-hidden={true}
+          ref={sizingContainerRefSet}
+          size={buttonSize}
+          buttons={buttons}
+        />
       </div>
-    </ReactResizeDetector>
+      {/* Hidden ButtonMenu used to report min size to host via onWidthChange */}
+      <div
+        className={`${blockClass}__button-container ${blockClass}__button-container--hidden`}
+        aria-hidden={true}>
+        <AButtonMenu
+          ref={sizingContainerRefCombo}
+          buttons={buttons}
+          size={buttonSize}
+        />
+      </div>
+
+      {/* The displayed components */}
+      {showAsOverflow ? (
+        <AButtonMenu buttons={buttons} size={buttonSize} />
+      ) : (
+        <AButtonSet
+          className={`${blockClass}__button-container`}
+          size={buttonSize}
+          buttons={buttons}
+        />
+      )}
+    </div>
   );
 };
 

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
@@ -34,16 +34,19 @@ export default {
 
 const buttons = [
   {
+    key: 'danger-button',
     kind: 'danger',
     onClick: action('Danger'),
     label: 'Danger',
   },
   {
+    key: 'secondary-button',
     kind: 'secondary',
     onClick: action('Secondary'),
     label: 'Secondary',
   },
   {
+    key: 'primary-button',
     kind: 'primary',
     onClick: action('Primary'),
     label: 'Primary',


### PR DESCRIPTION
The hook pattern (`useResizeDetector`) is lighter weight than the full class object pattern (`<ResizeDetector>`) and fits better with our general hook-based component approach.

@lee-chase please check that this still works as intended

Also, the ButtonSetWithOverflow stories were not supplied the now-required `key` field, generating stacks of console errors, so I fixed that and also improved the way omitted `key` prop is handled by the component.

#### What did you change?

ButtonSetWithOverflow and stories

#### How did you test and verify your work?

Storybook