### PR TITLE
Add .github folder to spellcheck and exclude hidden files

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -5,7 +5,7 @@ components. They are intended to be supportive rather than restrictive, and need
 to stay up-to-date, so do raise a question if anything needs changing or is
 unclear.
 
-## Organisation and files
+## Organization and files
 
 - Each component, or group of closely related components, is in its own
   directory which will normally contain the following files:
@@ -40,7 +40,7 @@ unclear.
     helper within the package, it should NOT be exported from the index.js,
     should NOT be included in \_index.scss, and should NOT have a flag in the
     package-settings.js. Instead, the JS should be imported, and the SCSS
-    included, whereever the component is needed internally.
+    included, wherever the component is needed internally.
 
 ## Component JavaScript code
 
@@ -255,7 +255,7 @@ unclear.
     });
     ```
   - A test for each input (props, slots, _etc_), verifying appropriate outputs.
-  - A test to validate each the behaviours and actions as far as is practical.
+  - A test to validate each the behaviors and actions as far as is practical.
   - A test that additional HTML attributes are passed through to an appropriate
     node. Something like:
     ```jsx

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -15,7 +15,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and
-expression, level of experience, education, socio-economic status, nationality,
+expression, level of experience, education, socioeconomic status, nationality,
 personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/.github/VARIANT_COMPONENT_GUIDELINES.md
+++ b/.github/VARIANT_COMPONENT_GUIDELINES.md
@@ -34,7 +34,7 @@ documentation and controls for a better documentation experience.
 ## Component creation
 
 In this example let's assume you're working with expressive and productive
-variants. You'll want to create three seperate components. The "base" component
+variants. You'll want to create three separate components. The "base" component
 being the main component where all the component code and styles should be. The
 "variant" components should act as simple wrappers for the base component. Their
 main purpose is to benefit from a specific named export (`Card` vs

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,2 +1,2 @@
-# https://github.com/probot/stale#usage
+# https://github.com/probot/stale#usage  cspell:words wontfix
 staleLabel: 'status: wontfix'

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "mdx"
   ],
   "ignorePaths": [
+    ".vscode",
     ".yarn",
     "cdai",
     "coverage",

--- a/cspell.json
+++ b/cspell.json
@@ -58,7 +58,8 @@
     "*.snap",
     "storybook-static",
     "yarn-error.log",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "**/.*"
   ],
   "words": [
     "apikey",

--- a/cspell.json
+++ b/cspell.json
@@ -66,6 +66,7 @@
     "checkmark",
     "classname",
     "divs",
+    "overridable",
     "pconsole",
     "readme",
     "renderable",

--- a/cspell.packages.txt
+++ b/cspell.packages.txt
@@ -2,9 +2,10 @@ browserslist
 cdai
 codesandbox
 docgen
+dsag
 flatpickr
 kubernetes
 markdownlint
-Plex
+plex
 stylelint
-WCAG
+wcag

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "run-s test:all 'test:jest {@}' --",
     "test:all": "yarn run-all --no-sort test",
     "test:jest": "jest",
-    "spellcheck": "yarn spellcheck:files '**/*'",
+    "spellcheck": "yarn spellcheck:files '**/*' '.github/*'",
     "spellcheck:files": "cspell lint --relative --no-progress --show-context --no-must-find-files",
     "storybook": "run-s storybook:build:dependencies storybook:start",
     "storybook:build": "run-s storybook:build:*",


### PR DESCRIPTION
Hidden files (beginning with .) are not included in `yarn spellcheck`, but they are still spellchecked when commitlint asks specifically for them, which could be inconvenient as we haven't cleared them of spellcheck errors.  This PR adds all hidden files in any directories, including root, to the ignore list, so that they are not spellchecked during commit either.

Files in hidden folders (beginning with .) are also not included in `yarn spellcheck`, but can still be spellchecked when commitlint asks specifically for them. We have already added '.yarn' to the ignore list to ensure that files in the offline mirror are not spellchecked during commit. This PR adds '.vscode' to the ignore list so that updates to files in that folder don't get spellchecked during commit, but adds '.github' to the `yarn spellcheck` so that files in that folder *are* routinely spellchecked.

This PR also addresses a (small) number of spelling issues that showed up once the '.github' folder was added to the spellcheck!

#### What did you change?

cspell.json and related files, package.json, and various files in .github

#### How did you test and verify your work?

Ran ci-check. This change should not affect any actual function.
