### PR TITLE
Add spellcheck to commit-lint and ci-check

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -60,7 +60,8 @@
     "security",
     "*.snap",
     "storybook-static",
-    "yarn-error.log"
+    "yarn-error.log",
+    "CHANGELOG.md"
   ],
   "words": [
     "apikey",
@@ -86,6 +87,6 @@
     "tabbable",
     "tearsheet",
     "tearsheets",
-    "uuidv",
+    "uuidv"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,16 +25,20 @@
     "clean:files": "rimraf coverage node_modules results",
     "copy-common-files": "sh ./scripts/copy-common-files.sh",
     "format": "run-s 'lint:es --fix' format:prettier",
-    "format:prettier": "prettier '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd,coverage}/**' '!README.md' --write",
+    "format:prettier": "yarn format:prettier:files '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd,coverage}/**' '!README.md'",
+    "format:prettier:files": "prettier --write",
     "generate": "lerna run generate --loglevel success --scope \"@carbon/ibm-cloud-cognitive\" --",
-    "lint": "run-p lint:*",
-    "lint:es": "eslint 'packages/*/src/**/*.js'",
-    "lint:style": "stylelint 'packages/*/src/**/*.scss' --report-needless-disables --report-invalid-scope-disables",
+    "lint": "run-p lint:* spellcheck",
+    "lint:es": "yarn lint:es:files 'packages/*/src/**/*.js'",
+    "lint:es:files": "eslint",
+    "lint:style": "yarn lint:style:files 'packages/*/src/**/*.scss'",
+    "lint:style:files": "stylelint --report-needless-disables --report-invalid-scope-disables",
     "run-all": "lerna run --stream --prefix --loglevel success",
     "test": "run-s test:all 'test:jest {@}' --",
     "test:all": "yarn run-all --no-sort test",
     "test:jest": "jest",
-    "spellcheck": "cspell lint --relative --no-progress --show-context '**/*'",
+    "spellcheck": "yarn spellcheck:files '**/*'",
+    "spellcheck:files": "cspell lint --relative --no-progress --show-context --no-must-find-files",
     "storybook": "run-s storybook:build:dependencies storybook:start",
     "storybook:build": "run-s storybook:build:*",
     "storybook:build:dependencies": "yarn run-all --include-dependencies --scope \"@carbon/storybook-addon-theme\" --scope \"@carbon/ibm-cloud-cognitive\" build",
@@ -130,8 +134,9 @@
     }
   },
   "lint-staged": {
-    "**/*.{js,md,mdx,scss}": "yarn format:prettier",
-    "**/*.js": "yarn lint:es",
-    "**/*.scss": "yarn lint:style"
+    "**/*.{js,md,mdx,scss}": "yarn format:prettier:files",
+    "**/*.js": "yarn lint:es:files",
+    "**/*.scss": "yarn lint:style:files",
+    "**/*": "yarn spellcheck:files"
   }
 }

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -55,8 +55,8 @@ const defaultProps = {
       key, you will have to reset it.
     </p>
   ),
-  createSuccessTitle: 'API key successully created',
-  editSuccessTitle: 'API key successully saved',
+  createSuccessTitle: 'API key successfully created',
+  editSuccessTitle: 'API key successfully saved',
   loadingMessage: 'Generating...',
 };
 
@@ -342,7 +342,7 @@ Create.args = {
   createTitle: 'Generate an API key',
   body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
   nameHelperText:
-    'Providing the application name will help you idenfity your API key later.',
+    'Providing the application name will help you identify your API key later.',
   nameLabel: 'Name your application',
   namePlaceholder: 'Application name',
   nameRequired: true,
@@ -357,7 +357,7 @@ CreateWithError.args = {
   createTitle: 'Generate an API key',
   body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
   nameHelperText:
-    'Providing the application name will help you idenfity your API key later.',
+    'Providing the application name will help you identify your API key later.',
   nameLabel: 'Name your application',
   namePlaceholder: 'Application name',
   nameRequired: true,
@@ -376,7 +376,7 @@ export const CustomCreate = MultiStepTemplate.bind({});
 CustomCreate.args = {
   ...defaultProps,
   createButtonText: 'Generate',
-  modalLabel: 'Genreate API key',
+  modalLabel: 'Generate API key',
   nextStepButtonText: 'Next',
   previousStepButtonText: 'Previous',
   downloadFileName: 'apikey',
@@ -395,7 +395,7 @@ Edit.args = {
   createTitle: 'Save an API key',
   body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
   nameHelperText:
-    'Providing the application name will help you idenfity your API key later.',
+    'Providing the application name will help you identify your API key later.',
   nameLabel: 'Name your application',
   namePlaceholder: 'Application name',
   nameRequired: true,
@@ -413,7 +413,7 @@ EditWithError.args = {
   createTitle: 'Save an API key',
   body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
   nameHelperText:
-    'Providing the application name will help you idenfity your API key later.',
+    'Providing the application name will help you identify your API key later.',
   nameLabel: 'Name your application',
   namePlaceholder: 'Application name',
   nameRequired: true,
@@ -431,7 +431,7 @@ export const CustomEdit = MultiStepTemplate.bind({});
 CustomEdit.args = {
   ...defaultProps,
   createButtonText: 'Generate',
-  modalLabel: 'Genreate API key',
+  modalLabel: 'Generate API key',
   nextStepButtonText: 'Next',
   previousStepButtonText: 'Previous',
   downloadFileName: 'apikey',

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
@@ -36,7 +36,7 @@ const defaultProps = {
   editSuccessTitle: 'edited successfully',
   editing: false,
   error: false,
-  errorMessage: 'an error occured',
+  errorMessage: 'an error occurred',
   hasDownloadLink: true,
   loading: false,
   loadingMessage: 'loading',
@@ -91,9 +91,9 @@ describe(name, () => {
     const nameInput = container.querySelector('.bx--text-input');
     const createButton = getByText(props.createButtonText);
 
-    change(nameInput, { target: { value: 'testkey' } });
+    change(nameInput, { target: { value: 'test-key' } });
     click(createButton);
-    expect(onRequestSubmit).toHaveBeenCalledWith('testkey');
+    expect(onRequestSubmit).toHaveBeenCalledWith('test-key');
 
     rerender(<APIKeyModal {...props} loading />);
     expect(getByText(props.loadingMessage)).toBeVisible();
@@ -113,7 +113,7 @@ describe(name, () => {
     const props = {
       ...defaultProps,
       onRequestSubmit,
-      errorMessage: 'an error occured',
+      errorMessage: 'an error occurred',
       apiKey: '',
     };
 
@@ -124,7 +124,7 @@ describe(name, () => {
     const nameInput = container.querySelector('.bx--text-input');
     const createButton = getByText(props.createButtonText);
 
-    change(nameInput, { target: { value: 'testkey' } });
+    change(nameInput, { target: { value: 'test-key' } });
     click(createButton);
     expect(onRequestSubmit).toHaveBeenCalled();
 

--- a/packages/cloud-cognitive/src/components/Card/Card.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.js
@@ -128,7 +128,7 @@ export let Card = forwardRef(
       return cardProps;
     };
 
-    // the only reason this is necessary is for clickzone 2
+    // the only reason this is necessary is for click zone 2
     const getHeaderBodyProps = () => {
       const clickable = hasClickEvent && clickZone === 'two';
       const headerBodyProps = {

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
@@ -42,7 +42,7 @@ export default {
   },
 };
 
-const createTearsheetNarrowBlockclass = `${pkg.prefix}--create-tearsheet-narrow--story`;
+const createTearsheetNarrowBlockClass = `${pkg.prefix}--create-tearsheet-narrow--story`;
 
 const defaultStoryProps = {
   title: 'Create partition',
@@ -117,7 +117,7 @@ const Template = (args) => {
             setMinimumInSyncReplicaCount(event.imaginaryTarget.value)
           }
         />
-        <div className={`${createTearsheetNarrowBlockclass}__flex-container`}>
+        <div className={`${createTearsheetNarrowBlockClass}__flex-container`}>
           <NumberInput
             id="retention-time"
             min={1}


### PR DESCRIPTION
Add spellcheck to commit-lint and ci-check so spelling is checked before repo is updated.

Excluded CHANGELOG.md files from the spellcheck, as these are auto-updated from PR names and so may inadvertently contain spelling/grammar errors that are not the fault of subsequent submitters. Care with forming good PR names is still important, but is not enforced through the spellcheck!

Fixed a few remaining spelling issues to ensure the repo is currently clean.

Also, discovered that the commit-lint was taking a lot longer than it needed to: the lint tasks were in several cases linting the entire project folder rather than the staged files. This also meant that if errors existed in files that were not currently added for commit, the commit could still fail, wrongly, because of linter errors in those files that are not part of the commit. Updated the package.json tasks to ensure that each lint/prettier/spellcheck task has a file-specific form that the commit-lint can call to ensure optimal calling. This speeds up the commit-lint quite noticeably.

#### What did you change?

A few files for spelling fixes, cspell.json to exclude the change logs, and package.json to revise the scripts.

#### How did you test and verify your work?

Ran tests and storybook. And committed the changes. And submitted a PR.