### PR TITLE
chore(CreateComponents): add custom hooks to reduce size

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { useEffect, useCallback, useState, useRef } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -32,6 +32,10 @@ import {
   SideNavLink,
 } from 'carbon-components-react/lib/components/UIShell';
 import { ActionSet } from '../ActionSet';
+import { usePreviousValue } from '../../global/js/use/usePreviousValue';
+import { useValidCreateStepCount } from '../../global/js/use/useValidCreateStepCount';
+import { useCreateComponentStepChange } from '../../global/js/use/useCreateComponentStepChange';
+
 const blockClass = `${pkg.prefix}--create-full-page`;
 const componentName = 'CreateFullPage';
 
@@ -53,14 +57,6 @@ const isValidChildren =
         return;
       });
   };
-
-const usePreviousValue = (value) => {
-  const ref = useRef();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-};
 
 export let CreateFullPage = React.forwardRef(
   (
@@ -94,6 +90,30 @@ export let CreateFullPage = React.forwardRef(
     const [modalIsOpen, setModalIsOpen] = useState(false);
     const previousState = usePreviousValue({ currentStep, open });
 
+    // returns an array of full page steps
+    const getFullPageSteps = useCallback(() => {
+      const steps = [];
+      const childrenArray = Array.isArray(children) ? children : [children];
+      const extractedChildren =
+        childrenArray && childrenArray[0]?.type === React.Fragment
+          ? childrenArray[0].props.children
+          : childrenArray;
+      extractedChildren.forEach((child) => {
+        if (isFullPageStep(child)) {
+          steps.push(child);
+        }
+      });
+      return steps;
+    }, [children]);
+
+    useCreateComponentStepChange(
+      previousState,
+      currentStep,
+      getFullPageSteps,
+      blockClass
+    );
+    useValidCreateStepCount(getFullPageSteps, componentName);
+
     useEffect(() => {
       const onUnmount = () => {
         setIsSubmitting(false);
@@ -113,14 +133,21 @@ export let CreateFullPage = React.forwardRef(
       const isSubmitDisabled = () => {
         let step = 0;
         let submitDisabled = false;
+        let viewAllSubmitDisabled = false;
         const createFullPageSteps = getFullPageSteps();
         createFullPageSteps.forEach((child) => {
           step++;
           if (currentStep === step) {
             submitDisabled = child.props.disableSubmit;
           }
+          if (shouldViewAll && child.props.disableSubmit) {
+            viewAllSubmitDisabled = true;
+          }
         });
-        return submitDisabled;
+        if (!shouldViewAll) {
+          return submitDisabled;
+        }
+        return viewAllSubmitDisabled;
       };
       const handleNext = async () => {
         setIsSubmitting(true);
@@ -205,16 +232,6 @@ export let CreateFullPage = React.forwardRef(
       shouldViewAll,
     ]);
 
-    useEffect(() => {
-      const createSteps = getFullPageSteps();
-      const total = createSteps.length;
-      if (total === 1) {
-        console.warn(
-          `${componentName}: CreateFullPages with one step are not permitted. If you require only one step, please use either the CreateFullPage, CreateSidePanel, or CreateModal components.`
-        );
-      }
-    }, [getFullPageSteps]);
-
     const continueToNextStep = () => {
       setIsSubmitting(false);
       setCurrentStep((prev) => prev + 1);
@@ -282,18 +299,6 @@ export let CreateFullPage = React.forwardRef(
         });
       }
     }, [includeViewAllToggle, shouldViewAll, children]);
-
-    // returns an array of full page steps
-    const getFullPageSteps = useCallback(() => {
-      const steps = [];
-      const childrenArray = Array.isArray(children) ? children : [children];
-      childrenArray.forEach((child) => {
-        if (isFullPageStep(child)) {
-          steps.push(child);
-        }
-      });
-      return steps;
-    }, [children]);
 
     // check if child is a full page step component
     const isFullPageStep = (child) => {
@@ -429,11 +434,6 @@ export let CreateFullPage = React.forwardRef(
                   [`${blockClass}__step--hidden-step`]:
                     !shouldViewAll && currentStep !== step,
                   [`${blockClass}__step--visible-step`]: currentStep === step,
-                  [`${blockClass}__step--first-panel-step`]:
-                    !previousState?.open &&
-                    open &&
-                    previousState?.currentStep === 0 &&
-                    stepIndex === 0,
                 }),
                 key: `key_${stepIndex}`,
               },
@@ -503,45 +503,6 @@ export let CreateFullPage = React.forwardRef(
       const stepTitle =
         (fullPageSteps && fullPageSteps[stepIndex]?.props.title) || null;
       return stepTitle;
-    };
-
-    // set initial focus when the step changes, if there is not an input to focus
-    // the next/create button receives focus
-    useEffect(() => {
-      if (previousState?.currentStep !== currentStep && currentStep > 0) {
-        const visibleStepInnerContent = document.querySelector(
-          `.${blockClass}__step.${blockClass}__step--visible-step`
-        );
-        const fullPageSteps = getFullPageSteps();
-        const focusableStepElements =
-          fullPageSteps &&
-          fullPageSteps.length &&
-          getFocusableElements(visibleStepInnerContent);
-        const activeStepComponent =
-          fullPageSteps &&
-          fullPageSteps.length &&
-          fullPageSteps[currentStep - 1];
-        if (activeStepComponent && activeStepComponent.props.onMount) {
-          activeStepComponent.props.onMount();
-        }
-        if (focusableStepElements && focusableStepElements.length) {
-          focusableStepElements[0].focus();
-        } else {
-          const nextButton = document.querySelector(
-            `.${blockClass}__create-button`
-          );
-          nextButton?.focus();
-        }
-      }
-    }, [currentStep, getFullPageSteps, previousState]);
-
-    // returns an array of focusable elements, for use in auto focusing the first input on a step
-    const getFocusableElements = (element) => {
-      return [
-        ...element.querySelectorAll(
-          'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
-        ),
-      ].filter((e) => !e.hasAttribute('disabled'));
     };
 
     const handleViewAllToggle = (toggleState) => {

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -31,17 +31,13 @@ import wrapFocus from '../../global/js/utils/wrapFocus';
 import { TearsheetShell } from '../Tearsheet/TearsheetShell';
 import { carbon, pkg } from '../../settings';
 import { CREATE_TEARSHEET_SECTION, CREATE_TEARSHEET_STEP } from './constants';
+import { usePreviousValue } from '../../global/js/use/usePreviousValue';
+import { useValidCreateStepCount } from '../../global/js/use/useValidCreateStepCount';
+import { useResetCreateComponent } from '../../global/js/use/useResetCreateComponent';
+import { useCreateComponentStepChange } from '../../global/js/use/useCreateComponentStepChange';
 
 const componentName = 'CreateTearsheet';
 const blockClass = `${pkg.prefix}--tearsheet-create`;
-
-const usePreviousValue = (value) => {
-  const ref = useRef();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-};
 
 export let CreateTearsheet = forwardRef(
   (
@@ -78,24 +74,30 @@ export let CreateTearsheet = forwardRef(
     const previousState = usePreviousValue({ currentStep, open });
     const contentRef = useRef();
 
-    // set current step to 1 upon tearsheet opening, in order
-    // to get the auto focus on the first step.
-    useEffect(() => {
-      if (!previousState?.open && open) {
-        setCurrentStep(1);
-      }
-    }, [open, previousState]);
+    // returns an array of tearsheet steps
+    const getTearsheetSteps = useCallback(() => {
+      const steps = [];
+      const childrenArray = Array.isArray(children) ? children : [children];
+      const extractedChildren =
+        childrenArray && childrenArray[0]?.type === React.Fragment
+          ? childrenArray[0].props.children
+          : childrenArray;
+      extractedChildren.forEach((child) => {
+        if (isTearsheetStep(child)) {
+          steps.push(child);
+        }
+      });
+      return steps;
+    }, [children]);
 
-    // Log a warning to the console in the event a create tearsheet is used with only one step
-    useEffect(() => {
-      const createSteps = getTearsheetSteps();
-      const total = createSteps.length;
-      if (total === 1) {
-        console.warn(
-          `${componentName}: CreateTearsheets with one step are not permitted. If you require only one step, please use either the narrow tearsheet, CreateSidePanel, or CreateModal components.`
-        );
-      }
-    }, [getTearsheetSteps]);
+    useCreateComponentStepChange(
+      previousState,
+      currentStep,
+      getTearsheetSteps,
+      blockClass
+    );
+    useValidCreateStepCount(getTearsheetSteps, componentName);
+    useResetCreateComponent(previousState, open, setCurrentStep);
 
     // Log a warning to the console in the event there are no CreateTearsheetSection components
     // inside of the CreateTearsheetSteps when the viewAll toggle is provided and turned on.
@@ -290,22 +292,6 @@ export let CreateTearsheet = forwardRef(
       setIsSubmitting(false);
       setCurrentStep((prev) => prev + 1);
     };
-
-    // returns an array of tearsheet steps
-    const getTearsheetSteps = useCallback(() => {
-      const steps = [];
-      const childrenArray = Array.isArray(children) ? children : [children];
-      const extractedChildren =
-        childrenArray && childrenArray[0]?.type === React.Fragment
-          ? childrenArray[0].props.children
-          : childrenArray;
-      extractedChildren.forEach((child) => {
-        if (isTearsheetStep(child)) {
-          steps.push(child);
-        }
-      });
-      return steps;
-    }, [children]);
 
     // check if child is a tearsheet step component
     const isTearsheetStep = (child) => {
@@ -542,49 +528,6 @@ export let CreateTearsheet = forwardRef(
       const stepTitle =
         (tearsheetSteps && tearsheetSteps[stepIndex]?.props?.title) || null;
       return stepTitle;
-    };
-
-    // set initial focus when the step changes, if there is not an input to focus
-    // the next/create button receives focus
-    useEffect(() => {
-      if (
-        open &&
-        previousState?.currentStep !== currentStep &&
-        currentStep > 0
-      ) {
-        const visibleStepInnerContent = document.querySelector(
-          `.${blockClass}__step.${blockClass}__step--visible-step`
-        );
-        const tearsheetSteps = getTearsheetSteps();
-        const focusableStepElements =
-          tearsheetSteps &&
-          tearsheetSteps.length &&
-          getFocusableElements(visibleStepInnerContent);
-        const activeStepComponent =
-          tearsheetSteps &&
-          tearsheetSteps.length &&
-          tearsheetSteps[currentStep - 1];
-        if (activeStepComponent && activeStepComponent.props.onMount) {
-          activeStepComponent.props.onMount();
-        }
-        if (focusableStepElements && focusableStepElements.length) {
-          focusableStepElements[0].focus();
-        } else {
-          const nextButton = document.querySelector(
-            `.${blockClass}__create-button`
-          );
-          nextButton?.focus();
-        }
-      }
-    }, [open, currentStep, getTearsheetSteps, previousState]);
-
-    // returns an array of focusable elements, for use in auto focusing the first input on a step
-    const getFocusableElements = (element) => {
-      return [
-        ...element.querySelectorAll(
-          'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
-        ),
-      ].filter((e) => !e.hasAttribute('disabled'));
     };
 
     // adds focus trap functionality

--- a/packages/cloud-cognitive/src/global/js/use/useCreateComponentStepChange.js
+++ b/packages/cloud-cognitive/src/global/js/use/useCreateComponentStepChange.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+import { getFocusableElements } from '../utils/getFocusableElements';
+
+/**
+ * Returns the previous state values included in the param
+ * @param {object} previousState
+ * @param {number} currentStep
+ * @param {Function} getCreateComponentSteps
+ * @param {string} componentBlockClass
+ */
+export const useCreateComponentStepChange = (
+  previousState,
+  currentStep,
+  getCreateComponentSteps,
+  componentBlockClass
+) => {
+  useEffect(() => {
+    if (previousState?.currentStep !== currentStep && currentStep > 0) {
+      const visibleStepInnerContent = document.querySelector(
+        `.${componentBlockClass}__step.${componentBlockClass}__step--visible-step`
+      );
+      const fullPageSteps = getCreateComponentSteps();
+      const focusableStepElements =
+        fullPageSteps &&
+        fullPageSteps.length &&
+        getFocusableElements(visibleStepInnerContent);
+      const activeStepComponent =
+        fullPageSteps && fullPageSteps.length && fullPageSteps[currentStep - 1];
+      if (activeStepComponent && activeStepComponent.props.onMount) {
+        activeStepComponent.props.onMount();
+      }
+      if (focusableStepElements && focusableStepElements.length) {
+        focusableStepElements[0].focus();
+      } else {
+        const nextButton = document.querySelector(
+          `.${componentBlockClass}__create-button`
+        );
+        nextButton?.focus();
+      }
+    }
+  }, [
+    currentStep,
+    getCreateComponentSteps,
+    previousState,
+    componentBlockClass,
+  ]);
+};

--- a/packages/cloud-cognitive/src/global/js/use/usePreviousValue.js
+++ b/packages/cloud-cognitive/src/global/js/use/usePreviousValue.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Returns the previous state values included in the param
+ * @param {object} value
+ */
+export const usePreviousValue = (value) => {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};

--- a/packages/cloud-cognitive/src/global/js/use/useResetCreateComponent.js
+++ b/packages/cloud-cognitive/src/global/js/use/useResetCreateComponent.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Resets the current step of the create component if it has been closed.
+ * @param {object} previousState
+ * @param {boolean} open
+ * @param {Function} setCurrentStep
+ */
+export const useResetCreateComponent = (
+  previousState,
+  open,
+  setCurrentStep
+) => {
+  useEffect(() => {
+    if (!previousState?.open && open) {
+      setCurrentStep(1);
+    }
+  }, [open, previousState, setCurrentStep]);
+};

--- a/packages/cloud-cognitive/src/global/js/use/useValidCreateStepCount.js
+++ b/packages/cloud-cognitive/src/global/js/use/useValidCreateStepCount.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * Logs a warning to console if an invalid number of steps are used with the given CreateComponent
+ * @param {Function} getCreateComponentSteps
+ * @param {string} componentName
+ */
+export const useValidCreateStepCount = (
+  getCreateComponentSteps,
+  componentName
+) => {
+  useEffect(() => {
+    const createSteps = getCreateComponentSteps();
+    const total = createSteps.length;
+    if (total === 1) {
+      console.warn(
+        `${componentName}: ${componentName}s with one step are not permitted. If you require only one step, please use either the CreateTearsheetNarrow, CreateSidePanel, or CreateModal components.`
+      );
+    }
+  }, [getCreateComponentSteps, componentName]);
+};

--- a/packages/cloud-cognitive/src/global/js/utils/getFocusableElements.js
+++ b/packages/cloud-cognitive/src/global/js/utils/getFocusableElements.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Returns an array of focusable elements
+export const getFocusableElements = (element) => {
+  return [
+    ...element.querySelectorAll(
+      'a, button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+    ),
+  ].filter((e) => !e.hasAttribute('disabled'));
+};


### PR DESCRIPTION
Contributes to #1123 

Extracts code from both CreateTearsheet and CreateFullPage components to both reduce the size of these components and to start creating shared logic between these components.

#### What did you change?
`packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js`
`packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js`
`packages/cloud-cognitive/src/global/js/use/useCreateComponentStepChange.js`
`packages/cloud-cognitive/src/global/js/use/usePreviousValue.js`
`packages/cloud-cognitive/src/global/js/use/useResetCreateComponent.js`
`packages/cloud-cognitive/src/global/js/use/useValidCreateStepCount.js`
`packages/cloud-cognitive/src/global/js/utils/getFocusableElements.js`
#### How did you test and verify your work?
Storybook and ran tests for both CreateTearsheet and CreateFullPage