### PR TITLE
chore(Storybook): remove styles that fixed a div that's no longer inserted

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -54,16 +54,6 @@
 }
 
 /**
-  Override used for modals in any .mdx preview block.
-  storybook generates preview blocks with a surrounding div with style="position: relative; z-index: 0;"
-  this causes style problems for modals when not using react portals.
-  modals in mdx files should now be formatted like this to prevent z-index issues
-*/
-.preview-position-fix > div {
-  position: static !important; /* stylelint-disable-line declaration-no-important */
-}
-
-/**
   Adds a box indicating the extent of the available space to the displayed component
 */
 .ccs-sb__display-box {


### PR DESCRIPTION
There used to be a DIV inserted around our stories, and David added these styles to prevent that inserted DIV mucking up our modals. That DIV is no longer inserted since I removed the addon-info, so the styles are getting randomly applied to top-level DIVs in our stories, causing mayhem. End the mayhem.

#### What did you change?

storybook index.scss

#### How did you test and verify your work?

Ran storybook. Again. And looked a bit more thoroughly.