### PR TITLE
fix(CreateModal): ensure closing the modal calls onRequestClose handler

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.js
@@ -65,7 +65,11 @@ export let CreateModal = React.forwardRef(
         {...{ open, ref }}
         aria-label={title}
         size="sm"
-        preventCloseOnClickOutside>
+        preventCloseOnClickOutside
+        onClose={() => {
+          onRequestClose?.();
+          return false;
+        }}>
         <ModalHeader title={title} titleClassName={`${blockClass}__title`}>
           {subtitle && <p className={`${blockClass}__subtitle`}>{subtitle}</p>}
         </ModalHeader>

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.test.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.test.js
@@ -124,8 +124,9 @@ describe(componentName, () => {
       onRequestSubmit: primaryHandler,
       onRequestClose: secondaryHandler,
     });
-    screen.getAllByRole('button').forEach(userEvent.click);
+    userEvent.click(screen.getByRole('button', { name: 'Create' }));
     expect(primaryHandler).toBeCalledTimes(1);
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(secondaryHandler).toBeCalledTimes(1);
   });
 


### PR DESCRIPTION
Closes #1137 

#### What did you change?

Added an onClose handler to CreateModal.js to suppress the automatic closing of the modal and notify the onRequestClose handler.

#### How did you test and verify your work?

Ran storybook