### PR TITLE
fix(SidePanel): title animation bug addressed, missing default value

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -170,6 +170,8 @@ export let SidePanel = React.forwardRef(
             sidePanelSubtitleElementHeight ||
           sidePanelSubtitleElementHeight === 0
             ? totalScrollingContentHeight - panelOuterHeight
+            : sidePanelSubtitleElementHeight < 0
+            ? 16
             : sidePanelSubtitleElementHeight;
         /* istanbul ignore next */
         sidePanelOuter &&


### PR DESCRIPTION
Contributes to #1056 

The problem here was that `sidePanelSubtitleElementHeight` was being assigned a negative number if the panel did not have scrolling content. But if the browser was resized, that value never got updated. In the case that it receives a negative number, the scrolling animation stops working so we simply needed to give it a default value.

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook