### PR TITLE
fix(SidePanel): add panel height to useEffect dependencies

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -64,6 +64,7 @@ export let SidePanel = React.forwardRef(
   ) => {
     const [shouldRender, setRender] = useState(open);
     const [animationComplete, setAnimationComplete] = useState(false);
+    const [panelHeight, setPanelHeight] = useState(0);
     const sidePanelRef = useRef();
     const sidePanelOverlayRef = useRef();
     const startTrapRef = useRef();
@@ -117,7 +118,8 @@ export let SidePanel = React.forwardRef(
     }, [actions, condensedActions, open, animationComplete]);
 
     /* istanbul ignore next */
-    const handleResize = () => {
+    const handleResize = (width, height) => {
+      setPanelHeight(height);
       const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
       const actionsContainer = getActionsContainerElement();
       let actionsHeight = actionsContainer.offsetHeight + 16; // add additional 1rem spacing to bottom padding
@@ -152,7 +154,7 @@ export let SidePanel = React.forwardRef(
         let sidePanelSubtitleElementHeight =
           sidePanelSubtitleElement?.offsetHeight || 0; // set default subtitle height if a subtitle is not provided to enable scrolling animation
 
-        const panelOuterHeight = sidePanelOuter?.offsetHeight;
+        const panelOuterHeight = panelHeight;
         const scrollSectionHeight = document.querySelector(
           `.${blockClass}__body-content`
         )?.offsetHeight;
@@ -170,7 +172,9 @@ export let SidePanel = React.forwardRef(
             sidePanelSubtitleElementHeight ||
           sidePanelSubtitleElementHeight === 0
             ? totalScrollingContentHeight - panelOuterHeight
-            : sidePanelSubtitleElementHeight < 0
+            : sidePanelSubtitleElementHeight;
+        sidePanelSubtitleElementHeight =
+          sidePanelSubtitleElementHeight < 0
             ? 16
             : sidePanelSubtitleElementHeight;
         /* istanbul ignore next */
@@ -296,7 +300,7 @@ export let SidePanel = React.forwardRef(
           `${sidePanelSubtitleElementHeight}px`
         );
       }
-    }, [open, animateTitle, animationComplete, shouldRender]);
+    }, [open, animateTitle, animationComplete, shouldRender, panelHeight]);
 
     // click outside functionality if `includeOverlay` prop is set
     useEffect(() => {


### PR DESCRIPTION
Contributes to #1056 

This PR addresses the issue @lily-peng found in #1056 where if the panel is open larger than the scrolling content, is then resized to include scrolling, the title animation would not behave as expected. This was because we needed a way to get the current panel height (not the panel height when it opened/first rendered).

I added a `panelHeight` state variable that receives it's value from the `useResizeDetector` hook, added this value to the useEffect that is animating the title as a dependency and now we always have the _current_ height of the side panel.

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook