### PR TITLE
chore(CreateTearsheetNarrow): refactor shared classname usage

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
@@ -60,6 +60,9 @@ export let CreateTearsheetNarrow = React.forwardRef(
         kind: 'secondary',
       },
     ];
+
+    const formTextClass = `${blockClass}__content-text`;
+
     return (
       <TearsheetNarrow
         {
@@ -77,12 +80,11 @@ export let CreateTearsheetNarrow = React.forwardRef(
         selectorPrimaryFocus={selectorPrimaryFocus}
         verticalPosition={verticalPosition}
         role="presentation">
-        <h3
-          className={`${blockClass}__form-title-text ${blockClass}__content-text`}>
+        <h3 className={cx(`${blockClass}__form-title-text`, formTextClass)}>
           {formTitle}
         </h3>
         <p
-          className={`${blockClass}__form-description-text ${blockClass}__content-text`}>
+          className={cx(`${blockClass}__form-description-text`, formTextClass)}>
           {formDescription}
         </p>
         <Form className={`${blockClass}__form`}>{children}</Form>


### PR DESCRIPTION
Contributes to #1000 review comment from @davidmenendez 

Move shared className into it's own variable and use cx package on the elements that use the shared classname.

#### What did you change?
`CreateTearsheetNarrow.js`
#### How did you test and verify your work?
Storybook