### PR TITLE
chore: remove really annoying blue "Show Info" button that gets in the way on all the storybook pages

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -87,6 +87,7 @@
     "tabbable",
     "tearsheet",
     "tearsheets",
-    "uuidv"
+    "uuidv",
+    "viewports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "spellcheck:files": "cspell lint --relative --no-progress --show-context --no-must-find-files",
     "storybook": "run-s storybook:build:dependencies storybook:start",
     "storybook:build": "run-s storybook:build:*",
-    "storybook:build:dependencies": "yarn run-all --include-dependencies --scope \"@carbon/storybook-addon-theme\" --scope \"@carbon/ibm-cloud-cognitive\" build",
+    "storybook:build:dependencies": "yarn run-all --include-dependencies --scope \"@carbon/storybook-addon-theme\" build",
     "storybook:build:storybook": "cd packages/core && yarn build",
     "storybook:start": "cd packages/core && yarn start",
     "sync": "carbon-cli sync",

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// cspell:words unuse
+
 import React, { useEffect } from 'react';
-import { withInfo } from '@storybook/addon-info';
 import { withCarbonTheme } from '@carbon/storybook-addon-theme/react';
 
 import { pkg } from '../../cloud-cognitive/src/settings';
@@ -30,7 +31,6 @@ const Style = ({ children, styles }) => {
 };
 
 const decorators = [
-  withInfo,
   (storyFn, { parameters: { styles } }) => {
     const story = storyFn();
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
     "@babel/core": "^7.14.8",
     "@carbon/elements": "^10.38.0",
     "@carbon/grid": "10.31.0",
-    "@carbon/ibm-cloud-cognitive": "^0.60.0",
     "@carbon/icons-react": "10.35.0",
     "@carbon/import-once": "10.5.0",
     "@carbon/layout": "10.27.0",


### PR DESCRIPTION
The "Show info" button is a relic of a deprecated addon-info, which we have already dropped in favour of the replacement addon-docs. Remove the unused decorator.

#### What did you change?

Storybook preview.js, also added some spellcheck fixes, and removed an unnecessary dependency core->ccs (the files are accessed directly, not via a dependency chain).

#### How did you test and verify your work?

Ran storybook.