### PR TITLE
build(cspell): ignore `.yarn` directory

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,11 +1,7 @@
 {
   "version": "0.1",
   "language": "en",
-  "dictionaries": [
-    "contributors",
-    "html",
-    "packages"
-  ],
+  "dictionaries": ["contributors", "html", "packages"],
   "dictionaryDefinitions": [
     { "name": "contributors", "path": "./cspell.contributors.txt" },
     { "name": "html", "path": "./cspell.html.txt" },
@@ -48,6 +44,7 @@
     "mdx"
   ],
   "ignorePaths": [
+    ".yarn",
     "cdai",
     "coverage",
     "css",


### PR DESCRIPTION
`cspell` is parsing files from Yarn's offline mirror — this change proposes to ignore the  `.yarn` directory from its configuration (in addition to my muscle memory accidentally formatting the configuration file):

<img width="1016" alt="cspell" src="https://user-images.githubusercontent.com/3846874/126618135-153d764e-318e-46da-a80e-2876d0c0f918.png">
