### PR TITLE
chore: consolidate helper functions for storybook titles and ids

### DIFF
--- a/.github/CANARY_STRUCTURE.md
+++ b/.github/CANARY_STRUCTURE.md
@@ -24,10 +24,10 @@ Only components that are to be used directly by our package consumers, those in
 As part of these changes the following also happened.
 
 - `pkgPrefix` is gone instead now import `pkg` and use `pkg.prefix`.
-- `getStorybookSlug` was added to `../../../config.js` to make building the
-  story slug simpler in `.mdx` files.
-- `getStorybookPrefix` was added to `../../../config.js` to make building your
-  story path simpler in story files.
+- `getStoryId` was added to `../../global/js/utils/story-helper.js` to make
+  building the story slug simpler in `.mdx` files.
+- `getStoryTitle` was added to `../../global/js/utils/story-helper.js` to make
+  building your story path simpler in story files.
 
 ## Canary structure
 

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.mdx
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { DISPLAY_NAME } from '.';
 
 # DISPLAY_NAME
@@ -20,7 +19,7 @@ import { DISPLAY_NAME } from '.';
 <!-- TODO: One example per designed use case. -->
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, DISPLAY_NAME.displayName, 'STYLE_NAME')} />
+  <Story id={getStoryId(DISPLAY_NAME.displayName, 'STYLE_NAME')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.stories.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.stories.js
@@ -9,19 +9,18 @@ import React from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { DISPLAY_NAME } from '.';
 import mdx from './DISPLAY_NAME.mdx';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, DISPLAY_NAME.displayName);
-
 export default {
-  title: `${storybookPrefix}/${DISPLAY_NAME.displayName}`,
+  title: getStoryTitle(DISPLAY_NAME.displayName),
   component: DISPLAY_NAME,
   // TODO: Define argTypes for props not represented by standard JS types.
   // argTypes: {

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.mdx
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.mdx
@@ -2,8 +2,7 @@
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 import { APIKeyModal } from './APIKeyModal';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 
 # APIKeyModal
 
@@ -20,7 +19,7 @@ To enable key editing you have to set the `edit` prop to true and supply any
 other edit related props with the relevant input.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, APIKeyModal.displayName, 'edit')} />
+  <Story id={getStoryId(APIKeyModal.displayName, 'edit')} />
 </Canvas>
 
 ## Custom steps
@@ -29,9 +28,7 @@ By default generate and edit only supply a name input for your key. If you need
 additional input you should use custom steps
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, APIKeyModal.displayName, 'custom-generate')}
-  />
+  <Story id={getStoryId(APIKeyModal.displayName, 'custom-generate')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -18,16 +18,17 @@ import {
 } from 'carbon-components-react';
 import { action } from '@storybook/addon-actions';
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { APIKeyModal } from '.';
 import mdx from './APIKeyModal.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, APIKeyModal.displayName);
 import wait from '../../global/js/utils/wait';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 
 export default {
-  title: `${storybookPrefix}/${APIKeyModal.displayName}`,
+  title: getStoryTitle(APIKeyModal.displayName),
   component: APIKeyModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.mdx
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { AboutModal } from '.';
 
 # AboutModal
@@ -23,7 +22,7 @@ immediately apparent to the user, with a clear and obvious path to completion.
 ## Example usage
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, AboutModal.displayName, 'fully-loaded')} />
+  <Story id={getStoryId(AboutModal.displayName, 'fully-loaded')} />
 </Canvas>
 
 ### Overriding the Carbon theme
@@ -46,9 +45,7 @@ Alternatively, the required Carbon theme can be set as above in a custom CSS
 class which is then applied to the AboutModal using the `className` prop.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, AboutModal.displayName, 'with-dark-theme')}
-  />
+  <Story id={getStoryId(AboutModal.displayName, 'with-dark-theme')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.stories.js
@@ -10,8 +10,10 @@
 import React, { useEffect, useState } from 'react';
 
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { AboutModal } from '.';
 
@@ -26,11 +28,10 @@ import jsLogo from './_story-assets/js-logo.png';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, AboutModal.displayName);
 const blockClass = `${pkg.prefix}--about-modal`;
 
 export default {
-  title: `${storybookPrefix}/${AboutModal.displayName}`,
+  title: getStoryTitle(AboutModal.displayName),
   component: AboutModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
@@ -10,16 +10,15 @@ import { action } from '@storybook/addon-actions';
 
 import { Bee16, Lightning16 } from '@carbon/icons-react';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
 import { ActionBar, deprecatedProps } from './ActionBar';
 
-const storybookPrefix = getStorybookPrefix(pkg, ActionBar.displayName);
-
 export default {
-  title: `${storybookPrefix}/${ActionBar.displayName}`,
+  title: getStoryTitle(ActionBar.displayName),
   component: ActionBar,
   argTypes: {
     ...getDeprecatedArgTypes(deprecatedProps),

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.stories.js
@@ -10,8 +10,10 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { ActionSet } from '.';
 import { actionsOptions, actionsLabels, actionsMapping } from './actions.js';
@@ -19,10 +21,9 @@ import { actionsOptions, actionsLabels, actionsMapping } from './actions.js';
 import styles from './_storybook-styles.scss';
 
 const blockClass = `${pkg.prefix}--action-set`;
-const storybookPrefix = getStorybookPrefix(pkg, ActionSet.displayName);
 
 export default {
-  title: `${storybookPrefix}/${ActionSet.displayName}`,
+  title: getStoryTitle(ActionSet.displayName),
   component: ActionSet,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.stories.js
@@ -8,18 +8,14 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
 import { BreadcrumbWithOverflow } from '.';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
-
-const storybookPrefix = getStorybookPrefix(
-  pkg,
-  BreadcrumbWithOverflow.displayName
-);
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${BreadcrumbWithOverflow.displayName}`,
+  title: getStoryTitle(BreadcrumbWithOverflow.displayName),
   component: BreadcrumbWithOverflow,
   argTypes: {
     containerWidth: {

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.mdx
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { ButtonMenu } from '.';
 
 # ButtonMenu
@@ -20,7 +19,7 @@ import { ButtonMenu } from '.';
 <!-- TODO: One example per designed use case. -->
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, ButtonMenu.displayName, 'button-menu')} />
+  <Story id={getStoryId(ButtonMenu.displayName, 'button-menu')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -9,9 +9,10 @@ import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
 import mdx from './ButtonMenu.mdx';
@@ -20,10 +21,8 @@ import styles from './_storybook-styles.scss';
 
 import { Add16 } from '@carbon/icons-react';
 
-const storybookPrefix = getStorybookPrefix(pkg, ButtonMenu.displayName);
-
 export default {
-  title: `${storybookPrefix}/${ButtonMenu.displayName}`,
+  title: getStoryTitle(ButtonMenu.displayName),
   component: ButtonMenu,
   // TODO: Define argTypes for props not represented by standard JS types.
   // argTypes: {

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
@@ -9,21 +9,16 @@ import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
-
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ButtonSetWithOverflow } from '.';
 
 // Carbon and package components we use.
 
-const storybookPrefix = getStorybookPrefix(
-  pkg,
-  ButtonSetWithOverflow.displayName
-);
-
 export default {
-  title: `${storybookPrefix}/${ButtonSetWithOverflow.displayName}`,
+  title: getStoryTitle(ButtonSetWithOverflow.displayName),
   component: ButtonSetWithOverflow,
   argTypes: {
     containerWidth: {

--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
@@ -8,18 +8,17 @@
 import CloudApp16 from '@carbon/icons-react/lib/cloud-app/16';
 import React from 'react';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { ComboButton, ComboButtonItem } from '..';
 
 import styles from './_combo-button.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, ComboButton.displayName);
-
 export default {
-  title: `${storybookPrefix}/${ComboButton.displayName}`,
+  title: getStoryTitle(ComboButton.displayName),
   component: ComboButton,
   subcomponents: {
     ComboButtonItem,

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.mdx
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { CreateFullPage } from '.';
 
 # CreateFullPage
@@ -20,7 +19,7 @@ This component is an example
 Here it is in use.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, CreateFullPage.displayName, 'boxed-set')} />
+  <Story id={getStoryId(CreateFullPage.displayName, 'boxed-set')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.stories.js
@@ -6,9 +6,10 @@
  */
 import React from 'react';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { CreateFullPage } from '.';
 import { CreateFullPageSection } from './CreateFullPageSection';
@@ -20,10 +21,8 @@ const storyClass = 'create-full-page-stories';
 
 import { TextInput, NumberInput } from 'carbon-components-react';
 
-const storybookPrefix = getStorybookPrefix(pkg, CreateFullPage.displayName);
-
 export default {
-  title: `${storybookPrefix}/${CreateFullPage.displayName}`,
+  title: getStoryTitle(CreateFullPage.displayName),
   component: CreateFullPage,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.mdx
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { CreateModal } from '.';
 
 # CreateModal
@@ -26,9 +25,7 @@ immediately apparent to the user, with a clear and obvious path to completion.
 Here it is in use.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, CreateModal.displayName, 'with-form-validation')}
-  />
+  <Story id={getStoryId(CreateModal.displayName, 'with-form-validation')} />
 </Canvas>
 
 ## Form validation

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.stories.js
@@ -20,16 +20,17 @@ import {
 } from 'carbon-components-react';
 
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { CreateModal } from '.';
 import mdx from './CreateModal.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, CreateModal.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
 export default {
-  title: `${storybookPrefix}/${CreateModal.displayName}`,
+  title: getStoryTitle(CreateModal.displayName),
   component: CreateModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.mdx
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { CreateSidePanel } from '.';
 
 # CreateSidePanel
@@ -27,7 +26,7 @@ clear and obvious path to completion.
 Here it is in use.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, CreateSidePanel.displayName, 'default')} />
+  <Story id={getStoryId(CreateSidePanel.displayName, 'default')} />
 </Canvas>
 
 ## Form validation

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.stories.js
@@ -22,21 +22,21 @@ import {
 } from 'carbon-components-react/lib/components/UIShell';
 
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { CreateSidePanel, deprecatedProps } from './CreateSidePanel';
 import mdx from './CreateSidePanel.mdx';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, CreateSidePanel.displayName);
-
 const blockClass = `${pkg.prefix}--create-side-panel`;
 
 export default {
-  title: `${storybookPrefix}/${CreateSidePanel.displayName}`,
+  title: getStoryTitle(CreateSidePanel.displayName),
   component: CreateSidePanel,
   argTypes: getDeprecatedArgTypes(deprecatedProps),
   parameters: {

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.mdx
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { CreateTearsheet } from '.';
 import createTearsheetGif from './storybook_assets/create_tearsheet.gif';
 import createTearsheetAnatomy from './storybook_assets/create_tearsheet_anatomy.jpg';
@@ -59,13 +58,7 @@ Tearsheet create flow example:
 ## Example usage
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      CreateTearsheet.displayName,
-      'multi-step-tearsheet'
-    )}
-  />
+  <Story id={getStoryId(CreateTearsheet.displayName, 'multi-step-tearsheet')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import styles from './_storybook-styles.scss';
 import { CreateTearsheet } from './CreateTearsheet';
 import { CreateTearsheetStep } from './CreateTearsheetStep';
@@ -15,10 +16,8 @@ import { MultiStepTearsheet } from './preview-components/MultiStepTearsheet';
 import { MultiStepWithSectionsTearsheet } from './preview-components/MultiStepWithSectionsTearsheet';
 import mdx from './CreateTearsheet.mdx';
 
-const storybookPrefix = getStorybookPrefix(pkg, CreateTearsheet.displayName);
-
 export default {
-  title: `${storybookPrefix}/${CreateTearsheet.displayName}`,
+  title: getStoryTitle(CreateTearsheet.displayName),
   component: CreateTearsheet,
   subcomponents: {
     CreateTearsheetStep,

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.mdx
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { CreateTearsheetNarrow } from '.';
 import narrowTearsheet from './storybook_assets/NarrowTearsheetAnatomy.jpg';
 
@@ -33,8 +32,7 @@ import narrowTearsheet from './storybook_assets/NarrowTearsheetAnatomy.jpg';
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       CreateTearsheetNarrow.displayName,
       'create-tearsheet-narrow'
     )}

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.stories.js
@@ -15,21 +15,18 @@ import {
   TextInput,
 } from 'carbon-components-react';
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { CreateTearsheetNarrow } from '.';
 import mdx from './CreateTearsheetNarrow.mdx';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(
-  pkg,
-  CreateTearsheetNarrow.displayName
-);
-
 export default {
-  title: `${storybookPrefix}/${CreateTearsheetNarrow.displayName}`,
+  title: getStoryTitle(CreateTearsheetNarrow.displayName),
   component: CreateTearsheetNarrow,
   // TODO: Define argTypes for props not represented by standard JS types.
   // argTypes: {

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { EmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,61 +19,31 @@ guidelines and documentation please refer to the links above.
 ### Default Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, EmptyState.displayName, 'default', 'emptystates')}
-  />
+  <Story id={getStoryId(EmptyState.displayName, 'default')} />
 </Canvas>
 
 ### Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      EmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(EmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### Empty state with action (Button with icon)
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      EmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(EmptyState.displayName, 'with-action-icon-button')} />
 </Canvas>
 
 ### Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      EmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(EmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### Empty state with action and link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      EmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(EmptyState.displayName, 'with-action-and-link')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
@@ -9,8 +9,10 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import mdx from './EmptyState.mdx';
 
 import {
@@ -25,11 +27,8 @@ import {
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, EmptyState.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/EmptyState`,
+  title: getStoryTitle(EmptyState.displayName),
   component: EmptyState,
   subcomponents: {
     ErrorEmptyState,

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { ErrorEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,79 +19,41 @@ guidelines and documentation please refer to the links above.
 ### Default Error Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(ErrorEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### Error Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
-    )}
+    id={getStoryId(ErrorEmptyState.displayName, 'with-dark-mode-illustration')}
   />
 </Canvas>
 
 ### Error Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(ErrorEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### Error Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
-    )}
+    id={getStoryId(ErrorEmptyState.displayName, 'with-action-icon-button')}
   />
 </Canvas>
 
 ### Error Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(ErrorEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### Error Empty state with action and link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      ErrorEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(ErrorEmptyState.displayName, 'with-action-and-link')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -9,18 +9,17 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './ErrorEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import { ErrorEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, ErrorEmptyState.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${ErrorEmptyState.displayName}`,
+  title: getStoryTitle(ErrorEmptyState.displayName),
   component: ErrorEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { NoDataEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,78 +19,42 @@ guidelines and documentation please refer to the links above.
 ### Default No data Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoDataEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### No data Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
-    )}
+    id={getStoryId(NoDataEmptyState.displayName, 'with-dark-mode-illustration')}
   />
 </Canvas>
 
 ### No data Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoDataEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### No data Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
-    )}
+    id={getStoryId(NoDataEmptyState.displayName, 'with-action-icon-button')}
   />
 </Canvas>
 
 ### No data Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoDataEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### No data Empty state with action and link
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoDataEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
+    id={getStoryId(NoDataEmptyState.displayName, 'with-action-and-link')}
   />
 </Canvas>
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -9,18 +9,17 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './NoDataEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import { NoDataEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, NoDataEmptyState.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${NoDataEmptyState.displayName}`,
+  title: getStoryTitle(NoDataEmptyState.displayName),
   component: NoDataEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { NoTagsEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,78 +19,42 @@ guidelines and documentation please refer to the links above.
 ### Default No tags Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoTagsEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### No tags Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
-    )}
+    id={getStoryId(NoTagsEmptyState.displayName, 'with-dark-mode-illustration')}
   />
 </Canvas>
 
 ### No tags Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoTagsEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### No tags Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
-    )}
+    id={getStoryId(NoTagsEmptyState.displayName, 'with-action-icon-button')}
   />
 </Canvas>
 
 ### No tags Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NoTagsEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### No tags Empty state with action and link
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NoTagsEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
+    id={getStoryId(NoTagsEmptyState.displayName, 'with-action-and-link')}
   />
 </Canvas>
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -9,18 +9,17 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './NoTagsEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import { NoTagsEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, NoTagsEmptyState.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${NoTagsEmptyState.displayName}`,
+  title: getStoryTitle(NoTagsEmptyState.displayName),
   component: NoTagsEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { NotFoundEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,25 +19,16 @@ guidelines and documentation please refer to the links above.
 ### Default Not Found Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotFoundEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotFoundEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### Not Found Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       NotFoundEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
+      'with-dark-mode-illustration'
     )}
   />
 </Canvas>
@@ -46,52 +36,28 @@ guidelines and documentation please refer to the links above.
 ### Not Found Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotFoundEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotFoundEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### Not Found Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NotFoundEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
-    )}
+    id={getStoryId(NotFoundEmptyState.displayName, 'with-action-icon-button')}
   />
 </Canvas>
 
 ### Not Found Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotFoundEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotFoundEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### Not Found Empty state with action and link
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NotFoundEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
+    id={getStoryId(NotFoundEmptyState.displayName, 'with-action-and-link')}
   />
 </Canvas>
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -9,17 +9,16 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './NotFoundEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 import { NotFoundEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, NotFoundEmptyState.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${NotFoundEmptyState.displayName}`,
+  title: getStoryTitle(NotFoundEmptyState.displayName),
   component: NotFoundEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { NotificationsEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,25 +19,16 @@ guidelines and documentation please refer to the links above.
 ### Default Notifications Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotificationsEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotificationsEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### Notifications Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       NotificationsEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
+      'with-dark-mode-illustration'
     )}
   />
 </Canvas>
@@ -46,25 +36,16 @@ guidelines and documentation please refer to the links above.
 ### Notifications Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotificationsEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotificationsEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### Notifications Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       NotificationsEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
+      'with-action-icon-button'
     )}
   />
 </Canvas>
@@ -72,26 +53,14 @@ guidelines and documentation please refer to the links above.
 ### Notifications Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      NotificationsEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(NotificationsEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### Notifications Empty state with action and link
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      NotificationsEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
+    id={getStoryId(NotificationsEmptyState.displayName, 'with-action-and-link')}
   />
 </Canvas>
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -9,20 +9,16 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './NotificationsEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 import { NotificationsEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(
-  pkg,
-  NotificationsEmptyState.displayName
-);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${NotificationsEmptyState.displayName}`,
+  title: getStoryTitle(NotificationsEmptyState.displayName),
   component: NotificationsEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../../settings';
-import { getStorybookSlug } from '../../../../config';
+import { getStoryId } from '../../../global/js/utils/story-helper';
 import { UnauthorizedEmptyState } from '.';
 // cspell:words emptystates
 
@@ -20,25 +19,16 @@ guidelines and documentation please refer to the links above.
 ### Default Unauthorized Empty state
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      UnauthorizedEmptyState.displayName,
-      'default',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(UnauthorizedEmptyState.displayName, 'default')} />
 </Canvas>
 
 ### Unauthorized Empty state with dark themed illustration
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       UnauthorizedEmptyState.displayName,
-      'with-dark-mode-illustration',
-      'emptystates'
+      'with-dark-mode-illustration'
     )}
   />
 </Canvas>
@@ -46,25 +36,16 @@ guidelines and documentation please refer to the links above.
 ### Unauthorized Empty state with action
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      UnauthorizedEmptyState.displayName,
-      'with-action',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(UnauthorizedEmptyState.displayName, 'with-action')} />
 </Canvas>
 
 ### Unauthorized Empty state with action (Button with icon)
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       UnauthorizedEmptyState.displayName,
-      'with-action-icon-button',
-      'emptystates'
+      'with-action-icon-button'
     )}
   />
 </Canvas>
@@ -72,26 +53,14 @@ guidelines and documentation please refer to the links above.
 ### Unauthorized Empty state with link
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      UnauthorizedEmptyState.displayName,
-      'with-link',
-      'emptystates'
-    )}
-  />
+  <Story id={getStoryId(UnauthorizedEmptyState.displayName, 'with-link')} />
 </Canvas>
 
 ### Unauthorized Empty state with action and link
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
-      UnauthorizedEmptyState.displayName,
-      'with-action-and-link',
-      'emptystates'
-    )}
+    id={getStoryId(UnauthorizedEmptyState.displayName, 'with-action-and-link')}
   />
 </Canvas>
 

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -9,20 +9,16 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Add20 } from '@carbon/icons-react';
 import mdx from './UnauthorizedEmptyState.mdx';
-import { pkg } from '../../../settings';
-import { getStorybookPrefix } from '../../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 import { UnauthorizedEmptyState } from '.';
 
 import styles from '../_index.scss';
 
-const storybookPrefix = getStorybookPrefix(
-  pkg,
-  UnauthorizedEmptyState.displayName
-);
-import { prepareStory } from '../../../global/js/utils/story-helper';
-
 export default {
-  title: `${storybookPrefix}/EmptyStates/${UnauthorizedEmptyState.displayName}`,
+  title: getStoryTitle(UnauthorizedEmptyState.displayName),
   component: UnauthorizedEmptyState,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.mdx
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { ExampleComponent } from '.';
 
 # ExampleComponent
@@ -20,9 +19,7 @@ This component is an example
 Here it is in use.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, ExampleComponent.displayName, 'boxed-set')}
-  />
+  <Story id={getStoryId(ExampleComponent.displayName, 'boxed-set')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.stories.js
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.stories.js
@@ -7,19 +7,18 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { ExampleComponent } from '.';
 import mdx from './ExampleComponent.mdx';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, ExampleComponent.displayName);
-
 export default {
-  title: `${storybookPrefix}/${ExampleComponent.displayName}`,
+  title: getStoryTitle(ExampleComponent.displayName),
   component: ExampleComponent,
   argTypes: {
     borderColor: { control: 'color' },

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.mdx
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { ExportModal } from '.';
 
 # ExportModal
@@ -14,9 +13,7 @@ import { ExportModal } from '.';
 ## Overview
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, ExportModal.displayName, 'with-success-message')}
-  />
+  <Story id={getStoryId(ExportModal.displayName, 'with-success-message')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
@@ -8,16 +8,16 @@
 import React, { useState } from 'react';
 import { Button } from 'carbon-components-react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ExportModal } from '.';
 import mdx from './ExportModal.mdx';
 import wait from '../../global/js/utils/wait';
-const storybookPrefix = getStorybookPrefix(pkg, ExportModal.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${ExportModal.displayName}`,
+  title: getStoryTitle(ExportModal.displayName),
   component: ExportModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.mdx
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.mdx
@@ -2,8 +2,7 @@
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 import { ExpressiveCard } from '.';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 
 # ExpressiveCard
 
@@ -17,9 +16,7 @@ match. For information on each implementation please refer to the
 [usage guidelines](https://pages.github.ibm.com/cdai-design/pal/components/card/overview).
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, ExpressiveCard.displayName, 'default', 'cards')}
-  />
+  <Story id={getStoryId(ExpressiveCard.displayName, 'default')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -10,16 +10,16 @@ import cx from 'classnames';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import { ArrowRight24, Cloud32 } from '@carbon/icons-react';
 import { AspectRatio } from 'carbon-components-react';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ExpressiveCard } from '.';
 import mdx from './ExpressiveCard.mdx';
 import { action } from '@storybook/addon-actions';
-const storybookPrefix = getStorybookPrefix(pkg, ExpressiveCard.displayName);
 
 export default {
-  title: `${storybookPrefix}/Cards/${ExpressiveCard.displayName}`,
+  title: getStoryTitle(ExpressiveCard.displayName),
   component: ExpressiveCard,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.stories.js
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import { pkg } from '../../../settings';
 import { HTTPError403 } from '.';
-import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, HTTPError403.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import page from './HTTPError403.mdx';
 import styles from '../_storybook-styles.scss';
 
 export default {
-  title: `${storybookPrefix}/HTTPErrors/${HTTPError403.displayName}`,
+  title: getStoryTitle(HTTPError403.displayName),
   component: HTTPError403,
   parameters: {
     docs: {

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.stories.js
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import { pkg } from '../../../settings';
 import { HTTPError404 } from '.';
-import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, HTTPError404.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import page from './HTTPError404.mdx';
 import styles from '../_storybook-styles.scss';
 
 export default {
-  title: `${storybookPrefix}/HTTPErrors/${HTTPError404.displayName}`,
+  title: getStoryTitle(HTTPError404.displayName),
   component: HTTPError404,
   parameters: {
     docs: {

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.stories.js
@@ -6,17 +6,17 @@
  */
 
 import React from 'react';
-import { pkg } from '../../../settings';
 import { HTTPErrorOther } from '.';
-import { getStorybookPrefix } from '../../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, HTTPErrorOther.displayName);
-import { prepareStory } from '../../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../global/js/utils/story-helper';
 
 import page from './HTTPErrorOther.mdx';
 import styles from '../_storybook-styles.scss';
 
 export default {
-  title: `${storybookPrefix}/HTTPErrors/${HTTPErrorOther.displayName}`,
+  title: getStoryTitle(HTTPErrorOther.displayName),
   component: HTTPErrorOther,
   parameters: {
     docs: {

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.mdx
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.mdx
@@ -1,8 +1,7 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { ImportModal } from '.';
 
 # ImportModal
@@ -16,7 +15,7 @@ import { ImportModal } from '.';
 ## Overview
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, ImportModal.displayName, 'standard')} />
+  <Story id={getStoryId(ImportModal.displayName, 'standard')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.stories.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.stories.js
@@ -9,15 +9,15 @@ import React, { useState } from 'react';
 import { Button } from 'carbon-components-react';
 import { action } from '@storybook/addon-actions';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ImportModal } from '.';
 import mdx from './ImportModal.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, ImportModal.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${ImportModal.displayName}`,
+  title: getStoryTitle(ImportModal.displayName),
   component: ImportModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.mdx
+++ b/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { LoadingBar } from '.';
 
 # LoadingBar
@@ -30,13 +29,13 @@ specified percentage to indicate current progress to the user.
 ### Indeterminate percentage
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, LoadingBar.displayName, 'indeterminate')} />
+  <Story id={getStoryId(LoadingBar.displayName, 'indeterminate')} />
 </Canvas>
 
 ### Determinate percentage
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, LoadingBar.displayName, 'determinate')} />
+  <Story id={getStoryId(LoadingBar.displayName, 'determinate')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.stories.js
+++ b/packages/cloud-cognitive/src/components/LoadingBar/LoadingBar.stories.js
@@ -6,22 +6,19 @@
  */
 
 import React from 'react';
-//import action to handle events if required.
-// import { action } from '@storybook/addon-actions';
 
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import { LoadingBar } from '.';
 import mdx from './LoadingBar.mdx';
 
 import styles from './_storybook-styles.scss';
 
-const storybookPrefix = getStorybookPrefix(pkg, LoadingBar.displayName);
-
 export default {
-  title: `${storybookPrefix}/${LoadingBar.displayName}`,
+  title: getStoryTitle(LoadingBar.displayName),
   component: LoadingBar,
   //Define argTypes for props not represented by standard JS types.
   parameters: {

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
@@ -10,12 +10,12 @@ import React, { useEffect, useState, useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Modal, RadioButton, RadioButtonGroup } from 'carbon-components-react';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ModifiedTabs } from '.';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-const storybookPrefix = getStorybookPrefix(pkg, ModifiedTabs.displayName);
 
 const commonStoryCode = {
   actionCloseTab: action('onCloseTab'),
@@ -35,7 +35,7 @@ const commonStoryCode = {
 };
 
 export default {
-  title: `${storybookPrefix}/${ModifiedTabs.displayName}`,
+  title: getStoryTitle(ModifiedTabs.displayName),
   component: ModifiedTabs,
   parameters: { styles },
 };

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.mdx
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { NotificationsPanel } from '.';
 
 # NotificationsPanel
@@ -19,9 +18,7 @@ and interact with them all in one place.
 See notification bell in global header above for interaction.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, NotificationsPanel.displayName, 'default')}
-  />
+  <Story id={getStoryId(NotificationsPanel.displayName, 'default')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
@@ -18,21 +18,21 @@ import {
 import { User20, Notification20 } from '@carbon/icons-react';
 import { white } from '@carbon/colors';
 import styles from './_storybook-styles.scss';
-import { pkg } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { UnreadNotificationBell } from './preview-components/UnreadNotificationBell';
 
 import { NotificationsPanel } from '.';
 
-import { getStorybookPrefix } from '../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, NotificationsPanel.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import mdx from './NotificationsPanel.mdx';
 import data from './NotificationsPanel_data';
 
 export default {
-  title: `${storybookPrefix}/${NotificationsPanel.displayName}`,
+  title: getStoryTitle(NotificationsPanel.displayName),
   component: NotificationsPanel,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { PageHeader } from '.';
 // cspell:ignore actionbar breadcrumbitems pageactions summarydetails
 
@@ -43,7 +42,7 @@ be used if only the breadcrumb, title, actions, and/or simple status are
 required.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-buttons')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-buttons')} />
 </Canvas>
 
 ### Page header with background
@@ -54,7 +53,7 @@ items. The page header with a background should be used if tabs, subtitles,
 and/or more global items are required.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-tabs')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-tabs')} />
 </Canvas>
 
 ### Page header with background (breadcrumb + actions toolbar included)
@@ -63,9 +62,7 @@ If the page header contains action icons, the default state includes a toolbar
 designated for the breadcrumbs and action icons.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, PageHeader.displayName, 'with-actions-toolbar')}
-  />
+  <Story id={getStoryId(PageHeader.displayName, 'with-actions-toolbar')} />
 </Canvas>
 
 ### Page header with background (breadcrumb + actions toolbar ONLY)
@@ -75,8 +72,7 @@ by just displaying the breadcrumb bar only.
 
 <Canvas>
   <Story
-    id={getStorybookSlug(
-      pkg,
+    id={getStoryId(
       PageHeader.displayName,
       'with-breadcrumb-actions-toolbar-only'
     )}
@@ -98,7 +94,7 @@ accommodate simple requirements, including page title only, or page title +
 buttons.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-title')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-title')} />
 </Canvas>
 
 #### With breadcrumbs
@@ -107,9 +103,7 @@ This variant of the page header accounts for page title, buttons, breadcrumbs,
 and occasionally icons and metadata.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, PageHeader.displayName, 'with-breadcrumbs')}
-  />
+  <Story id={getStoryId(PageHeader.displayName, 'with-breadcrumbs')} />
 </Canvas>
 
 #### With status indicator
@@ -118,7 +112,7 @@ Structured similarly to the examples above, this variant is for the inclusion of
 a page level status indicator.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-buttons')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-buttons')} />
 </Canvas>
 
 ### Examples with background
@@ -129,7 +123,7 @@ Tabs are positioned underneath the page title and sit flush at the base of the
 page header background.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-tabs')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-tabs')} />
 </Canvas>
 
 #### With tags
@@ -138,7 +132,7 @@ Tags are positioned underneath the page title and sit above the base of the page
 header background.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-tags')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-tags')} />
 </Canvas>
 
 #### With tabs & tags
@@ -147,9 +141,7 @@ If both tabs & tags need to be present, tabs should be remain left aligned with
 the page and tags reposition over to the right side of the screen.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, PageHeader.displayName, 'with-tabs-and-tags')}
-  />
+  <Story id={getStoryId(PageHeader.displayName, 'with-tabs-and-tags')} />
 </Canvas>
 
 #### With subtitle
@@ -159,7 +151,7 @@ with subtitles use the background to create hierarchy and to separate it from
 type placed within the page.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, PageHeader.displayName, 'with-subtitle')} />
+  <Story id={getStoryId(PageHeader.displayName, 'with-subtitle')} />
 </Canvas>
 
 #### With summary details
@@ -168,9 +160,7 @@ Page content with global page hierarchy can be placed above tabs within the page
 header. **This is just an example of an allowable zone for content.**
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, PageHeader.displayName, 'with-summary-details')}
-  />
+  <Story id={getStoryId(PageHeader.displayName, 'with-summary-details')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { pkg, carbon } from '../../settings';
+import { carbon } from '../../settings';
 
 import {
   Column,
@@ -37,10 +37,11 @@ import {
 import { ActionBarItem } from '../ActionBar';
 import { PageHeader, deprecatedProps } from './PageHeader';
 
-import { getStorybookPrefix } from '../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, PageHeader.displayName);
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 import { demoTableHeaders, demoTableData } from './PageHeaderDemo.data';
 
@@ -287,7 +288,7 @@ const title = {
 };
 
 export default {
-  title: `${storybookPrefix}/${PageHeader.displayName}`,
+  title: getStoryTitle(PageHeader.displayName),
   component: PageHeader,
   subcomponents: { ActionBarItem },
   parameters: { styles, layout: 'fullscreen', docs: { page: mdx } },

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.mdx
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.mdx
@@ -2,8 +2,7 @@
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 import { ProductiveCard } from '.';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 
 # ProductiveCard
 
@@ -17,9 +16,7 @@ match. For information on each implementation please refer to the
 [usage guidelines](https://pages.github.ibm.com/cdai-design/pal/components/card/overview).
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, ProductiveCard.displayName, 'default', 'cards')}
-  />
+  <Story id={getStoryId(ProductiveCard.displayName, 'default')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -9,16 +9,16 @@ import React from 'react';
 import cx from 'classnames';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import { TrashCan16, Edit16 } from '@carbon/icons-react';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { ProductiveCard } from '.';
 import mdx from './ProductiveCard.mdx';
 import { action } from '@storybook/addon-actions';
-const storybookPrefix = getStorybookPrefix(pkg, ProductiveCard.displayName);
 
 export default {
-  title: `${storybookPrefix}/Cards/${ProductiveCard.displayName}`,
+  title: getStoryTitle(ProductiveCard.displayName),
   component: ProductiveCard,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.mdx
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.mdx
@@ -1,8 +1,7 @@
 <!-- `position:fixed` cause rendering issues, so do not render the modal -->
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { RemoveModal } from '.';
 
 # RemoveModal
@@ -20,7 +19,7 @@ For additional usage guidelines and documentation please refer to the links
 above.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, RemoveModal.displayName, 'standard')} />
+  <Story id={getStoryId(RemoveModal.displayName, 'standard')} />
 </Canvas>
 
 ## High impact vs medium impact

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
@@ -8,15 +8,15 @@
 import React, { useState } from 'react';
 import { Button } from 'carbon-components-react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { RemoveModal } from '.';
 import mdx from './RemoveModal.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, RemoveModal.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${RemoveModal.displayName}`,
+  title: getStoryTitle(RemoveModal.displayName),
   component: RemoveModal,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/Saving/Saving.mdx
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.mdx
@@ -2,8 +2,7 @@
 
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
 import { Saving } from '.';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 
 # Saving
 
@@ -12,13 +11,13 @@ import { getStorybookSlug } from '../../../config';
 ## Manual type
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, Saving.displayName, 'manual')} />
+  <Story id={getStoryId(Saving.displayName, 'manual')} />
 </Canvas>
 
 ## Auto type
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, Saving.displayName, 'auto')} />
+  <Story id={getStoryId(Saving.displayName, 'auto')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.stories.js
@@ -7,17 +7,17 @@
 
 import React, { useState, useEffect } from 'react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { Saving } from '.';
 import mdx from './Saving.mdx';
 import wait from '../../global/js/utils/wait';
 import { TextArea } from 'carbon-components-react';
-const storybookPrefix = getStorybookPrefix(pkg, Saving.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${Saving.displayName}`,
+  title: getStoryTitle(Saving.displayName),
   component: Saving,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.mdx
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { SidePanel } from '.';
 
 # Side Panel
@@ -22,9 +21,7 @@ within them.
 ### Default SidePanel component
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, SidePanel.displayName, 'slide-over-medium')}
-  />
+  <Story id={getStoryId(SidePanel.displayName, 'slide-over-medium')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -30,16 +30,16 @@ import {
 } from 'carbon-components-react/lib/components/UIShell';
 import { Copy20, Delete20, Settings20 } from '@carbon/icons-react';
 import styles from './_storybook-styles.scss';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
 import { SidePanel, deprecatedProps } from './SidePanel';
 import mdx from './SidePanel.mdx';
-const storybookPrefix = getStorybookPrefix(pkg, SidePanel.displayName);
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/${SidePanel.displayName}`,
+  title: getStoryTitle(SidePanel.displayName),
   component: SidePanel,
   parameters: {
     styles,

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.mdx
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { StatusIcon } from '.';
 
 # StatusIcon
@@ -27,7 +26,7 @@ users to quickly assess and identify status and respond accordingly.
 ## Example usage
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, StatusIcon.displayName, 'default')} />
+  <Story id={getStoryId(StatusIcon.displayName, 'default')} />
 </Canvas>
 
 ## Accessibility

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.stories.js
@@ -8,15 +8,15 @@
 import React from 'react';
 
 import { StatusIcon } from '.';
-import { pkg } from '../../settings';
 import mdx from './StatusIcon.mdx';
 import styles from './_storybook-styles.scss'; // import storybook which includes component and additional storybook styles
-import { getStorybookPrefix } from '../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, 'StatusIcon');
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 export default {
-  title: `${storybookPrefix}/StatusIcon`,
+  title: getStoryTitle(StatusIcon.displayName),
   component: StatusIcon,
   argTypes: {
     kind: {

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.mdx
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { TagSet } from '.';
 
 # TagSet
@@ -24,20 +23,20 @@ how many additional labels exist and what they are.
 Here it is in use with no overflow. Change max-visible to see an overflow.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, TagSet.displayName, 'five-tags')} />
+  <Story id={getStoryId(TagSet.displayName, 'five-tags')} />
 </Canvas>
 
 Here it is with more than 10 tags.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, TagSet.displayName, 'many-tags')} />
+  <Story id={getStoryId(TagSet.displayName, 'many-tags')} />
 </Canvas>
 
 Here it is with hundreds of tags. This option offers a searchable modal to
 display all tags.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, TagSet.displayName, 'hundreds-of-tags')} />
+  <Story id={getStoryId(TagSet.displayName, 'hundreds-of-tags')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
@@ -9,12 +9,13 @@ import React from 'react';
 
 import { types as tagTypes } from 'carbon-components-react/es/components/Tag/Tag';
 import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { TagSet } from '.';
 import mdx from './TagSet.mdx';
 
-const storybookPrefix = getStorybookPrefix(pkg, TagSet.displayName);
 const blockClass = `${pkg.prefix}--tag-set`;
 const blockClassModal = `${blockClass}-modal`;
 
@@ -129,7 +130,7 @@ const overflowAndModalStrings = {
 };
 
 export default {
-  title: `${storybookPrefix}/${TagSet.displayName}`,
+  title: getStoryTitle(TagSet.displayName),
   component: TagSet,
   parameters: {
     docs: { page: mdx },

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.mdx
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { Tearsheet, TearsheetNarrow } from '.';
 import AnatomyImg from './_story-assets/tearsheet-anatomy.png';
 
@@ -41,27 +40,13 @@ Tearsheets may be stacked up to 3 levels deep.
 ### Wide tearsheet
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      Tearsheet.displayName,
-      'with-navigation',
-      'tearsheets'
-    )}
-  />
+  <Story id={getStoryId(Tearsheet.displayName, 'with-navigation')} />
 </Canvas>
 
 ### Narrow tearsheet
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      TearsheetNarrow.displayName,
-      'fully-loaded',
-      'tearsheets'
-    )}
-  />
+  <Story id={getStoryId(TearsheetNarrow.displayName, 'fully-loaded')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -30,17 +30,18 @@ import {
   actionsMapping,
 } from '../ActionSet/actions.js';
 
-import { getStorybookPrefix } from '../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, Tearsheet.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
 import mdx from './Tearsheet.mdx';
 
 export default {
-  title: `${storybookPrefix}/Tearsheets/${Tearsheet.displayName}`,
+  title: getStoryTitle(Tearsheet.displayName),
   component: Tearsheet,
   subcomponents: { TearsheetNarrow },
   parameters: { styles, docs: { page: mdx } },

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -22,17 +22,18 @@ import {
   actionsMapping,
 } from '../ActionSet/actions.js';
 
-import { getStorybookPrefix } from '../../../config';
-const storybookPrefix = getStorybookPrefix(pkg, TearsheetNarrow.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 
 import styles from './_storybook-styles.scss';
 
 import mdx from './Tearsheet.mdx';
 
 export default {
-  title: `${storybookPrefix}/Tearsheets/${TearsheetNarrow.displayName}`,
+  title: getStoryTitle(TearsheetNarrow.displayName),
   component: TearsheetNarrow,
   subcomponents: { Tearsheet },
   parameters: { styles, docs: { page: mdx } },

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.stories.js
@@ -8,17 +8,17 @@
 import React from 'react';
 
 import styles from './_storybook-styles.scss';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { TearsheetShell, deprecatedProps } from './TearsheetShell';
-const storybookPrefix = getStorybookPrefix(pkg, TearsheetShell.displayName);
 import { getDeprecatedArgTypes } from '../../global/js/utils/props-helper';
-import { prepareStory } from '../../global/js/utils/story-helper';
 
 import mdx from './TearsheetShell.mdx';
 
 export default {
-  title: `${storybookPrefix}/${TearsheetShell.displayName}`,
+  title: getStoryTitle(TearsheetShell.displayName),
   component: TearsheetShell,
   parameters: { controls: { expanded: true }, styles, docs: { page: mdx } },
   argTypes: getDeprecatedArgTypes(deprecatedProps),

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.mdx
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.mdx
@@ -1,11 +1,11 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs';
+import { getStoryId } from '../../global/js/utils/story-helper';
+import { UserProfileImage } from '.';
 
 ## User Profile Avatar
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, UserProfileImage.displayName, 'with-image')}
-  />
+  <Story id={getStoryId(UserProfileImage.displayName, 'with-image')} />
 </Canvas>
 
 ## Overview
@@ -17,7 +17,7 @@ a blue background.
 ### Default Avatar
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, UserProfileImage.displayName, 'default')} />
+  <Story id={getStoryId(UserProfileImage.displayName, 'default')} />
 </Canvas>
 
 ### Avatar with Group Icons
@@ -26,9 +26,7 @@ By passing in icon prop with a value of 'group', the avatar will display the
 group icon
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, UserProfileImage.displayName, 'with-group-icon')}
-  />
+  <Story id={getStoryId(UserProfileImage.displayName, 'with-group-icon')} />
 </Canvas>
 
 ### Avatar with Initials
@@ -38,9 +36,7 @@ down to the first and last initials of the display name. 'Thomas Watson' and
 'Thomas J. Watson' will both display 'TW' as the initials.
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(pkg, UserProfileImage.displayName, 'with-initials')}
-  />
+  <Story id={getStoryId(UserProfileImage.displayName, 'with-initials')} />
 </Canvas>
 
 <ArgsTable />

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.stories.js
@@ -7,14 +7,14 @@
 
 import React from 'react';
 import { UserProfileImage } from '.';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import mdx from './UserProfileImage.mdx';
 import image from './headshot.png'; // cspell:disable-line
 import styles from './_storybook.scss'; // import storybook which includes component and additional storybook styles
 
-const storybookPrefix = getStorybookPrefix(pkg, 'UserProfileImage');
 const defaultArgs = {
   backgroundColor: 'light-cyan',
   theme: 'light',
@@ -22,7 +22,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: `${storybookPrefix}/UserProfileImage`,
+  title: getStoryTitle(UserProfileImage.displayName),
   component: UserProfileImage,
   argTypes: {
     backgroundColor: {

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
@@ -1,6 +1,5 @@
 import { Story, ArgsTable, Canvas } from '@storybook/addon-docs';
-import { pkg } from '../../settings';
-import { getStorybookSlug } from '../../../config';
+import { getStoryId } from '../../global/js/utils/story-helper';
 import { WebTerminal } from '.';
 
 # WebTerminal
@@ -59,19 +58,13 @@ user desires to dismiss it they can click the close icon on the top right corner
 of the component.
 
 <Canvas>
-  <Story id={getStorybookSlug(pkg, WebTerminal.displayName, 'default')} />
+  <Story id={getStoryId(WebTerminal.displayName, 'default')} />
 </Canvas>
 
 ### With documentation links
 
 <Canvas>
-  <Story
-    id={getStorybookSlug(
-      pkg,
-      WebTerminal.displayName,
-      'with-documentation-links'
-    )}
-  />
+  <Story id={getStoryId(WebTerminal.displayName, 'with-documentation-links')} />
 </Canvas>
 
 ## Component API

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
@@ -9,13 +9,13 @@
 
 import React, { useState, useCallback } from 'react';
 import { Navigation } from './preview-components';
-import { pkg } from '../../settings';
-import { getStorybookPrefix } from '../../../config';
-import { prepareStory } from '../../global/js/utils/story-helper';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
 import { WebTerminal } from '.';
 import mdx from './WebTerminal.mdx';
 import { documentationLinks } from './preview-components/documentationLinks';
-const storybookPrefix = getStorybookPrefix(pkg, WebTerminal.displayName);
 
 import styles from './_storybook-styles.scss';
 
@@ -59,7 +59,7 @@ export const WithDocumentationLinks = prepareStory(Template, {
 });
 
 export default {
-  title: `${storybookPrefix}/${WebTerminal.displayName}`,
+  title: getStoryTitle(WebTerminal.displayName),
   parameters: {
     styles,
     docs: {

--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -5,6 +5,49 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+import { sanitize } from '@storybook/csf';
+import pkg from '../package-settings';
+
+// A set of title values, one for each component, that can be converted into
+// a structure story title or into an individual story id in slug form.
+const lib = 'Cloud & Cognitive';
+const storybookStructure = {
+  Tearsheet: `${lib}/$rci/Tearsheets/$comp$canaryTag`,
+  TearsheetNarrow: `${lib}/$rci/Tearsheets/$comp`,
+};
+
+/**
+ * A helper function to return the structured story title for a component.
+ * @param {string} componentName The name of the component.
+ * @returns The structured story title.
+ */
+export const getStoryTitle = (componentName) => {
+  const replacements = {
+    $rci: pkg.isComponentEnabled(componentName, true)
+      ? 'Released'
+      : pkg.isComponentPublic(componentName, true)
+      ? 'Canary'
+      : 'Internal',
+    $canaryTag: '',
+    $comp: componentName,
+  };
+
+  return Object.keys(replacements).reduce(
+    (result, token) => result.replaceAll(token, replacements[token]),
+    storybookStructure[componentName] || `${lib}/Lost + Found/$comp`
+  );
+};
+
+/**
+ * A helper function to return the slug (structured path name reduced to lower
+ * case text and hyphens) which identifies individual story instances.
+ * @param {string} componentName The name of the component.
+ * @param {string} scenario The scenario name, also as a slug.
+ * @returns The story id.
+ */
+export const getStoryId = (componentName, scenario) =>
+  `${sanitize(getStoryTitle(componentName))}--${scenario}`;
+
 /**
  * A helper function to prepare storybook stories for export. This function
  * binds the template, adds the supplied fields, and also inserts a sequence

--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -12,8 +12,59 @@ import pkg from '../package-settings';
 // a structure story title or into an individual story id in slug form.
 const lib = 'Cloud & Cognitive';
 const storybookStructure = {
-  Tearsheet: `${lib}/$rci/Tearsheets/$comp$canaryTag`,
+  AboutModal: `${lib}/$rci/$comp`,
+  ActionBar: `${lib}/$rci/$comp`,
+  ActionSet: `${lib}/$rci/$comp`,
+  APIKeyModal: `${lib}/$rci/$comp`,
+  BreadcrumbWithOverflow: `${lib}/$rci/$comp`,
+  ButtonMenu: `${lib}/$rci/$comp`,
+  ButtonSetWithOverflow: `${lib}/$rci/$comp`,
+
+  // cards
+  ExpressiveCard: `${lib}/$rci/Cards/$comp`,
+  ProductiveCard: `${lib}/$rci/Cards/$comp`,
+
+  ComboButton: `${lib}/$rci/$comp`,
+  CreateFullPage: `${lib}/$rci/$comp`,
+  CreateModal: `${lib}/$rci/$comp`,
+  CreateSidePanel: `${lib}/$rci/$comp`,
+  CreateTearsheet: `${lib}/$rci/$comp`,
+  CreateTearsheetNarrow: `${lib}/$rci/$comp`,
+
+  // empty states
+  EmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  ErrorEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  NoDataEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  NoTagsEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  NotFoundEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  NotificationsEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+  UnauthorizedEmptyState: `${lib}/$rci/EmptyStates/$comp`,
+
+  ExampleComponent: `${lib}/$rci/$comp`,
+  ExportModal: `${lib}/$rci/$comp`,
+
+  // HTTP errors
+  HTTPError403: `${lib}/$rci/HTTPErrors/$comp`,
+  HTTPError404: `${lib}/$rci/HTTPErrors/$comp`,
+  HTTPErrorOther: `${lib}/$rci/HTTPErrors/$comp`,
+
+  ImportModal: `${lib}/$rci/$comp`,
+  LoadingBar: `${lib}/$rci/$comp`,
+  ModifiedTabs: `${lib}/$rci/$comp`,
+  NotificationsPanel: `${lib}/$rci/$comp`,
+  PageHeader: `${lib}/$rci/$comp`,
+  RemoveModal: `${lib}/$rci/$comp`,
+  Saving: `${lib}/$rci/$comp`,
+  SidePanel: `${lib}/$rci/$comp`,
+  StatusIcon: `${lib}/$rci/$comp`,
+  TagSet: `${lib}/$rci/$comp`,
+  UserProfileImage: `${lib}/$rci/$comp`,
+  WebTerminal: `${lib}/$rci/$comp`,
+
+  // tearsheets
+  Tearsheet: `${lib}/$rci/Tearsheets/$comp`,
   TearsheetNarrow: `${lib}/$rci/Tearsheets/$comp`,
+  TearsheetShell: `${lib}/$rci/$comp`,
 };
 
 /**
@@ -28,7 +79,6 @@ export const getStoryTitle = (componentName) => {
       : pkg.isComponentPublic(componentName, true)
       ? 'Canary'
       : 'Internal',
-    $canaryTag: '',
     $comp: componentName,
   };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "@storybook/builder-webpack5": "^6.3.6",
     "@storybook/components": "^6.3.6",
     "@storybook/core-events": "^6.3.6",
+    "@storybook/csf": "^0.0.1",
     "@storybook/manager-webpack5": "^6.3.6",
     "@storybook/react": "^6.3.6",
     "@storybook/theming": "^6.3.6",


### PR DESCRIPTION
This PR adds a couple of new helper functions in story-helpers.js to create story titles and ids. This simplifies the calls, and consolidates the function so that all the storybook folder structure is captured in the helper function and none of it is hard-coded into individual story files as it was before. This produces no change, but means it will be much simpler to reorganise the story folders in the future.

#### What did you change?

Added new functions to `story-helpers.js` and updated all story files.

#### How did you test and verify your work?

Ran storybook. It makes no discernible change.