### PR TITLE
chore: ensure story export order is robustly used as story sort order in storybook

### DIFF
--- a/packages/cloud-cognitive/CHANGELOG.md
+++ b/packages/cloud-cognitive/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.62.6](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.5...@carbon/ibm-cloud-cognitive@0.62.6) (2021-07-27)
+
+
+### Bug Fixes
+
+* apikey story fix ([#1081](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1081)) ([a225b3a](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/a225b3a291734d1d29d564708ae267aa4a202134))
+
+
+
+
+
 ## [0.62.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.4...@carbon/ibm-cloud-cognitive@0.62.5) (2021-07-27)
 
 

--- a/packages/cloud-cognitive/CHANGELOG.md
+++ b/packages/cloud-cognitive/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.62.5](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.4...@carbon/ibm-cloud-cognitive@0.62.5) (2021-07-27)
+
+
+### Bug Fixes
+
+* update apikeymodal prop testing ([#1079](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1079)) ([92a1aa3](https://github.com/carbon-design-system/ibm-cloud-cognitive/commit/92a1aa3b0f03c6663e83e52f586e28e1a9010232))
+
+
+
+
+
 ## [0.62.4](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/@carbon/ibm-cloud-cognitive@0.62.3...@carbon/ibm-cloud-cognitive@0.62.4) (2021-07-27)
 
 

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-cloud-cognitive",
   "description": "Carbon for Cloud & Cognitive UI components",
-  "version": "0.62.4",
+  "version": "0.62.5",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ibm-cloud-cognitive",
   "description": "Carbon for Cloud & Cognitive UI components",
-  "version": "0.62.5",
+  "version": "0.62.6",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.stories.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.stories.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { DISPLAY_NAME } from '.';
 import mdx from './DISPLAY_NAME.mdx';
@@ -51,8 +52,9 @@ const Template = (args) => {
  * TODO: Declare one or more stories, generally one per design scenario.
  * NB no need for a 'Playground' because all stories have all controls anyway.
  */
-export const CAMEL_NAME = Template.bind({});
-CAMEL_NAME.args = {
-  // TODO: Component args - https://storybook.js.org/docs/react/writing-stories/args#DISPLAY_NAME-args
-  children: 'hello, world',
-};
+export const CAMEL_NAME = prepareStory(Template, {
+  args: {
+    // TODO: Component args - https://storybook.js.org/docs/react/writing-stories/args#DISPLAY_NAME-args
+    children: 'hello, world',
+  },
+});

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyDownloader.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyDownloader.js
@@ -38,9 +38,16 @@ export const APIKeyDownloader = ({
   }, [apiKey, fileName, fileType]);
 
   return (
-    <p className={`${pkg.prefix}--apikey-modal__messaging-text`}>
-      {body} <a {...linkProps}>{linkText}</a>
-    </p>
+    <div className={`${pkg.prefix}--apikey-modal__download-container`}>
+      <p className={`${pkg.prefix}--apikey-modal__messaging-text`}>
+        {body}{' '}
+        <a
+          {...linkProps}
+          className={`${pkg.prefix}--apikey-modal__download-link`}>
+          {linkText}
+        </a>
+      </p>
+    </div>
   );
 };
 

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyDownloader.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyDownloader.test.js
@@ -9,7 +9,7 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { APIKeyDownloader } from './APIKeyDownloader';
 
-const { name } = APIKeyDownloader;
+const componentName = APIKeyDownloader.name;
 const defaultProps = {
   apiKey: '123-456-789',
   body: 'API key created',
@@ -24,10 +24,10 @@ describe(name, () => {
   it('has json file download', async () => {
     const { getByText } = render(<APIKeyDownloader {...defaultProps} />);
     const link = getByText(defaultProps.linkText);
-
     await waitFor(() => {
       expect(link).toHaveProperty('download');
     });
+    getByText(defaultProps.body);
     expect(link).toHaveProperty('download', 'file.json');
     expect(link).toHaveProperty('href', 'http://localhost/download-link');
   });
@@ -65,5 +65,14 @@ describe(name, () => {
     });
     expect(link).toHaveProperty('download', 'apikey.json');
     expect(link).toHaveProperty('href', 'http://localhost/download-link');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { getByText, container } = render(
+      <APIKeyDownloader {...defaultProps} />
+    );
+    await waitFor(() => getByText('download'));
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
   });
 });

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -19,6 +19,7 @@ import {
 import { action } from '@storybook/addon-actions';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { APIKeyModal } from '.';
 import mdx from './APIKeyModal.mdx';
 const storybookPrefix = getStorybookPrefix(pkg, APIKeyModal.displayName);
@@ -351,104 +352,111 @@ const EditTemplate = (args) => {
   );
 };
 
-export const Generate = TemplateWithState.bind({});
-Generate.args = {
-  ...defaultProps,
-  generateButtonText: 'Generate API key',
-  generateTitle: 'Generate an API key',
-  body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
-  nameHelperText:
-    'Providing the application name will help you identify your API key later.',
-  nameLabel: 'Name your application',
-  namePlaceholder: 'Application name',
-  nameRequired: true,
-};
+export const Generate = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+    generateButtonText: 'Generate API key',
+    generateTitle: 'Generate an API key',
+    body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
+    nameHelperText:
+      'Providing the application name will help you identify your API key later.',
+    nameLabel: 'Name your application',
+    namePlaceholder: 'Application name',
+    nameRequired: true,
+  },
+});
 
-export const GenerateWithError = TemplateWithState.bind({});
-GenerateWithError.args = {
-  ...defaultProps,
-  hasAPIKeyVisibilityToggle: true,
-  generateButtonText: 'Generate API key',
-  generateTitle: 'Generate an API key',
-  body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
-  nameHelperText:
-    'Providing the application name will help you identify your API key later.',
-  nameLabel: 'Name your application',
-  namePlaceholder: 'Application name',
-  nameRequired: true,
-  error: true,
-  errorText: 'Failed to create API key',
-};
+export const GenerateWithError = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+    hasAPIKeyVisibilityToggle: true,
+    generateButtonText: 'Generate API key',
+    generateTitle: 'Generate an API key',
+    body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
+    nameHelperText:
+      'Providing the application name will help you identify your API key later.',
+    nameLabel: 'Name your application',
+    namePlaceholder: 'Application name',
+    nameRequired: true,
+    error: true,
+    errorText: 'Failed to create API key',
+  },
+});
 
-export const InstantGenerate = InstantTemplate.bind({});
-InstantGenerate.args = {
-  ...defaultProps,
-  apiKeyLabel: '',
-};
+export const InstantGenerate = prepareStory(InstantTemplate, {
+  args: {
+    ...defaultProps,
+    apiKeyLabel: '',
+  },
+});
 
-export const CustomGenerate = MultiStepTemplate.bind({});
-CustomGenerate.args = {
-  ...defaultProps,
-  generateButtonText: 'Generate',
-  modalLabel: 'Generate API key',
-  nextStepButtonText: 'Next',
-  previousStepButtonText: 'Previous',
-  downloadFileName: 'apikey',
-  savedName: '',
-  savedAllResources: false,
-  savedResource: '',
-  savedPermissions: '',
-};
+export const CustomGenerate = prepareStory(MultiStepTemplate, {
+  args: {
+    ...defaultProps,
+    generateButtonText: 'Generate',
+    modalLabel: 'Generate API key',
+    nextStepButtonText: 'Next',
+    previousStepButtonText: 'Previous',
+    downloadFileName: 'apikey',
+    savedName: '',
+    savedAllResources: false,
+    savedResource: '',
+    savedPermissions: '',
+  },
+});
 
-export const Edit = EditTemplate.bind({});
-Edit.args = {
-  ...defaultProps,
-  editButtonText: 'Save API key',
-  generateTitle: 'Save an API key',
-  body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
-  nameHelperText:
-    'Providing the application name will help you identify your API key later.',
-  nameLabel: 'Name your application',
-  namePlaceholder: 'Application name',
-  nameRequired: true,
-  editing: true,
-  apiKey: '',
-  loadingText: 'Saving...',
-  apiKeyName: 'test_key_1',
-};
+export const Edit = prepareStory(EditTemplate, {
+  args: {
+    ...defaultProps,
+    editButtonText: 'Save API key',
+    generateTitle: 'Save an API key',
+    body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
+    nameHelperText:
+      'Providing the application name will help you identify your API key later.',
+    nameLabel: 'Name your application',
+    namePlaceholder: 'Application name',
+    nameRequired: true,
+    editing: true,
+    apiKey: '',
+    loadingText: 'Saving...',
+    apiKeyName: 'test_key_1',
+  },
+});
 
-export const EditWithError = EditTemplate.bind({});
-EditWithError.args = {
-  ...defaultProps,
-  editButtonText: 'Save API key',
-  generateTitle: 'Save an API key',
-  body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
-  nameHelperText:
-    'Providing the application name will help you identify your API key later.',
-  nameLabel: 'Name your application',
-  namePlaceholder: 'Application name',
-  nameRequired: true,
-  editing: true,
-  apiKey: '',
-  loadingText: 'Saving...',
-  generateSuccessBody: 'API Key saved.',
-  apiKeyName: 'test_key_1',
-  error: true,
-  errorText: 'Failed to edit API key',
-};
+export const EditWithError = prepareStory(EditTemplate, {
+  args: {
+    ...defaultProps,
+    editButtonText: 'Save API key',
+    generateTitle: 'Save an API key',
+    body: '(Optional description text) To connect securely to [product name], your application or tool needs an API key with permission to access resources such as [product resource name].',
+    nameHelperText:
+      'Providing the application name will help you identify your API key later.',
+    nameLabel: 'Name your application',
+    namePlaceholder: 'Application name',
+    nameRequired: true,
+    editing: true,
+    apiKey: '',
+    loadingText: 'Saving...',
+    generateSuccessBody: 'API Key saved.',
+    apiKeyName: 'test_key_1',
+    error: true,
+    errorText: 'Failed to edit API key',
+  },
+});
 
-export const CustomEdit = MultiStepTemplate.bind({});
-CustomEdit.args = {
-  ...defaultProps,
-  generateButtonText: 'Generate',
-  modalLabel: 'Generate API key',
-  nextStepButtonText: 'Next',
-  previousStepButtonText: 'Previous',
-  downloadFileName: 'apikey',
-  savedName: 'test_key_1',
-  savedAllResources: false,
-  savedResource: 'resource_1',
-  savedPermissions: 'Read only',
-  editing: true,
-  editButtonText: 'Save API key',
-};
+export const CustomEdit = prepareStory(MultiStepTemplate, {
+  args: {
+    ...defaultProps,
+    generateButtonText: 'Generate',
+    modalLabel: 'Generate API key',
+    nextStepButtonText: 'Next',
+    previousStepButtonText: 'Previous',
+    downloadFileName: 'apikey',
+    savedName: 'test_key_1',
+    savedAllResources: false,
+    savedResource: 'resource_1',
+    savedPermissions: 'Read only',
+    editing: true,
+    editButtonText: 'Save API key',
+  },
+});

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -384,7 +384,6 @@ export const InstantGenerate = InstantTemplate.bind({});
 InstantGenerate.args = {
   ...defaultProps,
   apiKeyLabel: '',
-  apiKeyVisibilityLabel: 'Show key',
 };
 
 export const CustomGenerate = MultiStepTemplate.bind({});

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
@@ -11,6 +11,7 @@ import React, { useEffect, useState } from 'react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { AboutModal } from '.';
 
@@ -163,55 +164,79 @@ const commonArgs = {
 };
 
 const aboutModalStoryName = 'About modal';
-export const aboutModal = Template.bind({}, aboutModalStoryName, true);
-aboutModal.storyName = aboutModalStoryName;
-aboutModal.args = {
-  additionalInfo: 1,
-  ...commonArgs,
-};
+export const aboutModal = prepareStory(
+  Template.bind({}, aboutModalStoryName, true),
+  {
+    storyName: aboutModalStoryName,
+    args: {
+      additionalInfo: 1,
+      ...commonArgs,
+    },
+  }
+);
 
 const withAllBodyStoryName =
   'About modal with links and legal and copyright text';
-export const withAllBody = Template.bind({}, withAllBodyStoryName, true);
-withAllBody.storyName = withAllBodyStoryName;
-withAllBody.args = {
-  additionalInfo: 1,
-  copyrightText: <>Copyright &copy; 2020 IBM corporation</>,
-  legalText:
-    'This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information.',
-  links: 2,
-  ...commonArgs,
-};
+export const withAllBody = prepareStory(
+  Template.bind({}, withAllBodyStoryName, true),
+  {
+    storyName: withAllBodyStoryName,
+    args: {
+      additionalInfo: 1,
+      copyrightText: <>Copyright &copy; 2020 IBM corporation</>,
+      legalText:
+        'This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information.',
+      links: 2,
+      ...commonArgs,
+    },
+  }
+);
 
 const withAddInfoStoryName = 'About modal with additional info';
-export const withAddInfo = Template.bind({}, withAddInfoStoryName, true);
-withAddInfo.storyName = withAddInfoStoryName;
-withAddInfo.args = {
-  additionalInfo: 2,
-  ...commonArgs,
-};
+export const withAddInfo = prepareStory(
+  Template.bind({}, withAddInfoStoryName, true),
+  {
+    storyName: withAddInfoStoryName,
+    args: {
+      additionalInfo: 2,
+      ...commonArgs,
+    },
+  }
+);
 
 const fullyLoadedStoryName = 'About modal with all props set';
-export const fullyLoaded = Template.bind({}, fullyLoadedStoryName, false);
-fullyLoaded.storyName = fullyLoadedStoryName;
-fullyLoaded.args = { ...withAllBody.args, ...withAddInfo.args };
+export const fullyLoaded = prepareStory(
+  Template.bind({}, fullyLoadedStoryName, false),
+  {
+    storyName: fullyLoadedStoryName,
+    args: { ...withAllBody.args, ...withAddInfo.args },
+  }
+);
 
 const withDarkThemeStoryName = 'About modal using dark theme';
-export const withDarkTheme = Template.bind({}, withDarkThemeStoryName, false);
-withDarkTheme.storyName = withDarkThemeStoryName;
-withDarkTheme.args = {
-  additionalInfo: 1,
-  className: 'sb--use-carbon-theme-g90',
-  ...commonArgs,
-};
+export const withDarkTheme = prepareStory(
+  Template.bind({}, withDarkThemeStoryName, false),
+  {
+    storyName: withDarkThemeStoryName,
+    args: {
+      additionalInfo: 1,
+      className: 'sb--use-carbon-theme-g90',
+      ...commonArgs,
+    },
+  }
+);
 
 const withScrollStoryName = 'About modal with scrolling';
-export const withScroll = Template.bind({}, withScrollStoryName, true);
-withScroll.storyName = withScrollStoryName;
-withScroll.args = {
-  additionalInfo: 1,
-  copyrightText: <>Copyright &copy; 2020 IBM corporation</>,
-  legalText:
-    'This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information. IBM grants you a non-exclusive, non-transferable, limited permission to access and display the Web pages within this site as a customer or potential customer of IBM provided you comply with these Terms of Use, and all copyright, trademark, and other proprietary notices remain intact. You may only use a crawler to crawl this Web site as permitted by this Web site’s robots.txt protocol, and IBM may block any crawlers in its sole discretion. The use authorized under this agreement is non-commercial in nature (e.g., you may not sell the content you access on or through this Web site.) All other use of this site is prohibited. Except for the limited permission in the preceding paragraph, IBM does not grant you any express or implied rights or licenses under any patents, trademarks, copyrights, or other proprietary or intellectual property rights. You may not mirror any of the content from this site on another Web site or in any other media. Any software and other materials that are made available for downloading, access, or other use from this site with their own license terms will be governed by such terms, conditions, and notices. Your failure to comply with such terms or any of the terms on this site will result in automatic termination of any rights granted to you, without prior notice, and you must immediately destroy all copies of downloaded materials in your possession, custody or control. This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information. IBM grants you a non-exclusive, non-transferable, limited permission to access and display the Web pages within this site as a customer or potential customer of IBM provided you comply with these Terms of Use, and all copyright, trademark, and other proprietary notices remain intact. You may only use a crawler to crawl this Web site as permitted by this Web site’s robots.txt protocol, and IBM may block any crawlers in its sole discretion. The use authorized under this agreement is non-commercial in nature (e.g., you may not sell the content you access on or through this Web site.) All other use of this site is prohibited. Except for the limited permission in the preceding paragraph, IBM does not grant you any express or implied rights or licenses under any patents, trademarks, copyrights, or other proprietary or intellectual property rights. You may not mirror any of the content from this site on another Web site or in any other media. Any software and other materials that are made available for downloading, access, or other use from this site with their own license terms will be governed by such terms, conditions, and notices. Your failure to comply with such terms or any of the terms on this site will result in automatic termination of any rights granted to you, without prior notice, and you must immediately destroy all copies of downloaded materials in your possession, custody or control.',
-  ...commonArgs,
-};
+export const withScroll = prepareStory(
+  Template.bind({}, withScrollStoryName, true),
+  {
+    storyName: withScrollStoryName,
+    args: {
+      additionalInfo: 1,
+      copyrightText: <>Copyright &copy; 2020 IBM corporation</>,
+      legalText:
+        'This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information. IBM grants you a non-exclusive, non-transferable, limited permission to access and display the Web pages within this site as a customer or potential customer of IBM provided you comply with these Terms of Use, and all copyright, trademark, and other proprietary notices remain intact. You may only use a crawler to crawl this Web site as permitted by this Web site’s robots.txt protocol, and IBM may block any crawlers in its sole discretion. The use authorized under this agreement is non-commercial in nature (e.g., you may not sell the content you access on or through this Web site.) All other use of this site is prohibited. Except for the limited permission in the preceding paragraph, IBM does not grant you any express or implied rights or licenses under any patents, trademarks, copyrights, or other proprietary or intellectual property rights. You may not mirror any of the content from this site on another Web site or in any other media. Any software and other materials that are made available for downloading, access, or other use from this site with their own license terms will be governed by such terms, conditions, and notices. Your failure to comply with such terms or any of the terms on this site will result in automatic termination of any rights granted to you, without prior notice, and you must immediately destroy all copies of downloaded materials in your possession, custody or control. This Web site contains proprietary notices and copyright information, the terms of which must be observed and followed. Please see the tab entitled “Copyright and trademark information” for related information. IBM grants you a non-exclusive, non-transferable, limited permission to access and display the Web pages within this site as a customer or potential customer of IBM provided you comply with these Terms of Use, and all copyright, trademark, and other proprietary notices remain intact. You may only use a crawler to crawl this Web site as permitted by this Web site’s robots.txt protocol, and IBM may block any crawlers in its sole discretion. The use authorized under this agreement is non-commercial in nature (e.g., you may not sell the content you access on or through this Web site.) All other use of this site is prohibited. Except for the limited permission in the preceding paragraph, IBM does not grant you any express or implied rights or licenses under any patents, trademarks, copyrights, or other proprietary or intellectual property rights. You may not mirror any of the content from this site on another Web site or in any other media. Any software and other materials that are made available for downloading, access, or other use from this site with their own license terms will be governed by such terms, conditions, and notices. Your failure to comply with such terms or any of the terms on this site will result in automatic termination of any rights granted to you, without prior notice, and you must immediately destroy all copies of downloaded materials in your possession, custody or control.',
+      ...commonArgs,
+    },
+  }
+);

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
@@ -12,6 +12,7 @@ import { Bee16, Lightning16 } from '@carbon/icons-react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
 import { ActionBar, deprecatedProps } from './ActionBar';
 
@@ -47,9 +48,10 @@ const Template = (argsIn) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  actions: actions,
-  containerWidth: 500,
-  overflowAriaLabel: 'Open and close additional action bar items list.',
-};
+export const Default = prepareStory(Template, {
+  args: {
+    actions: actions,
+    containerWidth: 500,
+    overflowAriaLabel: 'Open and close additional action bar items list.',
+  },
+});

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ActionSet } from '.';
 import { actionsOptions, actionsLabels, actionsMapping } from './actions.js';
@@ -58,5 +59,6 @@ const Template = ({ actions, size, ...args }) => {
   );
 };
 
-export const actionSet = Template.bind({});
-actionSet.args = { actions: 3 };
+export const actionSet = prepareStory(Template, {
+  args: { actions: 3 },
+});

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 import { pkg } from '../../settings';
 import { BreadcrumbWithOverflow } from '.';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 const storybookPrefix = getStorybookPrefix(
   pkg,
@@ -110,9 +111,10 @@ const Template = (argsIn) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  breadcrumbs: breadcrumbItems,
-  containerWidth: 500,
-  overflowAriaLabel: 'Open and close additional breadcrumb item list.',
-};
+export const Default = prepareStory(Template, {
+  args: {
+    breadcrumbs: breadcrumbItems,
+    containerWidth: 500,
+    overflowAriaLabel: 'Open and close additional breadcrumb item list.',
+  },
+});

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -11,6 +11,7 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
 import mdx from './ButtonMenu.mdx';
@@ -60,6 +61,7 @@ const Template = (args) => {
   );
 };
 
-export const buttonMenu = Template.bind({});
-buttonMenu.storyName = 'Button menu';
-buttonMenu.args = {};
+export const buttonMenu = prepareStory(Template, {
+  storyName: 'Button menu',
+  args: {},
+});

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { pkg } from '../../settings';
 
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ButtonSetWithOverflow } from '.';
 
 // Carbon and package components we use.
@@ -64,9 +65,10 @@ const Template = (argsIn) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  buttons,
-  buttonSetOverflowLabel,
-  containerWidth: 600,
-};
+export const Default = prepareStory(Template, {
+  args: {
+    buttons,
+    buttonSetOverflowLabel,
+    containerWidth: 600,
+  },
+});

--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
@@ -10,6 +10,7 @@ import React from 'react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ComboButton, ComboButtonItem } from '..';
 
@@ -26,10 +27,10 @@ export default {
   parameters: { styles },
 };
 
-export const Default = () => (
+export const Default = prepareStory(() => (
   <ComboButton>
     <ComboButtonItem>ComboButtonItem 1</ComboButtonItem>
     <ComboButtonItem renderIcon={CloudApp16}>ComboButtonItem 2</ComboButtonItem>
     <ComboButtonItem>ComboButtonItem 3</ComboButtonItem>
   </ComboButton>
-);
+));

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { CreateFullPage } from '.';
 import { CreateFullPageSection } from './CreateFullPageSection';
@@ -224,20 +225,23 @@ const TemplateWithSections = ({ ...args }) => {
   );
 };
 
-export const createFullPage = Template.bind({});
-createFullPage.args = {
-  ...defaultFullPageProps,
-};
+export const createFullPage = prepareStory(Template, {
+  args: {
+    ...defaultFullPageProps,
+  },
+});
 
-export const createFullPageWithSections = TemplateWithSections.bind({});
-createFullPageWithSections.args = {
-  ...defaultFullPageProps,
-};
+export const createFullPageWithSections = prepareStory(TemplateWithSections, {
+  args: {
+    ...defaultFullPageProps,
+  },
+});
 
-export const createFullPageWithToggle = Template.bind({});
-createFullPageWithToggle.args = {
-  ...defaultFullPageProps,
-  hasToggle: true,
-  toggleAriaLabel: 'toggle button',
-  toggleLabelText: 'Show all available options',
-};
+export const createFullPageWithToggle = prepareStory(Template, {
+  args: {
+    ...defaultFullPageProps,
+    hasToggle: true,
+    toggleAriaLabel: 'toggle button',
+    toggleLabelText: 'Show all available options',
+  },
+});

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.stories.js
@@ -24,6 +24,7 @@ import { getStorybookPrefix } from '../../../config';
 import { CreateModal } from '.';
 import mdx from './CreateModal.mdx';
 const storybookPrefix = getStorybookPrefix(pkg, CreateModal.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
@@ -140,83 +141,86 @@ TemplateWithFormValidation.propTypes = {
   ...CreateModal.propTypes,
 };
 
-export const Default = Template.bind({});
-Default.storyName = 'Create Modal';
-Default.args = {
-  story: Default,
-  ...defaultProps,
-  children: (
-    <>
-      <TextInput
-        id="1"
-        key="form-field-1"
-        labelText="Text input label"
-        helperText="Helper text goes here"
-        placeholder="Placeholder"
-      />
-      <NumberInput
-        id="2"
-        className="create-modal--storybook-input"
-        label="Number input label"
-        helperText="Optional helper text goes here"
-        min={0}
-        max={50}
-        value={1}
-      />
-      <RadioButtonGroup
-        legendText="Radio button legend text goes here"
-        name="radio-button-group"
-        defaultSelected="radio-1">
-        <RadioButton labelText="Radio-1" value="radio-1" id="radio-1" />
-        <RadioButton labelText="Radio-2" value="radio-2" id="radio-2" />
-        <RadioButton labelText="Radio-3" value="radio-3" id="radio-3" />
-      </RadioButtonGroup>
-      <DatePicker datePickerType="single">
-        <DatePickerInput
-          placeholder="mm/dd/yyyy"
-          labelText="Date picker input label"
-          id="date-picker-single"
+export const Default = prepareStory(Template, {
+  storyName: 'Create Modal',
+  args: {
+    story: Default,
+    ...defaultProps,
+    children: (
+      <>
+        <TextInput
+          id="1"
+          key="form-field-1"
+          labelText="Text input label"
+          helperText="Helper text goes here"
+          placeholder="Placeholder"
         />
-      </DatePicker>
-    </>
-  ),
-};
+        <NumberInput
+          id="2"
+          className="create-modal--storybook-input"
+          label="Number input label"
+          helperText="Optional helper text goes here"
+          min={0}
+          max={50}
+          value={1}
+        />
+        <RadioButtonGroup
+          legendText="Radio button legend text goes here"
+          name="radio-button-group"
+          defaultSelected="radio-1">
+          <RadioButton labelText="Radio-1" value="radio-1" id="radio-1" />
+          <RadioButton labelText="Radio-2" value="radio-2" id="radio-2" />
+          <RadioButton labelText="Radio-3" value="radio-3" id="radio-3" />
+        </RadioButtonGroup>
+        <DatePicker datePickerType="single">
+          <DatePickerInput
+            placeholder="mm/dd/yyyy"
+            labelText="Date picker input label"
+            id="date-picker-single"
+          />
+        </DatePicker>
+      </>
+    ),
+  },
+});
 
-export const DefaultWithDarkTheme = Template.bind({});
-DefaultWithDarkTheme.storyName = 'Create Modal using dark theme';
-DefaultWithDarkTheme.args = {
-  story: DefaultWithDarkTheme,
-  className: 'sb--use-carbon-theme-g90',
-  ...defaultProps,
-  children: (
-    <>
-      <TextInput
-        id="1"
-        key="form-field-1"
-        labelText="Text input label"
-        helperText="Helper text goes here"
-        placeholder="Placeholder"
-      />
-      <Dropdown
-        id="default"
-        titleText="Dropdown label"
-        helperText="This is some helper text"
-        label="Dropdown menu options"
-        items={['Option 0', 'Option 1', 'Option 2']}
-      />
-      <TextArea
-        id="2"
-        placeholder="Placeholder text"
-        labelText="Text area label"
-        helperText="Optional helper text"
-      />
-    </>
-  ),
-};
+export const DefaultWithDarkTheme = prepareStory(Template, {
+  storyName: 'Create Modal using dark theme',
+  args: {
+    story: DefaultWithDarkTheme,
+    className: 'sb--use-carbon-theme-g90',
+    ...defaultProps,
+    children: (
+      <>
+        <TextInput
+          id="1"
+          key="form-field-1"
+          labelText="Text input label"
+          helperText="Helper text goes here"
+          placeholder="Placeholder"
+        />
+        <Dropdown
+          id="default"
+          titleText="Dropdown label"
+          helperText="This is some helper text"
+          label="Dropdown menu options"
+          items={['Option 0', 'Option 1', 'Option 2']}
+        />
+        <TextArea
+          id="2"
+          placeholder="Placeholder text"
+          labelText="Text area label"
+          helperText="Optional helper text"
+        />
+      </>
+    ),
+  },
+});
 
-export const WithFormValidation = TemplateWithFormValidation.bind({});
-WithFormValidation.storyName = 'Create Modal with form validation';
-WithFormValidation.args = {
-  story: WithFormValidation,
-  ...defaultProps,
-};
+export const WithFormValidation = prepareStory(TemplateWithFormValidation, {
+  storyName: 'Create Modal with form validation',
+  args: {
+    story: WithFormValidation,
+    ...defaultProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -24,6 +24,7 @@ import {
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { CreateSidePanel, deprecatedProps } from './CreateSidePanel';
 import mdx from './CreateSidePanel.mdx';
@@ -364,20 +365,23 @@ const TemplateWithMultipleForms = ({ ...args }) => {
   );
 };
 
-export const Default = DefaultTemplate.bind({});
-Default.args = {
-  selectorPageContent: '#cloud-and-cognitive-page-content',
-  ...defaultStoryProps,
-};
+export const Default = prepareStory(DefaultTemplate, {
+  args: {
+    selectorPageContent: '#cloud-and-cognitive-page-content',
+    ...defaultStoryProps,
+  },
+});
 
-export const WithFormValidation = TemplateWithFormValidation.bind({});
-WithFormValidation.args = {
-  selectorPageContent: '#cloud-and-cognitive-page-content',
-  ...defaultStoryProps,
-};
+export const WithFormValidation = prepareStory(TemplateWithFormValidation, {
+  args: {
+    selectorPageContent: '#cloud-and-cognitive-page-content',
+    ...defaultStoryProps,
+  },
+});
 
-export const WithMultipleForms = TemplateWithMultipleForms.bind({});
-WithMultipleForms.args = {
-  selectorPageContent: '#cloud-and-cognitive-page-content',
-  ...defaultStoryProps,
-};
+export const WithMultipleForms = prepareStory(TemplateWithMultipleForms, {
+  args: {
+    selectorPageContent: '#cloud-and-cognitive-page-content',
+    ...defaultStoryProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -7,6 +7,7 @@
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import styles from './_storybook-styles.scss';
 import { CreateTearsheet } from './CreateTearsheet';
 import { CreateTearsheetStep } from './CreateTearsheetStep';
@@ -33,10 +34,12 @@ export default {
   parameters: { styles, docs: { page: mdx } },
 };
 
-export const multiStepTearsheet = MultiStepTearsheet.bind({});
-multiStepTearsheet.storyName = 'With multiple steps';
-multiStepTearsheet.args = {};
+export const multiStepTearsheet = prepareStory(MultiStepTearsheet, {
+  storyName: 'With multiple steps',
+  args: {},
+});
 
-export const withViewAllToggle = MultiStepWithSectionsTearsheet.bind({});
-withViewAllToggle.storyName = 'With view all toggle';
-withViewAllToggle.args = {};
+export const withViewAllToggle = prepareStory(MultiStepWithSectionsTearsheet, {
+  storyName: 'With view all toggle',
+  args: {},
+});

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
@@ -16,6 +16,7 @@ import {
 } from 'carbon-components-react';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { CreateTearsheetNarrow } from '.';
 import mdx from './CreateTearsheetNarrow.mdx';
@@ -154,7 +155,8 @@ const Template = (args) => {
  * TODO: Declare one or more stories, generally one per design scenario.
  * NB no need for a 'Playground' because all stories have all controls anyway.
  */
-export const createTearsheetNarrow = Template.bind({});
-createTearsheetNarrow.args = {
-  ...defaultStoryProps,
-};
+export const createTearsheetNarrow = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
@@ -26,6 +26,7 @@ import {
 import styles from './_storybook-styles.scss';
 
 const storybookPrefix = getStorybookPrefix(pkg, EmptyState.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/EmptyState`,
@@ -65,58 +66,64 @@ const Template = (args) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...emptyStateCommonProps,
-};
-
-export const WithCustomIllustration = Template.bind({});
-WithCustomIllustration.args = {
-  ...emptyStateCommonProps,
-  illustration: CustomIllustration,
-  illustrationDescription: 'Test alt text',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithCustomIllustration = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
+    illustration: CustomIllustration,
+    illustrationDescription: 'Test alt text',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...emptyStateCommonProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...emptyStateCommonProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...emptyStateCommonProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -17,6 +17,7 @@ import { ErrorEmptyState } from '.';
 import styles from '../_index.scss';
 
 const storybookPrefix = getStorybookPrefix(pkg, ErrorEmptyState.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${ErrorEmptyState.displayName}`,
@@ -38,57 +39,63 @@ const Template = (args) => {
   return <ErrorEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -17,6 +17,7 @@ import { NoDataEmptyState } from '.';
 import styles from '../_index.scss';
 
 const storybookPrefix = getStorybookPrefix(pkg, NoDataEmptyState.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${NoDataEmptyState.displayName}`,
@@ -38,57 +39,63 @@ const Template = (args) => {
   return <NoDataEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -17,6 +17,7 @@ import { NoTagsEmptyState } from '.';
 import styles from '../_index.scss';
 
 const storybookPrefix = getStorybookPrefix(pkg, NoTagsEmptyState.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${NoTagsEmptyState.displayName}`,
@@ -38,57 +39,63 @@ const Template = (args) => {
   return <NoTagsEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -16,6 +16,7 @@ import { NotFoundEmptyState } from '.';
 import styles from '../_index.scss';
 
 const storybookPrefix = getStorybookPrefix(pkg, NotFoundEmptyState.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${NotFoundEmptyState.displayName}`,
@@ -37,57 +38,63 @@ const Template = (args) => {
   return <NotFoundEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -19,6 +19,7 @@ const storybookPrefix = getStorybookPrefix(
   pkg,
   NotificationsEmptyState.displayName
 );
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${NotificationsEmptyState.displayName}`,
@@ -40,57 +41,63 @@ const Template = (args) => {
   return <NotificationsEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -19,6 +19,7 @@ const storybookPrefix = getStorybookPrefix(
   pkg,
   UnauthorizedEmptyState.displayName
 );
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/EmptyStates/${UnauthorizedEmptyState.displayName}`,
@@ -40,57 +41,63 @@ const Template = (args) => {
   return <UnauthorizedEmptyState {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultStoryProps,
-};
-
-export const WithDarkModeIllustration = Template.bind({});
-WithDarkModeIllustration.args = {
-  ...defaultStoryProps,
-  illustrationTheme: 'dark',
-};
-
-export const withAction = Template.bind({});
-withAction.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
   },
-};
+});
 
-export const withActionIconButton = Template.bind({});
-withActionIconButton.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const WithDarkModeIllustration = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    illustrationTheme: 'dark',
   },
-};
+});
 
-export const withLink = Template.bind({});
-withLink.args = {
-  ...defaultStoryProps,
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+export const withAction = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+    },
   },
-};
+});
 
-export const withActionAndLink = Template.bind({});
-withActionAndLink.args = {
-  ...defaultStoryProps,
-  action: {
-    text: 'Create new',
-    onClick: action('Clicked empty state action button'),
-    renderIcon: Add20,
-    iconDescription: 'Add icon',
+export const withActionIconButton = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
   },
-  link: {
-    text: 'View documentation',
-    href: 'https://www.carbondesignsystem.com',
+});
+
+export const withLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
   },
-};
+});
+
+export const withActionAndLink = prepareStory(Template, {
+  args: {
+    ...defaultStoryProps,
+    action: {
+      text: 'Create new',
+      onClick: action('Clicked empty state action button'),
+      renderIcon: Add20,
+      iconDescription: 'Add icon',
+    },
+    link: {
+      text: 'View documentation',
+      href: 'https://www.carbondesignsystem.com',
+    },
+  },
+});

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.stories.js
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.stories.js
@@ -9,6 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { ExampleComponent } from '.';
 import mdx from './ExampleComponent.mdx';
@@ -43,12 +44,14 @@ const Template = (args) => {
   );
 };
 
-export const exampleComponent = Template.bind({});
-exampleComponent.args = {};
+export const exampleComponent = prepareStory(Template, {
+  args: {},
+});
 
-export const boxedSet = Template.bind({});
-boxedSet.args = {
-  ...exampleComponent.args,
-  borderColor: '#141414',
-  boxedBorder: true,
-};
+export const boxedSet = prepareStory(Template, {
+  args: {
+    ...exampleComponent.args,
+    borderColor: '#141414',
+    boxedBorder: true,
+  },
+});

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
@@ -14,6 +14,7 @@ import { ExportModal } from '.';
 import mdx from './ExportModal.mdx';
 import wait from '../../global/js/utils/wait';
 const storybookPrefix = getStorybookPrefix(pkg, ExportModal.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/${ExportModal.displayName}`,
@@ -83,45 +84,50 @@ const TemplateWithState = (args) => {
   );
 };
 
-export const WithSuccessMessage = TemplateWithState.bind({});
-WithSuccessMessage.args = {
-  ...defaultProps,
-  successful: true,
-};
+export const WithSuccessMessage = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+    successful: true,
+  },
+});
 
-export const WithErrorMessage = TemplateWithState.bind({});
-WithErrorMessage.args = {
-  ...defaultProps,
-  successful: false,
-};
+export const WithErrorMessage = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+    successful: false,
+  },
+});
 
-export const Standard = Template.bind({});
-Standard.args = {
-  ...defaultProps,
-};
+export const Standard = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+  },
+});
 
-export const WithExtensionValidation = Template.bind({});
-WithExtensionValidation.args = {
-  ...defaultProps,
-  validExtensions: ['pdf'],
-  filename: '',
-  invalidInputText: 'File must have valid extension .pdf',
-  body: 'File must be exported in a PDF format.',
-};
+export const WithExtensionValidation = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    validExtensions: ['pdf'],
+    filename: '',
+    invalidInputText: 'File must have valid extension .pdf',
+    body: 'File must be exported in a PDF format.',
+  },
+});
 
-export const WithPreformattedExtensions = Template.bind({});
-WithPreformattedExtensions.args = {
-  ...defaultProps,
-  filename: 'test',
-  preformattedExtensions: [
-    {
-      extension: 'YAML',
-      description: 'best for IBM managed cloud',
-    },
-    {
-      extension: 'BAR',
-      description: 'best for integration server',
-    },
-  ],
-  preformattedExtensionsLabel: 'Choose an export format',
-};
+export const WithPreformattedExtensions = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    filename: 'test',
+    preformattedExtensions: [
+      {
+        extension: 'YAML',
+        description: 'best for IBM managed cloud',
+      },
+      {
+        extension: 'BAR',
+        description: 'best for integration server',
+      },
+    ],
+    preformattedExtensionsLabel: 'Choose an export format',
+  },
+});

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -12,6 +12,7 @@ import { ArrowRight24, Cloud32 } from '@carbon/icons-react';
 import { AspectRatio } from 'carbon-components-react';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ExpressiveCard } from '.';
 import mdx from './ExpressiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -91,62 +92,70 @@ const MediaTemplate = (opts) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultProps,
-};
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+  },
+});
 
-export const LabelOnly = Template.bind({});
-LabelOnly.args = {
-  ...defaultProps,
-  title: '',
-};
+export const LabelOnly = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    title: '',
+  },
+});
 
-export const WithCaption = Template.bind({});
-WithCaption.args = {
-  ...defaultProps,
-  caption: 'Description or long caption',
-  label: '',
-};
+export const WithCaption = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    caption: 'Description or long caption',
+    label: '',
+  },
+});
 
-export const WithMedia = MediaTemplate.bind({});
-WithMedia.args = {
-  ...defaultProps,
-};
+export const WithMedia = prepareStory(MediaTemplate, {
+  args: {
+    ...defaultProps,
+  },
+});
 
-export const WithActionIcon = Template.bind({});
-WithActionIcon.args = {
-  ...defaultProps,
-  actionIcons: [
-    {
-      id: '1',
-      icon: ArrowRight24,
-      onClick: () => action('on click'),
-      onKeyDown: () => action('on keydown'),
-      iconDescription: 'Next',
-    },
-  ],
-  primaryButtonText: '',
-};
+export const WithActionIcon = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    actionIcons: [
+      {
+        id: '1',
+        icon: ArrowRight24,
+        onClick: () => action('on click'),
+        onKeyDown: () => action('on keydown'),
+        iconDescription: 'Next',
+      },
+    ],
+    primaryButtonText: '',
+  },
+});
 
-export const WithPictogram = Template.bind({});
-WithPictogram.args = {
-  ...defaultProps,
-  pictogram: Cloud32,
-};
+export const WithPictogram = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    pictogram: Cloud32,
+  },
+});
 
-export const WithSecondaryAction = Template.bind({});
-WithSecondaryAction.args = {
-  ...defaultProps,
-  secondaryButtonText: 'Secondary',
-  secondaryButtonKind: 'ghost',
-  columnSize: '8',
-};
+export const WithSecondaryAction = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    secondaryButtonText: 'Secondary',
+    secondaryButtonKind: 'ghost',
+    columnSize: '8',
+  },
+});
 
-export const Clickable = Template.bind({});
-Clickable.args = {
-  ...defaultProps,
-  onClick: () => action('on click'),
-  onKeyDown: () => action('on keydown'),
-  primaryButtonText: '',
-};
+export const Clickable = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    onClick: () => action('on click'),
+    onKeyDown: () => action('on keydown'),
+    primaryButtonText: '',
+  },
+});

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
@@ -10,6 +10,7 @@ import { pkg } from '../../../settings';
 import { HTTPError403 } from '.';
 import { getStorybookPrefix } from '../../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, HTTPError403.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import page from './HTTPError403.mdx';
 import styles from '../_storybook-styles.scss';
@@ -39,19 +40,20 @@ const Template = (args) => {
  * TODO: Declare one or more examples per template.
  * NOTE: Complete list of examples should match designed use cases
  */
-export const withAllPropsSet = Template.bind({});
-withAllPropsSet.args = {
-  errorCodeLabel: 'Error 403',
-  title: 'Forbidden',
-  description: 'You are not authorized to access this resource.',
-  links: [
-    {
-      text: 'Carbon Design System',
-      href: 'https://www.carbondesignsystem.com',
-    },
-    {
-      text: 'IBM Cloud and Cognitive component library',
-      href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
-    },
-  ],
-};
+export const withAllPropsSet = prepareStory(Template, {
+  args: {
+    errorCodeLabel: 'Error 403',
+    title: 'Forbidden',
+    description: 'You are not authorized to access this resource.',
+    links: [
+      {
+        text: 'Carbon Design System',
+        href: 'https://www.carbondesignsystem.com',
+      },
+      {
+        text: 'IBM Cloud and Cognitive component library',
+        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+      },
+    ],
+  },
+});

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
@@ -10,6 +10,7 @@ import { pkg } from '../../../settings';
 import { HTTPError404 } from '.';
 import { getStorybookPrefix } from '../../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, HTTPError404.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import page from './HTTPError404.mdx';
 import styles from '../_storybook-styles.scss';
@@ -33,19 +34,20 @@ const Template = (args) => {
  * TODO: Declare one or more examples per template.
  * NOTE: Complete list of examples should match designed use cases
  */
-export const withAllPropsSet = Template.bind({});
-withAllPropsSet.args = {
-  errorCodeLabel: 'Error 404',
-  title: 'Page not found',
-  description: 'The page you are looking for was not found.',
-  links: [
-    {
-      text: 'Carbon Design System',
-      href: 'https://www.carbondesignsystem.com',
-    },
-    {
-      text: 'IBM Cloud and Cognitive component library',
-      href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
-    },
-  ],
-};
+export const withAllPropsSet = prepareStory(Template, {
+  args: {
+    errorCodeLabel: 'Error 404',
+    title: 'Page not found',
+    description: 'The page you are looking for was not found.',
+    links: [
+      {
+        text: 'Carbon Design System',
+        href: 'https://www.carbondesignsystem.com',
+      },
+      {
+        text: 'IBM Cloud and Cognitive component library',
+        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+      },
+    ],
+  },
+});

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
@@ -10,6 +10,7 @@ import { pkg } from '../../../settings';
 import { HTTPErrorOther } from '.';
 import { getStorybookPrefix } from '../../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, HTTPErrorOther.displayName);
+import { prepareStory } from '../../../global/js/utils/story-helper';
 
 import page from './HTTPErrorOther.mdx';
 import styles from '../_storybook-styles.scss';
@@ -33,19 +34,20 @@ const Template = (args) => {
  * TODO: Declare one or more examples per template.
  * NOTE: Complete list of examples should match designed use cases
  */
-export const withAllPropsSet = Template.bind({});
-withAllPropsSet.args = {
-  errorCodeLabel: 'Error 502',
-  title: 'Bad gateway',
-  description: 'Received an invalid response.',
-  links: [
-    {
-      text: 'Carbon Design System',
-      href: 'https://www.carbondesignsystem.com',
-    },
-    {
-      text: 'IBM Cloud and Cognitive component library',
-      href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
-    },
-  ],
-};
+export const withAllPropsSet = prepareStory(Template, {
+  args: {
+    errorCodeLabel: 'Error 502',
+    title: 'Bad gateway',
+    description: 'Received an invalid response.',
+    links: [
+      {
+        text: 'Carbon Design System',
+        href: 'https://www.carbondesignsystem.com',
+      },
+      {
+        text: 'IBM Cloud and Cognitive component library',
+        href: 'https://github.com/carbon-design-system/ibm-cloud-cognitive',
+      },
+    ],
+  },
+});

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.stories.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.stories.js
@@ -14,6 +14,7 @@ import { getStorybookPrefix } from '../../../config';
 import { ImportModal } from '.';
 import mdx from './ImportModal.mdx';
 const storybookPrefix = getStorybookPrefix(pkg, ImportModal.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/${ImportModal.displayName}`,
@@ -66,7 +67,8 @@ const TemplateWithState = (args) => {
   );
 };
 
-export const Standard = TemplateWithState.bind({});
-Standard.args = {
-  ...defaultProps,
-};
+export const Standard = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.stories.js
+++ b/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.stories.js
@@ -11,6 +11,7 @@ import React from 'react';
 
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { LoadingBar } from '.';
 import mdx from './LoadingBar.mdx';
@@ -64,17 +65,19 @@ const TemplateDeterminate = (args) => {
  * Declare one or more stories, generally one per design scenario.
  * NB no need for a 'Playground' because all stories have all controls anyway.
  */
-export const Indeterminate = TemplateIndeterminate.bind({});
-Indeterminate.args = {
-  percentage: undefined,
-  showPercentageIndicator: false,
-  ...defaultProps,
-};
+export const Indeterminate = prepareStory(TemplateIndeterminate, {
+  args: {
+    percentage: undefined,
+    showPercentageIndicator: false,
+    ...defaultProps,
+  },
+});
 
-export const Determinate = TemplateDeterminate.bind({});
-Determinate.args = {
-  // Component args - https://storybook.js.org/docs/react/writing-stories/args#LoadingBar-args
-  percentage: 67,
-  showPercentageIndicator: true,
-  ...defaultProps,
-};
+export const Determinate = prepareStory(TemplateDeterminate, {
+  args: {
+    // Component args - https://storybook.js.org/docs/react/writing-stories/args#LoadingBar-args
+    percentage: 67,
+    showPercentageIndicator: true,
+    ...defaultProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
@@ -12,6 +12,7 @@ import { action } from '@storybook/addon-actions';
 import { Modal, RadioButton, RadioButtonGroup } from 'carbon-components-react';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ModifiedTabs } from '.';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 const storybookPrefix = getStorybookPrefix(pkg, ModifiedTabs.displayName);
@@ -84,11 +85,12 @@ const Template = (args) => {
 };
 
 // const parameters = { styles };
-export const Default = Template.bind({});
-Default.args = {
-  newTabLabel: 'Add new tab',
-  newTabContent: <div>Your new tab is being prepared...</div>,
-};
+export const Default = prepareStory(Template, {
+  args: {
+    newTabLabel: 'Add new tab',
+    newTabContent: <div>Your new tab is being prepared...</div>,
+  },
+});
 
 // Example with external save prompt
 const TemplateWithExternalSavePrompt = (args) => {
@@ -175,10 +177,14 @@ const TemplateWithExternalSavePrompt = (args) => {
   );
 };
 
-export const WithExternalSavePrompt = TemplateWithExternalSavePrompt.bind({});
-WithExternalSavePrompt.args = {
-  props: {
-    newTabLabel: 'Add new tab',
-    newTabContent: <div>Your new tab is being prepared...</div>,
-  },
-};
+export const WithExternalSavePrompt = prepareStory(
+  TemplateWithExternalSavePrompt,
+  {
+    args: {
+      props: {
+        newTabLabel: 'Add new tab',
+        newTabContent: <div>Your new tab is being prepared...</div>,
+      },
+    },
+  }
+);

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
@@ -26,6 +26,7 @@ import { NotificationsPanel } from '.';
 
 import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, NotificationsPanel.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import mdx from './NotificationsPanel.mdx';
 import data from './NotificationsPanel_data';
@@ -164,17 +165,19 @@ const EmptyNotifications = (args) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  onDoNotDisturbChange: action('Toggled to do not disturb'),
-  onViewAllClick: action('Clicked view all button'),
-  onSettingsClick: action('Clicked settings gear'),
-};
+export const Default = prepareStory(Template, {
+  args: {
+    onDoNotDisturbChange: action('Toggled to do not disturb'),
+    onViewAllClick: action('Clicked view all button'),
+    onSettingsClick: action('Clicked settings gear'),
+  },
+});
 
-export const EmptyState = EmptyNotifications.bind({});
-EmptyState.args = {
-  data: [],
-  onDoNotDisturbChange: action('Toggled to do not disturb'),
-  onViewAllClick: action('Clicked view all button'),
-  onSettingsClick: action('Clicked settings gear'),
-};
+export const EmptyState = prepareStory(EmptyNotifications, {
+  args: {
+    data: [],
+    onDoNotDisturbChange: action('Toggled to do not disturb'),
+    onViewAllClick: action('Clicked view all button'),
+    onSettingsClick: action('Clicked settings gear'),
+  },
+});

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -40,6 +40,7 @@ import { PageHeader, deprecatedProps } from './PageHeader';
 import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, PageHeader.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { demoTableHeaders, demoTableData } from './PageHeaderDemo.data';
 
@@ -101,8 +102,6 @@ const breadcrumbs = {
     makeBreadcrumb(3, `${ms} ${ys}`, `../${ms}{ys}`),
   ],
 };
-
-console.dir(breadcrumbs);
 
 const children = {
   'Nothing in the available area': null,
@@ -448,146 +447,157 @@ const Template = ({ children, ...props }) => (
 );
 
 // Stories
-export const withTitle = Template.bind({});
-withTitle.storyName = 'Simple page header with page title';
-withTitle.args = {
-  title: 2,
-  hasBackgroundAlways: false,
-};
+export const withTitle = prepareStory(Template, {
+  storyName: 'Simple page header with page title',
+  args: {
+    title: 2,
+    hasBackgroundAlways: false,
+  },
+});
 
-export const withBreadcrumbs = Template.bind({});
-withBreadcrumbs.storyName = 'Simple page header with breadcrumb';
-withBreadcrumbs.args = {
-  ...withTitle.args,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-};
+export const withBreadcrumbs = prepareStory(Template, {
+  storyName: 'Simple page header with breadcrumb',
+  args: {
+    ...withTitle.args,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+  },
+});
 
-export const withButtons = Template.bind({});
-withButtons.storyName = 'Simple page header with status and actions';
-withButtons.args = {
-  ...withBreadcrumbs.args,
-  pageActions: 2,
-  pageActionsOverflowLabel,
-  children: 1,
-};
+export const withButtons = prepareStory(Template, {
+  storyName: 'Simple page header with status and actions',
+  args: {
+    ...withBreadcrumbs.args,
+    pageActions: 2,
+    pageActionsOverflowLabel,
+    children: 1,
+  },
+});
 
-export const withTabs = Template.bind({});
-withTabs.storyName = 'Page header with navigation tabs';
-withTabs.args = {
-  title: 2,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 2,
-  pageActionsOverflowLabel,
-  navigation: 1,
-};
+export const withTabs = prepareStory(Template, {
+  storyName: 'Page header with navigation tabs',
+  args: {
+    title: 2,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 2,
+    pageActionsOverflowLabel,
+    navigation: 1,
+  },
+});
 
-export const withTags = Template.bind({});
-withTags.storyName = 'Page header with tags';
-withTags.args = {
-  title: 2,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 2,
-  pageActionsOverflowLabel,
-  tags: 1,
-};
+export const withTags = prepareStory(Template, {
+  storyName: 'Page header with tags',
+  args: {
+    title: 2,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 2,
+    pageActionsOverflowLabel,
+    tags: 1,
+  },
+});
 
-export const withTabsAndTags = Template.bind({});
-withTabsAndTags.storyName = 'Page header with tags and navigation tabs';
-withTabsAndTags.args = {
-  title: 2,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 2,
-  pageActionsOverflowLabel,
-  navigation: 1,
-  tags: 1,
-};
+export const withTabsAndTags = prepareStory(Template, {
+  storyName: 'Page header with tags and navigation tabs',
+  args: {
+    title: 2,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 2,
+    pageActionsOverflowLabel,
+    navigation: 1,
+    tags: 1,
+  },
+});
 
-export const withSubtitle = Template.bind({});
-withSubtitle.storyName = 'Page header with title and subtitle';
-withSubtitle.args = {
-  title: 2,
-  subtitle,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  navigation: 1,
-};
+export const withSubtitle = prepareStory(Template, {
+  storyName: 'Page header with title and subtitle',
+  args: {
+    title: 2,
+    subtitle,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    navigation: 1,
+  },
+});
 
-export const withSummaryDetails = Template.bind({});
-withSummaryDetails.storyName = 'Page header with summary details';
-withSummaryDetails.args = {
-  title: 2,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  navigation: 1,
-  children: 2,
-};
+export const withSummaryDetails = prepareStory(Template, {
+  storyName: 'Page header with summary details',
+  args: {
+    title: 2,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    navigation: 1,
+    children: 2,
+  },
+});
 
-export const withActionsToolbar = Template.bind({});
-withActionsToolbar.storyName = 'Page header with actions toolbar';
-withActionsToolbar.args = {
-  title: 2,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  navigation: 1,
-  actionBarItems: 2,
-  actionBarOverflowAriaLabel,
-};
+export const withActionsToolbar = prepareStory(Template, {
+  storyName: 'Page header with actions toolbar',
+  args: {
+    title: 2,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    navigation: 1,
+    actionBarItems: 2,
+    actionBarOverflowAriaLabel,
+  },
+});
 
-export const withBreadcrumbActionsToolbarOnly = Template.bind({});
-withBreadcrumbActionsToolbarOnly.storyName =
-  'Reduced page header with breadcrumb bar only';
-withBreadcrumbActionsToolbarOnly.args = {
-  title: 1,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  actionBarItems: 2,
-  actionBarOverflowAriaLabel,
-  collapseTitle: true,
-};
+export const withBreadcrumbActionsToolbarOnly = prepareStory(Template, {
+  storyName: 'Reduced page header with breadcrumb bar only',
+  args: {
+    title: 1,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    actionBarItems: 2,
+    actionBarOverflowAriaLabel,
+    collapseTitle: true,
+  },
+});
 
-export const fullyLoaded = Template.bind({});
-fullyLoaded.storyName = 'Page header with all items, pre-collapsed';
-fullyLoaded.args = {
-  title: 2,
-  subtitle,
-  breadcrumbs: 2,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 2,
-  pageActionsOverflowLabel,
-  children: 2,
-  navigation: 1,
-  tags: 1,
-  actionBarItems: 2,
-  actionBarOverflowAriaLabel,
-  collapseHeader: true,
-};
+export const fullyLoaded = prepareStory(Template, {
+  storyName: 'Page header with all items, pre-collapsed',
+  args: {
+    title: 2,
+    subtitle,
+    breadcrumbs: 2,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 2,
+    pageActionsOverflowLabel,
+    children: 2,
+    navigation: 1,
+    tags: 1,
+    actionBarItems: 2,
+    actionBarOverflowAriaLabel,
+    collapseHeader: true,
+  },
+});
 
-export const fullyLoadedAndSome = Template.bind({});
-fullyLoadedAndSome.storyName = 'Page header with long values and many items';
-fullyLoadedAndSome.args = {
-  title: 3,
-  subtitle: longSubtitle,
-  breadcrumbs: 3,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 3,
-  pageActionsOverflowLabel,
-  children: 2,
-  navigation: 2,
-  tags: 2,
-  allTagsModalSearchLabel,
-  allTagsModalSearchPlaceholderText,
-  allTagsModalTitle,
-  showAllTagsLabel,
-  actionBarItems: 3,
-  actionBarOverflowAriaLabel,
-  hasCollapseHeaderToggle: true,
-  collapseHeaderIconDescription,
-  expandHeaderIconDescription,
-};
+export const fullyLoadedAndSome = prepareStory(Template, {
+  storyName: 'Page header with long values and many items',
+  args: {
+    title: 3,
+    subtitle: longSubtitle,
+    breadcrumbs: 3,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 3,
+    pageActionsOverflowLabel,
+    children: 2,
+    navigation: 2,
+    tags: 2,
+    allTagsModalSearchLabel,
+    allTagsModalSearchPlaceholderText,
+    allTagsModalTitle,
+    showAllTagsLabel,
+    actionBarItems: 3,
+    actionBarOverflowAriaLabel,
+    hasCollapseHeaderToggle: true,
+    collapseHeaderIconDescription,
+    expandHeaderIconDescription,
+  },
+});
 
 // Template for demo.
 // eslint-disable-next-line react/prop-types
@@ -615,19 +625,20 @@ const TemplateDemo = ({ children, ...props }) => {
   );
 };
 
-export const demo = TemplateDemo.bind({});
-demo.storyName = 'Page header in context';
-demo.args = {
-  title: 5,
-  subtitle: demoSubtitle,
-  breadcrumbs: 4,
-  breadcrumbOverflowAriaLabel,
-  pageActions: 4,
-  pageActionsOverflowLabel,
-  children: 3,
-  navigation: 3,
-  tags: 3,
-  actionBarItems: 4,
-  actionBarOverflowAriaLabel,
-  disableBreadcrumbScroll: true,
-};
+export const demo = prepareStory(TemplateDemo, {
+  storyName: 'Page header in context',
+  args: {
+    title: 5,
+    subtitle: demoSubtitle,
+    breadcrumbs: 4,
+    breadcrumbOverflowAriaLabel,
+    pageActions: 4,
+    pageActionsOverflowLabel,
+    children: 3,
+    navigation: 3,
+    tags: 3,
+    actionBarItems: 4,
+    actionBarOverflowAriaLabel,
+    disableBreadcrumbScroll: true,
+  },
+});

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -11,6 +11,7 @@ import styles from './_storybook-styles.scss'; // import index in case more file
 import { TrashCan16, Edit16 } from '@carbon/icons-react';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { ProductiveCard } from '.';
 import mdx from './ProductiveCard.mdx';
 import { action } from '@storybook/addon-actions';
@@ -83,71 +84,79 @@ const Template = (opts) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultProps,
-};
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+  },
+});
 
-export const WithCaption = Template.bind({});
-WithCaption.args = {
-  ...defaultProps,
-  caption: 'caption',
-};
+export const WithCaption = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    caption: 'caption',
+  },
+});
 
-export const WithLabel = Template.bind({});
-WithLabel.args = {
-  ...defaultProps,
-  label: 'Label',
-};
+export const WithLabel = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    label: 'Label',
+  },
+});
 
-export const LabelOnly = Template.bind({});
-LabelOnly.args = {
-  ...defaultProps,
-  title: '',
-  label: 'Label',
-  actionsPlacement: 'bottom',
-  primaryButtonText: 'Ghost button',
-};
+export const LabelOnly = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    title: '',
+    label: 'Label',
+    actionsPlacement: 'bottom',
+    primaryButtonText: 'Ghost button',
+  },
+});
 
-export const WithOverflow = Template.bind({});
-WithOverflow.args = {
-  ...defaultProps,
-  overflowActions: [
-    {
-      id: '1',
-      itemText: 'Edit',
-      onClick: () => action('on click'),
-      onKeyDown: () => action('on keydown'),
-    },
-    {
-      id: '2',
-      itemText: 'Delete',
-      onClick: () => action('on click'),
-      onKeyDown: () => action('on keydown'),
-    },
-  ],
-};
+export const WithOverflow = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    overflowActions: [
+      {
+        id: '1',
+        itemText: 'Edit',
+        onClick: () => action('on click'),
+        onKeyDown: () => action('on keydown'),
+      },
+      {
+        id: '2',
+        itemText: 'Delete',
+        onClick: () => action('on click'),
+        onKeyDown: () => action('on keydown'),
+      },
+    ],
+  },
+});
 
-export const SupplementalBottomBar = Template.bind({});
-SupplementalBottomBar.args = {
-  ...defaultProps,
-  primaryButtonText: 'Ghost button',
-};
+export const SupplementalBottomBar = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    primaryButtonText: 'Ghost button',
+  },
+});
 
-export const ComplexBottomBar = Template.bind({});
-ComplexBottomBar.args = {
-  ...defaultProps,
-  primaryButtonText: 'Ghost button',
-  actionsPlacement: 'bottom',
-  title: '',
-  label: 'label',
-};
+export const ComplexBottomBar = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    primaryButtonText: 'Ghost button',
+    actionsPlacement: 'bottom',
+    title: '',
+    label: 'label',
+  },
+});
 
-export const Clickable = Template.bind({});
-Clickable.args = {
-  ...defaultProps,
-  onClick: () => action('on click'),
-  onKeyDown: () => action('on keydown'),
-  primaryButtonText: 'Ghost button',
-  actionIcons: [],
-};
+export const Clickable = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    onClick: () => action('on click'),
+    onKeyDown: () => action('on keydown'),
+    primaryButtonText: 'Ghost button',
+    actionIcons: [],
+  },
+});

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
@@ -13,6 +13,7 @@ import { getStorybookPrefix } from '../../../config';
 import { RemoveModal } from '.';
 import mdx from './RemoveModal.mdx';
 const storybookPrefix = getStorybookPrefix(pkg, RemoveModal.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/${RemoveModal.displayName}`,
@@ -59,26 +60,29 @@ const TemplateWithState = (args) => {
   );
 };
 
-export const Standard = TemplateWithState.bind({});
-Standard.args = {
-  ...defaultProps,
-  body: `Removing ${resourceName} will permanently remove the configuration. This action cannot be undone.`,
-  title: 'Confirm removal',
-  primaryButtonText: 'Remove',
-  label: `Remove ${resourceName}`,
-};
+export const Standard = prepareStory(TemplateWithState, {
+  args: {
+    ...defaultProps,
+    body: `Removing ${resourceName} will permanently remove the configuration. This action cannot be undone.`,
+    title: 'Confirm removal',
+    primaryButtonText: 'Remove',
+    label: `Remove ${resourceName}`,
+  },
+});
 
-export const RemovePattern = Template.bind({});
-RemovePattern.args = {
-  ...defaultProps,
-  body: `Removing ${resourceName} will permanently remove the configuration. This action cannot be undone.`,
-  title: 'Confirm removal',
-  primaryButtonText: 'Remove',
-  label: `Remove ${resourceName}`,
-};
+export const RemovePattern = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    body: `Removing ${resourceName} will permanently remove the configuration. This action cannot be undone.`,
+    title: 'Confirm removal',
+    primaryButtonText: 'Remove',
+    label: `Remove ${resourceName}`,
+  },
+});
 
-export const DeletePattern = Template.bind({});
-DeletePattern.args = {
-  ...defaultProps,
-  textConfirmation: true,
-};
+export const DeletePattern = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    textConfirmation: true,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
@@ -14,6 +14,7 @@ import mdx from './Saving.mdx';
 import wait from '../../global/js/utils/wait';
 import { TextArea } from 'carbon-components-react';
 const storybookPrefix = getStorybookPrefix(pkg, Saving.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/${Saving.displayName}`,
@@ -99,16 +100,18 @@ const ManualTemplate = (opts) => {
   );
 };
 
-export const Auto = AutoTemplate.bind({});
-Auto.args = {
-  ...defaultProps,
-  type: 'auto',
-};
+export const Auto = prepareStory(AutoTemplate, {
+  args: {
+    ...defaultProps,
+    type: 'auto',
+  },
+});
 
-export const Manual = ManualTemplate.bind({});
-Manual.args = {
-  ...defaultProps,
-  type: 'manual',
-  failText: 'Failed to save. Try again?',
-  secondaryButtonText: 'Cancel',
-};
+export const Manual = prepareStory(ManualTemplate, {
+  args: {
+    ...defaultProps,
+    type: 'manual',
+    failText: 'Failed to save. Try again?',
+    secondaryButtonText: 'Cancel',
+  },
+});

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -36,6 +36,7 @@ import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
 import { SidePanel, deprecatedProps } from './SidePanel';
 import mdx from './SidePanel.mdx';
 const storybookPrefix = getStorybookPrefix(pkg, SidePanel.displayName);
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/${SidePanel.displayName}`,
@@ -384,95 +385,106 @@ const SlideInTemplate = ({ actions, ...args }) => {
   );
 };
 
-export const SlideOver = SlideOverTemplate.bind({});
-SlideOver.args = {
-  includeOverlay: true,
-  actions: 0,
-  ...defaultStoryProps,
-};
+export const SlideOver = prepareStory(SlideOverTemplate, {
+  args: {
+    includeOverlay: true,
+    actions: 0,
+    ...defaultStoryProps,
+  },
+});
 
-export const SlideIn = SlideInTemplate.bind({});
-SlideIn.args = {
-  placement: 'right',
-  slideIn: true,
-  selectorPageContent: '#cloud-and-cognitive-page-content',
-  actions: 0,
-  ...defaultStoryProps,
-};
+export const SlideIn = prepareStory(SlideInTemplate, {
+  args: {
+    placement: 'right',
+    slideIn: true,
+    selectorPageContent: '#cloud-and-cognitive-page-content',
+    actions: 0,
+    ...defaultStoryProps,
+  },
+});
 
-export const WithActionToolbar = SlideOverTemplate.bind({});
-WithActionToolbar.args = {
-  actionToolbarButtons: [
-    {
-      label: 'Copy',
-      icon: Copy20,
-      onActionToolbarButtonClick: () => {},
+export const WithActionToolbar = prepareStory(SlideOverTemplate, {
+  args: {
+    actionToolbarButtons: [
+      {
+        label: 'Copy',
+        icon: Copy20,
+        onActionToolbarButtonClick: () => {},
+      },
+      {
+        label: 'Settings',
+        icon: Settings20,
+        onActionToolbarButtonClick: () => {},
+      },
+      {
+        label: 'Delete',
+        icon: Delete20,
+        onActionToolbarButtonClick: () => {},
+      },
+    ],
+    ...defaultStoryProps,
+  },
+});
+
+export const PanelWithSecondStep = prepareStory(StepTemplate, {
+  args: {
+    actions: 0,
+    includeOverlay: true,
+    currentStep: 1,
+    ...defaultStoryProps,
+  },
+});
+
+export const SpecifyElementToHaveInitialFocus = prepareStory(
+  SlideOverTemplate,
+  {
+    args: {
+      actions: 0,
+      selectorPrimaryFocus: '#side-panel-story-text-input-a',
+      ...defaultStoryProps,
     },
-    {
-      label: 'Settings',
-      icon: Settings20,
-      onActionToolbarButtonClick: () => {},
-    },
-    {
-      label: 'Delete',
-      icon: Delete20,
-      onActionToolbarButtonClick: () => {},
-    },
-  ],
-  ...defaultStoryProps,
-};
+  }
+);
 
-export const PanelWithSecondStep = StepTemplate.bind({});
-PanelWithSecondStep.args = {
-  actions: 0,
-  includeOverlay: true,
-  currentStep: 1,
-  ...defaultStoryProps,
-};
+export const WithMinimalContent = prepareStory(SlideOverTemplate, {
+  args: {
+    ...defaultStoryProps,
+    actions: 0,
+    minimalContent: true,
+  },
+});
 
-export const SpecifyElementToHaveInitialFocus = SlideOverTemplate.bind({});
-SpecifyElementToHaveInitialFocus.args = {
-  actions: 0,
-  selectorPrimaryFocus: '#side-panel-story-text-input-a',
-  ...defaultStoryProps,
-};
+export const WithStaticTitle = prepareStory(SlideOverTemplate, {
+  args: {
+    ...defaultStoryProps,
+    actions: 0,
+    animateTitle: false,
+    includeOverlay: true,
+  },
+});
 
-export const WithMinimalContent = SlideOverTemplate.bind({});
-WithMinimalContent.args = {
-  ...defaultStoryProps,
-  actions: 0,
-  minimalContent: true,
-};
-
-export const WithStaticTitle = SlideOverTemplate.bind({});
-WithStaticTitle.args = {
-  ...defaultStoryProps,
-  actions: 0,
-  animateTitle: false,
-  includeOverlay: true,
-};
-
-export const WithStaticTitleAndActionToolbar = SlideOverTemplate.bind({});
-WithStaticTitleAndActionToolbar.args = {
-  ...defaultStoryProps,
-  actions: 0,
-  animateTitle: false,
-  includeOverlay: true,
-  actionToolbarButtons: [
-    {
-      label: 'Copy',
-      icon: Copy20,
-      onActionToolbarButtonClick: () => {},
-    },
-    {
-      label: 'Settings',
-      icon: Settings20,
-      onActionToolbarButtonClick: () => {},
-    },
-    {
-      label: 'Delete',
-      icon: Delete20,
-      onActionToolbarButtonClick: () => {},
-    },
-  ],
-};
+export const WithStaticTitleAndActionToolbar = prepareStory(SlideOverTemplate, {
+  args: {
+    ...defaultStoryProps,
+    actions: 0,
+    animateTitle: false,
+    includeOverlay: true,
+    actionToolbarButtons: [
+      {
+        label: 'Copy',
+        icon: Copy20,
+        onActionToolbarButtonClick: () => {},
+      },
+      {
+        label: 'Settings',
+        icon: Settings20,
+        onActionToolbarButtonClick: () => {},
+      },
+      {
+        label: 'Delete',
+        icon: Delete20,
+        onActionToolbarButtonClick: () => {},
+      },
+    ],
+  },
+});

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
@@ -13,6 +13,7 @@ import mdx from './StatusIcon.mdx';
 import styles from './_storybook-styles.scss'; // import storybook which includes component and additional storybook styles
 import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, 'StatusIcon');
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
   title: `${storybookPrefix}/StatusIcon`,
@@ -68,7 +69,8 @@ const Template = (args) => {
   return <StatusIcon {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultProps,
-};
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
@@ -10,6 +10,7 @@ import React from 'react';
 import { types as tagTypes } from 'carbon-components-react/es/components/Tag/Tag';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { TagSet } from '.';
 import mdx from './TagSet.mdx';
 
@@ -160,22 +161,25 @@ const Template = (argsIn) => {
   );
 };
 
-export const FiveTags = Template.bind({});
-FiveTags.args = {
-  tags: tags,
-  containerWidth: 500,
-};
+export const FiveTags = prepareStory(Template, {
+  args: {
+    tags: tags,
+    containerWidth: 500,
+  },
+});
 
-export const ManyTags = Template.bind({});
-ManyTags.args = {
-  tags: manyTags,
-  containerWidth: 500,
-  ...overflowAndModalStrings,
-};
+export const ManyTags = prepareStory(Template, {
+  args: {
+    tags: manyTags,
+    containerWidth: 500,
+    ...overflowAndModalStrings,
+  },
+});
 
-export const HundredsOfTags = Template.bind({});
-HundredsOfTags.args = {
-  tags: hundredsOfTags,
-  containerWidth: 500,
-  ...overflowAndModalStrings,
-};
+export const HundredsOfTags = prepareStory(Template, {
+  args: {
+    tags: hundredsOfTags,
+    containerWidth: 500,
+    ...overflowAndModalStrings,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -33,6 +33,7 @@ import {
 import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, Tearsheet.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
@@ -285,70 +286,75 @@ const StackedTemplate = ({ actions, ...args }) => {
 };
 
 // Stories
-export const tearsheet = Template.bind({});
-tearsheet.storyName = 'Tearsheet';
-tearsheet.args = {
-  closeIconDescription,
-  description,
-  onClose: action('onClose called'),
-  title,
-  actions: 6,
-};
+export const tearsheet = prepareStory(Template, {
+  storyName: 'Tearsheet',
+  args: {
+    closeIconDescription,
+    description,
+    onClose: action('onClose called'),
+    title,
+    actions: 6,
+  },
+});
 
-export const withNavigation = Template.bind({});
-withNavigation.storyName = 'Tearsheet with navigation';
-withNavigation.args = {
-  closeIconDescription,
-  description,
-  label,
-  navigation: tabs,
-  onClose: action('onClose called'),
-  title,
-  actions: 6,
-};
+export const withNavigation = prepareStory(Template, {
+  storyName: 'Tearsheet with navigation',
+  args: {
+    closeIconDescription,
+    description,
+    label,
+    navigation: tabs,
+    onClose: action('onClose called'),
+    title,
+    actions: 6,
+  },
+});
 
-export const withInfluencer = Template.bind({});
-withInfluencer.storyName = 'Tearsheet with influencer';
-withInfluencer.args = {
-  closeIconDescription,
-  description,
-  influencer,
-  influencerPosition: 'left',
-  influencerWidth: 'narrow',
-  onClose: action('onClose called'),
-  title,
-  verticalPosition: 'normal',
-  actions: 6,
-};
+export const withInfluencer = prepareStory(Template, {
+  storyName: 'Tearsheet with influencer',
+  args: {
+    closeIconDescription,
+    description,
+    influencer,
+    influencerPosition: 'left',
+    influencerWidth: 'narrow',
+    onClose: action('onClose called'),
+    title,
+    verticalPosition: 'normal',
+    actions: 6,
+  },
+});
 
-export const fullyLoaded = Template.bind({});
-fullyLoaded.storyName = 'Tearsheet with all header items and influencer';
-fullyLoaded.args = {
-  closeIconDescription,
-  description,
-  hasCloseIcon: true,
-  headerActions: 2,
-  influencer,
-  influencerPosition: 'left',
-  influencerWidth: 'narrow',
-  label,
-  navigation: tabs,
-  onClose: action('onClose called'),
-  title,
-  verticalPosition: 'normal',
-  actions: 0,
-};
+export const fullyLoaded = prepareStory(Template, {
+  storyName: 'Tearsheet with all header items and influencer',
+  args: {
+    closeIconDescription,
+    description,
+    hasCloseIcon: true,
+    headerActions: 2,
+    influencer,
+    influencerPosition: 'left',
+    influencerWidth: 'narrow',
+    label,
+    navigation: tabs,
+    onClose: action('onClose called'),
+    title,
+    verticalPosition: 'normal',
+    actions: 0,
+  },
+});
 
 // eslint-disable-next-line react/prop-types
-export const stacked = StackedTemplate.bind({});
-stacked.storyName = 'Stacking tearsheets';
-stacked.args = {
-  headerActions: 2,
-  closeIconDescription,
-  description,
-  height: 'lower',
-  influencer,
-  label,
-  preventCloseOnClickOutside: true,
-  actions: 6,
-};
+export const stacked = prepareStory(StackedTemplate, {
+  storyName: 'Stacking tearsheets',
+  args: {
+    headerActions: 2,
+    closeIconDescription,
+    description,
+    height: 'lower',
+    influencer,
+    label,
+    preventCloseOnClickOutside: true,
+    actions: 6,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -25,6 +25,7 @@ import {
 import { getStorybookPrefix } from '../../../config';
 const storybookPrefix = getStorybookPrefix(pkg, TearsheetNarrow.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
@@ -213,36 +214,39 @@ const StackedTemplate = ({ actions, ...args }) => {
 };
 
 // Stories
-export const tearsheetNarrow = Template.bind({});
-tearsheetNarrow.storyName = 'Narrow tearsheet';
-tearsheetNarrow.args = {
-  closeIconDescription,
-  description,
-  onClose: action('onClose called'),
-  title,
-  actions: 6,
-};
+export const tearsheetNarrow = prepareStory(Template, {
+  storyName: 'Narrow tearsheet',
+  args: {
+    closeIconDescription,
+    description,
+    onClose: action('onClose called'),
+    title,
+    actions: 6,
+  },
+});
 
-export const fullyLoaded = Template.bind({});
-fullyLoaded.storyName = 'Narrow tearsheet with all header items';
-fullyLoaded.args = {
-  closeIconDescription,
-  description,
-  hasCloseIcon: true,
-  label,
-  onClose: action('onClose called'),
-  title,
-  verticalPosition: 'normal',
-  actions: 0,
-};
+export const fullyLoaded = prepareStory(Template, {
+  storyName: 'Narrow tearsheet with all header items',
+  args: {
+    closeIconDescription,
+    description,
+    hasCloseIcon: true,
+    label,
+    onClose: action('onClose called'),
+    title,
+    verticalPosition: 'normal',
+    actions: 0,
+  },
+});
 
-export const stacked = StackedTemplate.bind({});
-stacked.storyName = 'Stacking narrow tearsheets';
-stacked.args = {
-  closeIconDescription,
-  description,
-  height: 'lower',
-  label,
-  preventCloseOnClickOutside: true,
-  actions: 6,
-};
+export const stacked = prepareStory(StackedTemplate, {
+  storyName: 'Stacking narrow tearsheets',
+  args: {
+    closeIconDescription,
+    description,
+    height: 'lower',
+    label,
+    preventCloseOnClickOutside: true,
+    actions: 6,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.stories.js
@@ -13,11 +13,12 @@ import { getStorybookPrefix } from '../../../config';
 import { TearsheetShell, deprecatedProps } from './TearsheetShell';
 const storybookPrefix = getStorybookPrefix(pkg, TearsheetShell.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
+import { prepareStory } from '../../global/js/utils/story-helper';
 
 import mdx from './TearsheetShell.mdx';
 
 export default {
-  title: `${storybookPrefix}/Tearsheets/${TearsheetShell.displayName}`,
+  title: `${storybookPrefix}/${TearsheetShell.displayName}`,
   component: TearsheetShell,
   parameters: { controls: { expanded: true }, styles, docs: { page: mdx } },
   argTypes: getDeprecatedArgTypes(deprecatedProps),
@@ -43,17 +44,19 @@ const Template = (args) => {
 };
 
 // Stories
-export const AllAttributesSet = Template.bind({});
-AllAttributesSet.args = {
-  closeIconDescription,
-  height: 'normal',
-  // onClose: () => false,
-  open: true,
-  preventCloseOnClickOutside: true,
-  size: 'narrow',
-};
+export const AllAttributesSet = prepareStory(Template, {
+  args: {
+    closeIconDescription,
+    height: 'normal',
+    // onClose: () => false,
+    open: true,
+    preventCloseOnClickOutside: true,
+    size: 'narrow',
+  },
+});
 
-export const NoAttributesSet = Template.bind({});
-NoAttributesSet.args = {
-  size: 'wide',
-};
+export const NoAttributesSet = prepareStory(Template, {
+  args: {
+    size: 'wide',
+  },
+});

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
@@ -9,6 +9,7 @@ import React from 'react';
 import { UserProfileImage } from '.';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import mdx from './UserProfileImage.mdx';
 import image from './headshot.png'; // cspell:disable-line
 import styles from './_storybook.scss'; // import storybook which includes component and additional storybook styles
@@ -59,37 +60,42 @@ const Template = (args) => {
   return <UserProfileImage {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  ...defaultArgs,
-  kind: 'user',
-  tooltipText: 'Thomas Watson',
-};
+export const Default = prepareStory(Template, {
+  args: {
+    ...defaultArgs,
+    kind: 'user',
+    tooltipText: 'Thomas Watson',
+  },
+});
 
-export const WithGroupIcon = Template.bind({});
-WithGroupIcon.args = {
-  ...defaultArgs,
-  kind: 'group',
-};
+export const WithGroupIcon = prepareStory(Template, {
+  args: {
+    ...defaultArgs,
+    kind: 'group',
+  },
+});
 
-export const WithInitials = Template.bind({});
-WithInitials.args = {
-  ...defaultArgs,
-  initials: 'thomas j. watson',
-  tooltipText: 'Thomas Watson',
-};
+export const WithInitials = prepareStory(Template, {
+  args: {
+    ...defaultArgs,
+    initials: 'thomas j. watson',
+    tooltipText: 'Thomas Watson',
+  },
+});
 
-export const WithImage = Template.bind({});
-WithImage.args = {
-  ...defaultArgs,
-  image,
-  imageDescription: 'image here',
-};
+export const WithImage = prepareStory(Template, {
+  args: {
+    ...defaultArgs,
+    image,
+    imageDescription: 'image here',
+  },
+});
 
-export const WithImageAndTooltip = Template.bind({});
-WithImageAndTooltip.args = {
-  ...defaultArgs,
-  image,
-  imageDescription: 'image here',
-  tooltipText: 'Display Name',
-};
+export const WithImageAndTooltip = prepareStory(Template, {
+  args: {
+    ...defaultArgs,
+    image,
+    imageDescription: 'image here',
+    tooltipText: 'Display Name',
+  },
+});

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
@@ -11,6 +11,7 @@ import React, { useState, useCallback } from 'react';
 import { Navigation } from './preview-components';
 import { pkg } from '../../settings';
 import { getStorybookPrefix } from '../../../config';
+import { prepareStory } from '../../global/js/utils/story-helper';
 import { WebTerminal } from '.';
 import mdx from './WebTerminal.mdx';
 import { documentationLinks } from './preview-components/documentationLinks';
@@ -49,11 +50,13 @@ const Template = (args) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Default = prepareStory(Template, {
+  args: {},
+});
 
-export const WithDocumentationLinks = Template.bind({});
-WithDocumentationLinks.args = { documentationLinks };
+export const WithDocumentationLinks = prepareStory(Template, {
+  args: { documentationLinks },
+});
 
 export default {
   title: `${storybookPrefix}/${WebTerminal.displayName}`,

--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -1,0 +1,25 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+/**
+ * A helper function to prepare storybook stories for export. This function
+ * binds the template, adds the supplied fields, and also inserts a sequence
+ * number so that stories can then be sorted into declared order reliably.
+ * @param template the story template render function
+ * @param options an object containing fields to be added to the bound
+ * template, such as `args`, `storyName`, etc.
+ * @returns A bound template with the option fields applied.
+ */
+let sequence = 0;
+const bindTarget = {};
+export const prepareStory = (template, options) => {
+  const result = Object.assign(template.bind(bindTarget), options);
+  result.parameters ??= {};
+  result.parameters.ccsSettings ??= {};
+  result.parameters.ccsSettings.sequence = sequence++;
+  return result;
+};

--- a/packages/core/.storybook/preview.js
+++ b/packages/core/.storybook/preview.js
@@ -99,7 +99,8 @@ const parameters = {
       } else {
         // from storybook doc example https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy
         return a[1].kind === b[1].kind
-          ? 0
+          ? (a[1]?.parameters?.ccsSettings?.sequence || 0) -
+              (b[1]?.parameters?.ccsSettings?.sequence || 0)
           : a[1].id.localeCompare(b[1].id, undefined, { numeric: true });
       }
     },


### PR DESCRIPTION
Closes #1071 

The export order of stories is not a robust cue for story sort order, and in particular is currently scrambled by Webpack which produces a dictionary of exports sorted alphabetically. Added a helper function `prepareStory` for exporting stories, which binds the template, applies story properties, and additionally injects an incremented sequence number. Expanded the story sort function to use the sequence number to sort stories. This effectively produces the export order story sort, but in a robust and assured way rather than relying on the export list being preserved during bundling and optimisation operations.

#### What did you change?

Added story-helper.js, updated preview.js for storybook, and updated stories for every component to use the helper function.

#### How did you test and verify your work?

Ran storybook.
