### PR TITLE
feat(CreateTearsheet): add microinteraction to influencer menus

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -18,6 +18,7 @@ import {
   ProgressStep,
   Toggle,
 } from 'carbon-components-react';
+import { moderate02 } from '@carbon/motion';
 import {
   SideNav,
   SideNavItems,
@@ -71,6 +72,8 @@ export let CreateTearsheet = forwardRef(
     const [shouldViewAll, setShouldViewAll] = useState(false);
     const [currentStep, setCurrentStep] = useState(0);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [progressIndicatorState, setProgressIndicatorState] = useState('');
+    const [sideNavState, setSideNavState] = useState('');
     const [activeSectionIndex, setActiveSectionIndex] = useState(0);
     const previousState = usePreviousValue({ currentStep, open });
     const contentRef = useRef();
@@ -362,10 +365,36 @@ export let CreateTearsheet = forwardRef(
           }
         }
       });
-      if (shouldViewAll) {
-        return (
-          <div className={`${blockClass}__left-nav`}>
-            <SideNav expanded isFixedNav aria-label={sideNavAriaLabel}>
+      return (
+        <div className={`${blockClass}__left-nav`}>
+          {!shouldViewAll ? (
+            <ProgressIndicator
+              currentIndex={currentStep - 1}
+              spaceEqually
+              vertical
+              className={cx(`${blockClass}__progress-indicator`, {
+                [`${blockClass}__progress-indicator-opening`]:
+                  progressIndicatorState === 'opening',
+                [`${blockClass}__progress-indicator-closing`]:
+                  progressIndicatorState === 'closing',
+              })}>
+              {tearsheetStepComponents.map((child, stepIndex) => (
+                <ProgressStep
+                  label={child.props.title}
+                  key={stepIndex}
+                  secondaryLabel={child.props.secondaryLabel}
+                />
+              ))}
+            </ProgressIndicator>
+          ) : (
+            <SideNav
+              expanded
+              isFixedNav
+              aria-label={sideNavAriaLabel}
+              className={cx({
+                [`${blockClass}__side-nav-opening`]: sideNavState === 'opening',
+                [`${blockClass}__side-nav-closing`]: sideNavState === 'closing',
+              })}>
               <SideNavItems>
                 {tearsheetSectionComponents?.length &&
                   tearsheetSectionComponents.map(
@@ -400,24 +429,7 @@ export let CreateTearsheet = forwardRef(
                   )}
               </SideNavItems>
             </SideNav>
-          </div>
-        );
-      }
-      return (
-        <div className={`${blockClass}__left-nav`}>
-          <ProgressIndicator
-            currentIndex={currentStep - 1}
-            spaceEqually
-            vertical
-            className={`${blockClass}__progress-indicator`}>
-            {tearsheetStepComponents.map((child, stepIndex) => (
-              <ProgressStep
-                label={child.props.title}
-                key={stepIndex}
-                secondaryLabel={child.props.secondaryLabel}
-              />
-            ))}
-          </ProgressIndicator>
+          )}
         </div>
       );
     };
@@ -598,7 +610,19 @@ export let CreateTearsheet = forwardRef(
     };
 
     const handleViewAllToggle = (toggleState) => {
-      setShouldViewAll(toggleState);
+      if (toggleState) {
+        setProgressIndicatorState('closing');
+        setTimeout(() => {
+          setShouldViewAll(toggleState);
+          setSideNavState('opening');
+        }, moderate02);
+      } else {
+        setSideNavState('closing');
+        setTimeout(() => {
+          setShouldViewAll(toggleState);
+          setProgressIndicatorState('opening');
+        }, moderate02);
+      }
       setActiveSectionIndex(0);
       const createTearsheetContainer = document.querySelector(`.${blockClass}`);
       createTearsheetContainer.scrollTop = 0;

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.test.js
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { moderate02 } from '@carbon/motion';
 import { pkg, carbon } from '../../settings';
 import { CreateTearsheet } from './CreateTearsheet';
 import { CreateTearsheetStep } from './CreateTearsheetStep';
@@ -393,10 +394,12 @@ describe(CreateTearsheet.displayName, () => {
     const viewAllToggleElement = container.querySelector(
       `#${tearsheetBlockClass}__view-all-toggle`
     );
-    expect(viewAllToggleElement).toBeChecked();
-    expect(warn).toBeCalledWith(
-      `CreateTearsheet: You must have at least one CreateTearsheetSection component in a CreateTearsheetStep when using the 'includeViewAllToggle' prop.`
-    );
+    setTimeout(() => {
+      expect(viewAllToggleElement).toBeChecked();
+      expect(warn).toBeCalledWith(
+        `CreateTearsheet: You must have at least one CreateTearsheetSection component in a CreateTearsheetStep when using the 'includeViewAllToggle' prop.`
+      );
+    }, moderate02);
     rerender(
       <CreateTearsheet
         onRequestSubmit={jest.fn()}
@@ -498,7 +501,9 @@ describe(CreateTearsheet.displayName, () => {
     );
     const { click } = userEvent;
     click(screen.getByText(viewAllToggleLabelText));
-    expect(getByText(/Submit/g)).toHaveAttribute('disabled');
+    setTimeout(() => {
+      expect(getByText(/Submit/g)).toHaveAttribute('disabled');
+    }, moderate02);
   });
 
   it('should click one of the side navigation menu items that are displayed after clicking the view all toggle and call the scrollTo fn', () => {
@@ -541,11 +546,13 @@ describe(CreateTearsheet.displayName, () => {
       </CreateTearsheet>
     );
     click(screen.getByText(viewAllToggleLabelText));
-    const sideNavElement = screen.getByText(/test title 2/g, {
-      selector: `.${carbon.prefix}--side-nav__link-text`,
-    });
-    click(sideNavElement.parentElement);
-    expect(scrollToFn).toHaveBeenCalledTimes(1);
+    setTimeout(() => {
+      const sideNavElement = screen.getByText(/test title 2/g, {
+        selector: `.${carbon.prefix}--side-nav__link-text`,
+      });
+      click(sideNavElement.parentElement);
+      expect(scrollToFn).toHaveBeenCalledTimes(1);
+    }, moderate02);
   });
 
   it("should click one of the side navigation menu items that are displayed after clicking the view all toggle and produce a warning if the section's id is missing", () => {
@@ -575,14 +582,16 @@ describe(CreateTearsheet.displayName, () => {
       </CreateTearsheet>
     );
     click(screen.getByText(viewAllToggleLabelText));
-    const sideNavElement = screen.getByText(/test title 2/g, {
-      selector: `.${carbon.prefix}--side-nav__link-text`,
-    });
-    click(sideNavElement.parentElement);
-    expect(warn).toBeCalledWith(
-      `CreateTearsheet: CreateTearsheetSection is missing a required prop of 'id'`
-    );
-    jest.spyOn(console, 'error').mockRestore();
-    warn.mockRestore();
+    setTimeout(() => {
+      const sideNavElement = screen.getByText(/test title 2/g, {
+        selector: `.${carbon.prefix}--side-nav__link-text`,
+      });
+      click(sideNavElement.parentElement);
+      expect(warn).toBeCalledWith(
+        `CreateTearsheet: CreateTearsheetSection is missing a required prop of 'id'`
+      );
+      jest.spyOn(console, 'error').mockRestore();
+      warn.mockRestore();
+    }, moderate02);
   });
 });

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -11,6 +11,29 @@
 @import 'carbon-components/scss/components/progress-indicator/progress-indicator';
 
 @mixin create-tearsheet {
+  $influencerAnimationStart: calc(-1 * #{$spacing-05});
+  @keyframes influencerMenuEntrance {
+    0% {
+      opacity: 0;
+      // stylelint-disable-next-line carbon/layout-token-use
+      transform: translateX($influencerAnimationStart);
+    }
+    100% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+  @keyframes influencerMenuExit {
+    0% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+    100% {
+      opacity: 0;
+      // stylelint-disable-next-line carbon/layout-token-use
+      transform: translateX($influencerAnimationStart);
+    }
+  }
   @keyframes stepContentEntrance {
     0% {
       opacity: 0;
@@ -108,6 +131,32 @@
     margin: $spacing-06 calc(-1 * #{$spacing-08}) $spacing-07
       calc(-1 * #{$spacing-06});
     background-color: $ui-03;
+  }
+
+  .#{$block-class}__side-nav-opening,
+  .#{$block-class}__progress-indicator-opening {
+    // stylelint-disable-next-line carbon/motion-token-use
+    animation: influencerMenuEntrance $duration--moderate-02 1;
+    animation-fill-mode: forwards;
+    @include carbon--motion(entrance, productive);
+  }
+
+  .#{$block-class}__side-nav-closing,
+  .#{$block-class}__progress-indicator-closing {
+    // stylelint-disable-next-line carbon/motion-token-use
+    animation: influencerMenuExit $duration--moderate-02 1;
+    animation-fill-mode: forwards;
+    @include carbon--motion(exit, productive);
+  }
+
+  @media (prefers-reduced-motion) {
+    .#{$block-class}__side-nav-opening,
+    .#{$block-class}__progress-indicator-opening,
+    .#{$block-class}__side-nav-closing,
+    .#{$block-class}__progress-indicator-closing {
+      animation: none;
+      opacity: 1;
+    }
   }
 }
 


### PR DESCRIPTION
Contributes to #1085 

Adds microinteraction to the `CreateTearsheet` when you turn the "View all" toggle on and off. The progress indicator component and SideNav (from Carbon UI shell) will animate in and out respectively.

#### What did you change?
`CreateTearsheet.js`
`_create-tearsheet.scss`
#### How did you test and verify your work?
Storybook


https://user-images.githubusercontent.com/10215203/128032919-faaf5ffc-f879-4f6b-a941-591224554ab3.mov

