### PR TITLE
chore: add storybook title canary tag

### DIFF
--- a/packages/core/.storybook/manager.js
+++ b/packages/core/.storybook/manager.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
+
 import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming/create';
 
@@ -14,4 +16,44 @@ addons.setConfig({
   theme: create({
     brandTitle: packageInfo.name,
   }),
+  sidebar: {
+    renderLabel: (item) => {
+      const parts = item.name.split('#');
+      const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+      switch (parts[1]) {
+        // if the name has #canary then render a 'Canary' tag on the right
+        case 'canary':
+          return (
+            <div
+              style={{
+                flex: '1 0 auto',
+                display: 'flex',
+                alignItems: 'stretch',
+                justifyContent: 'space-between',
+              }}>
+              {parts[0]}
+              <div
+                style={{
+                  background: dark ? '#555555' : '#e0e0e0',
+                  /* stylelint-disable-next-line carbon/type-token-use */
+                  fontSize: '11px',
+                  border: '.1px solid transparent',
+                  /* stylelint-disable-next-line carbon/layout-token-use */
+                  padding: '0 .5rem',
+                  /* stylelint-disable-next-line carbon/layout-token-use */
+                  margin: '0 .5em',
+                  borderRadius: '8px',
+                }}>
+                Canary
+              </div>
+            </div>
+          );
+
+        // if the name doesn't have a recognized # label, just render the name
+        default:
+          return parts[0];
+      }
+    },
+  },
 });


### PR DESCRIPTION
This PR adds the ability to turn on a "Canary" marker tag in storybook component titles by including "#canary" on the end of the generated title. NB this is not currently used, and the detail may be adjusted before it is, but it sets up the ability ready for when we do use it.

#### What did you change?

storybook config in `manager.js`

#### How did you test and verify your work?

Ran storybook. It makes no difference to the current storybook, but can be seen by adding #canary onto the end of an existing story file `title` field in the default export.