### PR TITLE
chore: add commentary for 'data-test-id' config setting

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -19,6 +19,9 @@ import toBeAccessible from './matchers/toBeAccessible';
 // `expect` can be extended using custom matchers as per https://jest-bot.github.io/jest/docs/expect.html#expectextendmatchers
 expect.extend({ toBeAccessible, toHaveNoAxeViolations });
 
+// Use 'data-test-id' as the attribute which the getByTestId queries look for.
+// (the default omits the second '-', but this upsets spell checkers and doesn't
+// match the camel-casing of the methods, so 'data-test-id' just seems better)
 configure({ testIdAttribute: 'data-test-id' });
 
 // Our test suite will throw an error if one of the below console methods are


### PR DESCRIPTION
I should really have included an explanatory comment for this otherwise mysterious config setting which affects how our tests need to use `getByTestId` and related queries.

#### What did you change?

Just added a comment to setupFilesAfterEnv.js.

#### How did you test and verify your work?

This change does not have any functional effect.