### PR TITLE
chore(EmptyState): use prop type util for conditional props

### DIFF
--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
 import { pkg } from '../../settings';
-import { allPropTypes } from '../../global/js/utils/props-helper';
+import '../../global/js/utils/props-helper';
 import { EmptyStateContent } from './EmptyStateContent';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -72,16 +72,6 @@ export let EmptyState = React.forwardRef(
 // Return a placeholder if not released and not enabled by feature flag
 EmptyState = pkg.checkComponentEnabled(EmptyState, componentName);
 
-EmptyState.validateIllustrationDescription =
-  () =>
-  ({ illustration, illustrationDescription }) => {
-    if (illustration && !illustrationDescription) {
-      throw new Error(
-        `${componentName}: illustrationDescription is missing, this is required when using the illustration prop`
-      );
-    }
-  };
-
 export const EmptyStateDefaultProps = {
   size: 'lg',
 };
@@ -112,10 +102,9 @@ EmptyState.propTypes = {
   /**
    * The alt text for custom provided illustrations
    */
-  illustrationDescription: allPropTypes([
-    EmptyState.validateIllustrationDescription(),
-    PropTypes.string,
-  ]),
+  illustrationDescription: PropTypes.string.isRequired.if(
+    ({ illustration }) => illustration
+  ),
 
   /**
    * Empty state link object


### PR DESCRIPTION
Contributes to #1043 

Adds the new prop type util for conditionally required props.

#### What did you change?
`EmptyState.js`
#### How did you test and verify your work?
Storybook