### PR TITLE
feat: ensure all component SCSS imports all dependencies

### DIFF
--- a/.github/REVIEWERS_GUIDELINES.md
+++ b/.github/REVIEWERS_GUIDELINES.md
@@ -94,13 +94,14 @@ public component has a flag in package-settings.js.
 `- [ ]` No linter warnings or errors are produced.\
 `- [ ]` Carbon tokens (theme, layout, motion) are used unless the design specifies
 otherwise.\
-`- [ ]` All components utilizing motion must include reduced-motion queries for accessibility purposes - [read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).\
-`- [ ]` Code is formatted according to prettier rules (no use of
-//prettier-ignore).\
+`- [ ]` All components utilizing motion must include reduced-motion queries for
+accessibility purposes -
+[read more here](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).\
+`- [ ]` Code is formatted according to prettier rules (no use of //prettier-ignore).\
 `- [ ]` Code is clear, maintainable and follows standard React practices and the
 [code guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md).\
-`- [ ]` Copyright header in every source file (js, css, scss etc.) with the
-appropriate years.
+`- [ ]` Copyright header in every source file (js, css, scss etc.) with the appropriate
+years.
 
 `###` Testing
 

--- a/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
@@ -10,8 +10,14 @@
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
-// TODO: @import(s) of Carbon settings and component styles and other
-// related component styles used by DISPLAY_NAME
+// Other Carbon settings.
+// TODO: add as required
+
+// DISPLAY_NAME uses the following Carbon components:
+// TODO: @import(s) of Carbon component styles used by DISPLAY_NAME
+
+// DISPLAY_NAME uses the following Cloud & Cognitive components:
+// TODO: @import(s) of Cloud & Cognitive component styles used by DISPLAY_NAME
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1273,48 +1273,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   margin: 0;
 }
 
-.exp--button-menu {
-  min-width: 160px;
-}
-
-.exp--button-menu .exp--button-menu__trigger {
-  width: 100%;
-  padding: 0 var(--cds-spacing-05, 1rem);
-}
-
-.exp--button-menu__options.bx--overflow-menu-options::after {
-  content: initial;
-}
-
-.exp--button-set-with-overflow.exp--button-set-with-overflow {
-  display: flex;
-}
-
-.exp--button-set-with-overflow .exp--button-set-with-overflow__space {
-  position: relative;
-  display: block;
-  width: 100%;
-  white-space: nowrap;
-}
-
-.exp--button-set-with-overflow .exp--button-set-with-overflow__button-container {
-  display: inline-flex;
-}
-
-.exp--button-set-with-overflow .exp--button-set-with-overflow__button-container--hidden {
-  position: absolute;
-  top: -100vh;
-  left: -100vw;
-  overflow: hidden;
-  max-width: 100vw;
-  pointer-events: none;
-  visibility: hidden;
-}
-
-.exp--button-set-with-overflow.exp--button-set-with-overflow--right {
-  justify-content: flex-end;
-}
-
 .exp--action-bar.exp--action-bar {
   display: block;
 }
@@ -1355,6 +1313,75 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 
 .exp--action-bar-overflow-items__options .exp--action-bar-overflow-items__item svg {
   margin: 0 var(--cds-spacing-02, 0.25rem);
+}
+
+.exp--breadcrumb-with-overflow.exp--breadcrumb-with-overflow {
+  display: block;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__space {
+  position: relative;
+  display: block;
+  width: 100%;
+  white-space: nowrap;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container.exp--breadcrumb-with-overflow__breadcrumb-container-with-items {
+  display: none;
+  width: 100%;
+}
+
+@media (min-width: 42rem) {
+  .exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container.exp--breadcrumb-with-overflow__breadcrumb-container-with-items {
+    display: inline-flex;
+  }
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container .bx--breadcrumb {
+  width: 100%;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container--hidden {
+  position: absolute;
+  top: -100vh;
+  left: -100vw;
+  overflow: hidden;
+  max-width: 100vw;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.exp--breadcrumb-with-overflow .bx--breadcrumb-item:last-child {
+  display: inline;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__displayed-breadcrumb:last-child {
+  display: inline;
+  overflow: hidden;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__displayed-breadcrumb:last-child .bx--link {
+  display: inline-block;
+  overflow: hidden;
+  width: 100%;
+  text-overflow: ellipsis;
+}
+
+.exp--breadcrumb-with-overflow .bx--link {
+  max-height: 18px;
+}
+
+.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-back-button.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
+  display: inline-flex;
+  margin-top: calc(-1 * var(--cds-spacing-04, 0.75rem));
+}
+
+@media (min-width: 42rem) {
+  .exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-back-button.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
+    display: none;
+  }
 }
 
 .exp--tag-set.exp--tag-set {
@@ -1487,35 +1514,35 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   box-shadow: inset 0 0 0 var(--cds-spacing-01, 0.125rem) var(--cds-focus, #0f62fe);
 }
 
-.exp--breadcrumb-with-overflow.exp--breadcrumb-with-overflow {
-  display: block;
+.exp--button-menu {
+  min-width: 160px;
 }
 
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__space {
+.exp--button-menu .exp--button-menu__trigger {
+  width: 100%;
+  padding: 0 var(--cds-spacing-05, 1rem);
+}
+
+.exp--button-menu__options.bx--overflow-menu-options::after {
+  content: initial;
+}
+
+.exp--button-set-with-overflow.exp--button-set-with-overflow {
+  display: flex;
+}
+
+.exp--button-set-with-overflow .exp--button-set-with-overflow__space {
   position: relative;
   display: block;
   width: 100%;
   white-space: nowrap;
 }
 
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container.exp--breadcrumb-with-overflow__breadcrumb-container-with-items {
-  display: none;
-  width: 100%;
+.exp--button-set-with-overflow .exp--button-set-with-overflow__button-container {
+  display: inline-flex;
 }
 
-@media (min-width: 42rem) {
-  .exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container.exp--breadcrumb-with-overflow__breadcrumb-container-with-items {
-    display: inline-flex;
-  }
-}
-
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container .bx--breadcrumb {
-  width: 100%;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-}
-
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-container--hidden {
+.exp--button-set-with-overflow .exp--button-set-with-overflow__button-container--hidden {
   position: absolute;
   top: -100vh;
   left: -100vw;
@@ -1525,35 +1552,8 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   visibility: hidden;
 }
 
-.exp--breadcrumb-with-overflow .bx--breadcrumb-item:last-child {
-  display: inline;
-}
-
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__displayed-breadcrumb:last-child {
-  display: inline;
-  overflow: hidden;
-}
-
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__displayed-breadcrumb:last-child .bx--link {
-  display: inline-block;
-  overflow: hidden;
-  width: 100%;
-  text-overflow: ellipsis;
-}
-
-.exp--breadcrumb-with-overflow .bx--link {
-  max-height: 18px;
-}
-
-.exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-back-button.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
-  display: inline-flex;
-  margin-top: calc(-1 * var(--cds-spacing-04, 0.75rem));
-}
-
-@media (min-width: 42rem) {
-  .exp--breadcrumb-with-overflow .exp--breadcrumb-with-overflow__breadcrumb-back-button.bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
-    display: none;
-  }
+.exp--button-set-with-overflow.exp--button-set-with-overflow--right {
+  justify-content: flex-end;
 }
 
 .exp--page-header.exp--page-header {
@@ -2094,6 +2094,52 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--remove-modal__body {
   padding-right: 20%;
   margin-bottom: var(--cds-spacing-05, 1rem);
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
+  }
 }
 
 .exp--saving__message {
@@ -3143,6 +3189,52 @@ path:nth-of-type(1),
 @media (prefers-reduced-motion) {
   .exp--status-icon--dark.exp--status-icon--dark-pending .exp--status-icon--dark.exp--status-icon--dark-in-progress {
     animation: none;
+  }
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p1 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes rotate-end-p2 {
+  100% {
+    transform: rotate(-360deg);
+  }
+}
+
+/* Stroke animations */
+@keyframes init-stroke {
+  0% {
+    stroke-dashoffset: 240;
+  }
+  100% {
+    stroke-dashoffset: 16;
+  }
+}
+
+@keyframes stroke-end {
+  0% {
+    stroke-dashoffset: 16;
+  }
+  100% {
+    stroke-dashoffset: 240;
+  }
+}
+
+@keyframes stroke {
+  100% {
+    stroke-dashoffset: 0;
   }
 }
 

--- a/packages/cloud-cognitive/src/components/APIKeyModal/_api-key-modal.scss
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/_api-key-modal.scss
@@ -5,13 +5,19 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// APIKeyModal uses the following Carbon components:
+// ComposedModal, ModalHeader, ModalFooter, ModalBody, TextInput,
+// InlineLoading, Form, Button
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/text-input/text-input';
 @import 'carbon-components/scss/components/inline-loading/inline-loading';
-@import 'carbon-components/scss/components/toggle/toggle';
+@import 'carbon-components/scss/components/form/form';
+@import 'carbon-components/scss/components/button/button';
 
 @mixin apikey-modal {
   $block-class: #{$pkg-prefix}--apikey-modal;

--- a/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
+++ b/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
@@ -10,11 +10,12 @@
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
-// Imports of Carbon settings and component styles and other
-// related component styles used by `AboutModal`.
+// Other Carbon settings.
 @import '@carbon/themes/scss/themes';
 @import 'carbon-components/scss/globals/scss/vars';
-@import 'carbon-components/scss/components/link/link';
+
+// AboutModal uses the following Carbon components:
+// ComposedModal, ModalHeader, ModalFooter, ModalBody, Tabs, Tab
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/tabs/tabs';
 

--- a/packages/cloud-cognitive/src/components/ActionBar/_action-bar.scss
+++ b/packages/cloud-cognitive/src/components/ActionBar/_action-bar.scss
@@ -9,13 +9,14 @@
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../../global/styles/mixins';
 
-// Imports of Carbon settings and component styles and other
-// related component styles used by ExampleComponent.
+// ActionBar uses the following Carbon components:
+// Button, OverflowMenu, OverflowMenuItem
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/overflow-menu/overflow-menu';
-@import 'carbon-components/scss/components/tooltip/tooltip';
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/_breadcrumb-with-overflow.scss
@@ -7,12 +7,14 @@
 
 // Standard imports.
 @import '@carbon/import-once/scss/import-once';
-@import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
+@import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../../global/styles/mixins';
 
-// Imports of Carbon settings and component styles and other
-// related component styles used by ExampleComponent.
+// BreadcrumbWithOverflow uses the following Carbon components:
+// Breadcrumb, BreadcrumbItem, OverflowMenu, OverflowMenuItem
 @import 'carbon-components/scss/components/breadcrumb/breadcrumb';
 @import 'carbon-components/scss/components/overflow-menu/overflow-menu';
 

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_button-set-with-overflow.scss
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_button-set-with-overflow.scss
@@ -4,12 +4,21 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../../global/styles/mixins';
 
+// ButtonSetWithOverflow uses the following Carbon components:
+// ButtonSet, Button
 @import 'carbon-components/scss/components/button/button';
-@import '../ButtonMenu/index';
+
+// ButtonSetWithOverflow uses the following Cloud & Cognitive components:
+// ButtonMenu, ButtonMenuItem
+@import '../ButtonMenu/button-menu';
 
 $block-class: #{$pkg-prefix}--button-set-with-overflow;
 

--- a/packages/cloud-cognitive/src/components/Card/_card.scss
+++ b/packages/cloud-cognitive/src/components/Card/_card.scss
@@ -5,10 +5,15 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// Card uses the following Carbon components:
+// Button, OverflowMenu, OverflowMenuItem
 @import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
 
 @mixin card {
   $block-class: #{$pkg-prefix}--card;

--- a/packages/cloud-cognitive/src/components/ContextHeader/_context-header.scss
+++ b/packages/cloud-cognitive/src/components/ContextHeader/_context-header.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 

--- a/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
@@ -5,11 +5,26 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// Other Carbon settings.
+@import 'carbon-components/scss/globals/grid/grid';
+
+// CreateFullPage uses the following Carbon components:
+// Grid, Row, Column, Form, ProgressIndicator, ProgressStep, Toggle,
+// ComposedModal, ModalHeader, ModalBody, ModalFooter, Button
+@import 'carbon-components/scss/components/form/form';
+@import 'carbon-components/scss/components/progress-indicator/progress-indicator';
+@import 'carbon-components/scss/components/toggle/toggle';
+@import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/button/button';
+
+// CreateFullPage uses the following Cloud & Cognitive components:
+// ActionSet
+@import '../ActionSet/action-set';
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/cloud-cognitive/src/components/CreateModal/_create-modal.scss
+++ b/packages/cloud-cognitive/src/components/CreateModal/_create-modal.scss
@@ -5,12 +5,19 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/themes/scss/themes';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import 'carbon-components/scss/globals/scss/_vars.scss';
+
+// CreateModal uses the following Carbon components:
+// ComposedModal, ModalHeader, ModalFooter, ModalBody, Form, Button
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/form/form';
+@import 'carbon-components/scss/components/button/button';
 
 @mixin create-modal {
   .#{$pkg-prefix}--create-modal {

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/_create-side-panel.scss
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/_create-side-panel.scss
@@ -5,12 +5,21 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../SidePanel/side-panel-variables';
 
-@import 'carbon-components/scss/components/button/button';
+// CreateSidePanel uses the following Carbon components:
+// Form
+@import 'carbon-components/scss/components/form/form';
+
+// CreateSidePanel uses the following Cloud & Cognitive components:
+// SidePanel
+@import '../SidePanel/side-panel';
 
 $sizes: (
   extra-small: $extra-small-panel-size,

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -5,10 +5,20 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// CreateTearsheet uses the following Carbon components:
+// ProgressIndicator, ProgressStep, Toggle, SideNav, SideNavItems, SideNavLink
 @import 'carbon-components/scss/components/progress-indicator/progress-indicator';
+@import 'carbon-components/scss/components/toggle/toggle';
+@import 'carbon-components/scss/components/ui-shell/side-nav';
+
+// CreateTearsheet uses the following Cloud & Cognitive components:
+// TearsheetShell
+@import '../Tearsheet/tearsheet';
 
 @mixin create-tearsheet {
   $influencerAnimationStart: calc(-1 * #{$spacing-05});

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/_create-tearsheet-narrow.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/_create-tearsheet-narrow.scss
@@ -10,6 +10,14 @@
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// CreateTearsheetNarrow uses the following Carbon components:
+// Form
+@import 'carbon-components/scss/components/form/form';
+
+// CreateTearsheetNarrow uses the following Cloud & Cognitive components:
+// TearsheetNarrow
+@import '../Tearsheet/tearsheet';
+
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin create-tearsheet-narrow {

--- a/packages/cloud-cognitive/src/components/EmptyStates/_empty-state.scss
+++ b/packages/cloud-cognitive/src/components/EmptyStates/_empty-state.scss
@@ -5,10 +5,13 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// Empty states use the following Carbon components:
+// Button, Link
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/link/link';
 

--- a/packages/cloud-cognitive/src/components/ExampleComponent/_example-component.scss
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/_example-component.scss
@@ -5,10 +5,13 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// ExampleComponent uses the following Carbon components:
+// Button, ButtonSet
 @import 'carbon-components/scss/components/button/button';
 
 // Define all component styles in a mixin which is then exported using

--- a/packages/cloud-cognitive/src/components/ExportModal/_export-modal.scss
+++ b/packages/cloud-cognitive/src/components/ExportModal/_export-modal.scss
@@ -5,14 +5,19 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// ExportModal uses the following Carbon components:
+// Button, ComposedModal, ModalHeader, ModalFooter, ModalBody, TextInput,
+// RadioButton, RadioButtonGroup, FormGroup, Loading
+@import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/text-input/text-input';
 @import 'carbon-components/scss/components/radio-button/radio-button';
+@import 'carbon-components/scss/components/form/form';
 @import 'carbon-components/scss/components/loading/loading';
-@import 'carbon-components/scss/components/button/button';
 
 @mixin export-modal {
   $block-class: #{$pkg-prefix}--export-modal;

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/_expressive-card.scss
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/_expressive-card.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-// An index file is most useful when you have multiple components
-
-// shared card styles can be found in the Card folder
-// in this case the expressive card is considered the default Card mode
-
+// ExpressiveCard uses the following Cloud & Cognitive components:
+// Card
 @import '../Card/card';

--- a/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
@@ -5,10 +5,13 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// HTTP errors use the following Carbon components:
+// Link
 @import 'carbon-components/scss/components/link/link';
 
 // Define all component styles in a mixin which is then exported using

--- a/packages/cloud-cognitive/src/components/ImportModal/_import-modal.scss
+++ b/packages/cloud-cognitive/src/components/ImportModal/_import-modal.scss
@@ -5,12 +5,17 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// ImportModal uses the following Carbon components:
+// ComposedModal, ModalHeader, ModalFooter, ModalBody,
+// FileUploaderDropContainer, FileUploaderItem, TextInput, Button
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/file-uploader/file-uploader';
 @import 'carbon-components/scss/components/text-input/text-input';
+@import 'carbon-components/scss/components/button/button';
 
 @mixin import-modal {
   $block-class: #{$pkg-prefix}--import-modal;

--- a/packages/cloud-cognitive/src/components/LoadingBar/_loading-bar.scss
+++ b/packages/cloud-cognitive/src/components/LoadingBar/_loading-bar.scss
@@ -10,8 +10,7 @@
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
-// Import(s) of Carbon settings and component styles and other
-// related component styles used by LoadingBar
+// Other Carbon settings.
 @import '@carbon/themes/scss/themes';
 @import 'carbon-components/scss/globals/scss/_vars.scss';
 

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/_modified-tabs.scss
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/_modified-tabs.scss
@@ -1,6 +1,10 @@
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/tooltip/tooltip';
+@import '../../global/styles/project-settings';
+
+// ModifiedTabs uses the following Carbon components:
+// Tabs, Tab
 @import 'carbon-components/scss/components/tabs/tabs';
 
 .modified-tabs .modified-tabs__tab-label {

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/_notifications-panel.scss
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/_notifications-panel.scss
@@ -5,16 +5,25 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '@carbon/themes/scss/themes';
 @import '@carbon/colors/scss/colors';
-@import '@carbon/motion/scss/motion.scss';
+@import '@carbon/motion/scss/motion';
 
+// NotificationsPanel uses the following Carbon components:
+// Button, Link, Toggle
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/link/link';
 @import 'carbon-components/scss/components/toggle/toggle';
+
+// NotificationsPanel uses the following Cloud & Cognitive components:
+// NotificationsEmptyState
+@import '../EmptyStates/empty-state';
 
 @mixin notifications-panel {
   $block-class: #{$pkg-prefix}--notifications-panel;

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -5,19 +5,28 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../../global/styles/mixins';
-
 @import 'carbon-components/scss/globals/grid/grid';
-@import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/content-switcher/content-switcher';
-@import 'carbon-components/scss/components/tabs/tabs';
 
+// PageHeader uses the following Carbon components:
+// BreadcrumbItem, Grid, Column, Row, Button, SkeletonText, Tag
+@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+@import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/skeleton/skeleton-text';
+@import 'carbon-components/scss/components/tag/tag';
+
+// PageHeader uses the following Cloud & Cognitive components:
+// ActionBar, BreadcrumbWithOverflow, TagSet, ButtonSetWithOverflow
+@import '../ActionBar/action-bar';
+@import '../BreadcrumbWithOverflow/breadcrumb-with-overflow';
+@import '../TagSet/tag-set';
 @import '../ButtonSetWithOverflow/button-set-with-overflow';
-@import '../ActionBar/index';
-@import '../TagSet/index';
-@import '../BreadcrumbWithOverflow/index';
 
 $block-class: #{$pkg-prefix}--page-header;
 $breadcrumb-block-class: #{$pkg-prefix}--breadcrumb-with-overflow;

--- a/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
@@ -5,12 +5,14 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
-// shared card styles can be found in the Card folder
-@import '../Card/card';
 
-@import 'carbon-components/scss/components/overflow-menu/overflow-menu';
+// ProductiveCard uses the following Cloud & Cognitive components:
+// Card
+@import '../Card/card';
 
 @mixin card-productive {
   $block-class: #{$pkg-prefix}--card;

--- a/packages/cloud-cognitive/src/components/RemoveModal/_remove-modal.scss
+++ b/packages/cloud-cognitive/src/components/RemoveModal/_remove-modal.scss
@@ -5,9 +5,13 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// RemoveModal uses the following Carbon components:
+// Button, ComposedModal, ModalHeader, ModalFooter, ModalBody, TextInput
 @import 'carbon-components/scss/components/button/button';
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/text-input/text-input';

--- a/packages/cloud-cognitive/src/components/Saving/_saving.scss
+++ b/packages/cloud-cognitive/src/components/Saving/_saving.scss
@@ -5,10 +5,15 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// Saving uses the following Carbon components:
+// Button, InlineLoading
 @import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/inline-loading/inline-loading';
 
 @mixin saving {
   $block-class: #{$pkg-prefix}--saving;

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -5,14 +5,23 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import 'carbon-components/scss/globals/grid/grid';
 @import '@carbon/motion/scss/motion.scss';
 @import './side-panel-variables';
 
+// SidePanel uses the following Carbon components:
+// Button
 @import 'carbon-components/scss/components/button/button';
-@import 'carbon-components/scss/components/inline-loading/inline-loading';
+
+// SidePanel uses the following Cloud & Cognitive components:
+// ActionSet
+@import '../ActionSet/action-set';
 
 $block-class: #{$pkg-prefix}--side-panel;
 $action-set-block-class: #{$pkg-prefix}--action-set;

--- a/packages/cloud-cognitive/src/components/StatusIcon/_status-icon.scss
+++ b/packages/cloud-cognitive/src/components/StatusIcon/_status-icon.scss
@@ -5,6 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -4,14 +4,22 @@
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
 //
-@import '../../global/styles/carbon-settings'; // goes before index as it affects how carbon is used.
+
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
+@import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import '../../global/styles/mixins';
 
+// TagSet uses the following Carbon components:
+// ComposedModal, ModalHeader, ModalBody, Search, Link, Tag, Tooltip
 @import 'carbon-components/scss/components/modal/modal';
 @import 'carbon-components/scss/components/search/search';
-@import 'carbon-components/scss/components/tooltip/tooltip';
+@import 'carbon-components/scss/components/link/link';
 @import 'carbon-components/scss/components/tag/tag';
+@import 'carbon-components/scss/components/tooltip/tooltip';
 
 $block-class: #{$pkg-prefix}--tag-set;
 $block-class-overflow: #{$block-class}-overflow;

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -5,11 +5,18 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 
+// Tearsheets use the following Carbon components:
+// Button, ComposedModal, ModalHeader, ModalBody,
 @import 'carbon-components/scss/components/modal/modal';
+
+// Tearsheets use the following Cloud & Cognitive components:
+// ActionSet
+@import '../ActionSet/action-set';
 
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.

--- a/packages/cloud-cognitive/src/components/UserProfileImage/_user-profile-image.scss
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/_user-profile-image.scss
@@ -5,10 +5,17 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+// Standard imports.
 @import '@carbon/import-once/scss/import-once';
-@import '../../global/styles/carbon-settings'; // goes before carbon imports as it affects how carbon is used.
+@import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
+
+// Other Carbon settings.
 @import './color-map';
+
+// UserProfileImage uses the following Carbon components:
+// TooltipIcon
+@import 'carbon-components/scss/components/tooltip/tooltip';
 
 $block-class: #{$pkg-prefix}-user-profile-avatar;
 

--- a/packages/cloud-cognitive/src/components/WebTerminal/_web-terminal.scss
+++ b/packages/cloud-cognitive/src/components/WebTerminal/_web-terminal.scss
@@ -1,3 +1,5 @@
+// Standard imports.
+@import '@carbon/import-once/scss/import-once';
 @import '../../global/styles/carbon-settings';
 @import '../../global/styles/project-settings';
 


### PR DESCRIPTION
Closes #1111 

Users who import individual component SCSS have noted that not all the required SCSS is pulled in. This PR works through all the components setting up a clear section in each SCSS file listing the components (Carbon and C&CS) that the component JS imports, so we can ensure that all the corresponding Carbon and C&CS SCSS is imported. As well as adding missing imports, unnecessary imports are removed.

#### What did you change?

Most component SCSS files.

#### How did you test and verify your work?

Ran tests and storybook.