### PR TITLE
fix(CreateTearsheet): story component updates

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -248,7 +248,7 @@ export let CreateTearsheet = forwardRef(
           key: 'create-tearsheet-action-button-cancel',
           label: cancelButtonText,
           onClick: onUnmount,
-          kind: shouldViewAll ? 'secondary' : 'ghost',
+          kind: 'ghost',
         });
         buttons.push({
           key: 'create-tearsheet-action-button-submit',

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -59,7 +59,6 @@ export const MultiStepTearsheet = () => {
         backButtonText="Back"
         nextButtonText="Next"
         description="Specify details for the new topic you want to create"
-        label="This is the label of the multi step tearsheet"
         title="Create topic"
         open={open}
         onClose={clearCreateData}
@@ -100,7 +99,7 @@ export const MultiStepTearsheet = () => {
             connection information, so make it something easy to recognize.
           </p>
           <TextInput
-            labelText="Topic name*"
+            labelText="Topic name"
             id="tearsheet-multi-step-story-text-input-multi-step-1"
             value={stepOneTextInputValue}
             placeholder="Enter topic name"
@@ -119,14 +118,14 @@ export const MultiStepTearsheet = () => {
             }}
           />
           <TextInput
-            labelText="Topic description"
+            labelText="Topic description (optional)"
             id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
             value={topicDescriptionValue}
             placeholder="Enter topic description"
             onChange={(event) => setTopicDescriptionValue(event.target.value)}
           />
           <TextInput
-            labelText="Topic version"
+            labelText="Topic version (optional)"
             id="tearsheet-multi-step-story-text-input-multi-step-1-input-3"
             value={topicVersionValue}
             placeholder="Enter topic version"

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
@@ -70,7 +70,6 @@ export const MultiStepWithSectionsTearsheet = () => {
         backButtonText="Back"
         nextButtonText="Next"
         description="Specify details for the new topic you want to create"
-        label="This is the label of the multi step tearsheet"
         title="Create topic"
         open={open}
         onClose={clearCreateData}
@@ -135,7 +134,7 @@ export const MultiStepWithSectionsTearsheet = () => {
               recognize.
             </p>
             <TextInput
-              labelText="Topic name*"
+              labelText="Topic name"
               id="tearsheet-multi-step-story-text-input-multi-step-1"
               value={stepOneTextInputValue}
               placeholder="Enter topic name"
@@ -154,14 +153,14 @@ export const MultiStepWithSectionsTearsheet = () => {
               }}
             />
             <TextInput
-              labelText="Topic description"
+              labelText="Topic description (optional)"
               id="tearsheet-multi-step-story-text-input-multi-step-1-input-2"
               value={topicDescriptionValue}
               placeholder="Enter topic description"
               onChange={(event) => setTopicDescriptionValue(event.target.value)}
             />
             <TextInput
-              labelText="Topic version"
+              labelText="Topic version (optional)"
               id="tearsheet-multi-step-story-text-input-multi-step-1-input-3"
               value={topicVersionValue}
               placeholder="Enter topic version"
@@ -178,7 +177,7 @@ export const MultiStepWithSectionsTearsheet = () => {
                 setSelectedTopicOwner(selectedItem)
               }
               selectedItem={selectedTopicOwner}
-              titleText="Topic owner"
+              titleText="Topic owner (optional)"
               warn={apiFailed}
               warnText="API request failed."
             />
@@ -248,7 +247,7 @@ export const MultiStepWithSectionsTearsheet = () => {
               }
             />
             <TextInput
-              labelText="Partition name*"
+              labelText="Partition name"
               id="tearsheet-multi-step-story-text-input-multi-step-3-input-1"
               value={partitionName}
               placeholder="Enter partition name"


### PR DESCRIPTION
Contributes to #1085 

Addresses 2 of the items in #1085 regarding the handling of optional form fields and removing an example label from the tearsheet.

#### What did you change?
`CreateTearsheet/preview-components/MultiStepTearsheet.js`
`CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js`
#### How did you test and verify your work?
Storybook