### PR TITLE
fix(CreateSidePanel): title and subtitle padding is correct now

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateSidePanel/_create-side-panel.scss
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/_create-side-panel.scss
@@ -8,8 +8,17 @@
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+@import '../SidePanel/side-panel-variables';
 
 @import 'carbon-components/scss/components/button/button';
+
+$sizes: (
+  extra-small: $extra-small-panel-size,
+  small: $small-panel-size,
+  medium: $medium-panel-size,
+  large: $large-panel-size,
+  max: $max-panel-size,
+);
 
 @mixin create-side-panel {
   $block-class: #{$pkg-prefix}--create-side-panel;
@@ -20,18 +29,23 @@
     padding-right: calc(20% - #{$spacing-05});
   }
 
-  .#{$block-class}.#{$side-panel-block-class}__container
-    .#{$side-panel-block-class}__title-text {
-    padding-right: calc(20% - #{$spacing-05});
-    margin-bottom: $spacing-02;
-  }
-
-  .#{$block-class}.#{$side-panel-block-class}__container
-    .#{$side-panel-block-class}__subtitle-text {
-    padding-right: calc(20% - #{$spacing-05});
-    padding-bottom: $spacing-05;
-    border-bottom: 1px solid $ui-03;
-    color: $text-02;
+  @each $size, $value in $sizes {
+    .#{$block-class}.#{$side-panel-block-class}__container--#{$size}
+      .#{$side-panel-block-class}__title-text {
+      width: calc(#{$value} - #{$spacing-05});
+      // stylelint-disable-next-line carbon/layout-token-use
+      padding-right: calc((#{$value} * 0.2) - #{$spacing-05});
+      margin-bottom: $spacing-02;
+    }
+    .#{$block-class}.#{$side-panel-block-class}__container--#{$size}
+      .#{$side-panel-block-class}__subtitle-text {
+      width: calc(#{$value} - #{$spacing-05});
+      // stylelint-disable-next-line carbon/layout-token-use
+      padding-right: calc((#{$value} * 0.2) - #{$spacing-05});
+      padding-bottom: $spacing-05;
+      border-bottom: 1px solid $ui-03;
+      color: $text-02;
+    }
   }
 
   .#{$block-class}__form {

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel-variables.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel-variables.scss
@@ -1,0 +1,12 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+$extra-small-panel-size: 16rem;
+$small-panel-size: 20rem;
+$medium-panel-size: 30rem;
+$large-panel-size: 40rem;
+$max-panel-size: 75%;

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -9,18 +9,13 @@
 @import '../../global/styles/project-settings';
 @import 'carbon-components/scss/globals/grid/grid';
 @import '@carbon/motion/scss/motion.scss';
+@import './side-panel-variables';
 
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/inline-loading/inline-loading';
 
 $block-class: #{$pkg-prefix}--side-panel;
 $action-set-block-class: #{$pkg-prefix}--action-set;
-
-$extra-small-panel-size: 16rem;
-$small-panel-size: 20rem;
-$medium-panel-size: 30rem;
-$large-panel-size: 40rem;
-$max-panel-size: 75%; // set max-width on max panels to 75%
 
 @mixin sidePanelEntranceRight($size: $medium-panel-size) {
   @keyframes sidePanelEntranceRight {


### PR DESCRIPTION
Contributes to https://ibm-casdesign.slack.com/archives/G01PUCL3V8R/p1627365838044100

Looks like the title and subtitle on the create side panel were not getting the proper padding, I have made some updates so this behaves as expected. Because of the positioning of the title/subtitle, the previous implementation was calculating 20% of the window, not of the panel.

#### What did you change?
`_create-side-panel.scss`
`_side-panel.scss`
`_side-panel-variables.scss`
#### How did you test and verify your work?
Storybook

_Incorrect_
![Screen Shot 2021-07-27 at 9 15 07 AM](https://user-images.githubusercontent.com/10215203/127159766-38d122cc-1bbd-4f6a-bb40-68ea672bb197.png)
_Correct_
<img width="482" alt="Screen Shot 2021-07-27 at 8 06 23 AM" src="https://user-images.githubusercontent.com/10215203/127159768-eea5ae8a-01bb-449e-9518-990d7ce394f1.png">
