### PR TITLE
fix(PageHeader): ensure all dependency changes trigger header collapse

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -40,6 +40,7 @@ import {
   utilCheckUpdateVerticalSpace,
   utilGetTitleShape,
   utilSetCustomCSSProps,
+  utilSetCollapsed,
 } from './PageHeaderUtils';
 
 export let PageHeader = React.forwardRef(
@@ -184,24 +185,12 @@ export let PageHeader = React.forwardRef(
       checkUpdateVerticalSpace();
     };
 
-    const toggleCollapse = (forceCollapse) => {
-      const collapse =
-        typeof forceCollapse !== 'undefined' ? forceCollapse : !fullyCollapsed;
-
-      /* don't know how to test resize */
-      /* istanbul ignore next if */
-      if (collapse) {
-        window.scrollTo({
-          top: (metrics?.headerOffset || 0) - (metrics?.headerTopValue || 0),
-          behavior: 'smooth',
-        });
-      } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      }
-    };
-
     const handleCollapseToggle = () => {
-      toggleCollapse();
+      utilSetCollapsed(
+        !fullyCollapsed,
+        metrics.headerOffset,
+        metrics.headerTopValue
+      );
     };
 
     // use effects
@@ -420,9 +409,14 @@ export let PageHeader = React.forwardRef(
     };
 
     useEffect(() => {
-      toggleCollapse(collapseHeader);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [collapseHeader]);
+      if (typeof collapseHeader === 'boolean') {
+        utilSetCollapsed(
+          collapseHeader,
+          metrics.headerOffset,
+          metrics.headerTopValue
+        );
+      }
+    }, [collapseHeader, metrics.headerOffset, metrics.headerTopValue]);
 
     const {
       text: titleText,

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeaderUtils.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeaderUtils.js
@@ -160,3 +160,14 @@ export const utilSetCustomCSSProps = (targetRef, kvPairs) => {
     }
   }
 };
+
+// Trigger a window scroll, if necessary, to set the collapsed state.
+export const utilSetCollapsed = (collapse, headerOffset, headerTopValue) => {
+  /* don't know how to test resize */
+  /* istanbul ignore next if */
+  if (collapse) {
+    window.scrollTo({ top: headerOffset - headerTopValue, behavior: 'smooth' });
+  } else {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+};


### PR DESCRIPTION
Contributes to #996

Not all the dependencies were listed for the toggleCollapse function, leading to it not being called e.g. if the metrics were calculated *after* the `collapseHeader` prop was applied, which happened if the prop was set true on initial render.

#### What did you change?

Changed the toggle function to a set function, to avoid it 'bouncing' as the collapse state changed. Moved the function into utils file and ensured all callers listed all dependencies.

#### How did you test and verify your work?

Ran storybook