### PR TITLE
fix(about-modal): align copyright and legal text color with design

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -59,7 +59,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--about-modal .exp--about-modal__copyright-text {
   margin-top: var(--cds-spacing-07, 2rem);
   margin-bottom: 0;
-  color: var(--cds-text-03, #a8a8a8);
+  color: var(--cds-text-02, #525252);
 }
 
 .exp--about-modal .exp--about-modal__copyright-text {

--- a/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
+++ b/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
@@ -80,7 +80,7 @@
   .#{$block-class} .#{$block-class}__copyright-text {
     margin-top: $spacing-07;
     margin-bottom: 0;
-    color: $text-03;
+    color: $text-02;
   }
 
   .#{$block-class} .#{$block-class}__copyright-text {


### PR DESCRIPTION
#### Affected issue

Resolves #1035 

#### Proposed change

Align `AboutModal` copyright and legal text color with [design](https://pages.github.ibm.com/cdai-design/pal/patterns/about-modal/usage/#anatomy).
