### PR TITLE
feat: custom button set with overflow straw man

### DIFF
--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -81,19 +81,23 @@ export const ButtonSetWithOverflow = ({
   const AButtonSet = React.forwardRef(({ buttons, ...rest }, ref) => {
     return (
       <ButtonSet {...rest} ref={ref}>
-        {buttons.map(({ label, key, kind, ...other }) => {
-          /* istanbul ignore next */
-          const usedKind = kind || 'primary';
-          return (
-            <Button
-              key={key && `button-set-${key}`}
-              kind={usedKind}
-              {...other}
-              size={buttonSize}
-              type="button">
-              {label}
-            </Button>
-          );
+        {buttons.map(({ label, key, kind, custom, ...other }) => {
+          if (custom) {
+            return custom;
+          } else {
+            /* istanbul ignore next */
+            const usedKind = kind || 'primary';
+            return (
+              <Button
+                key={key && `button-set-${key}`}
+                kind={usedKind}
+                {...other}
+                size={buttonSize}
+                type="button">
+                {label}
+              </Button>
+            );
+          }
         })}
       </ButtonSet>
     );
@@ -102,14 +106,18 @@ export const ButtonSetWithOverflow = ({
     return (
       <ButtonMenu {...rest} ref={ref} label={buttonSetOverflowLabel}>
         {buttons
-          .map(({ label, key, kind, ...other }) => (
-            <ButtonMenuItem
-              key={key && `button-menu-${key}`}
-              isDelete={kind?.startsWith('danger')}
-              itemText={label}
-              {...prepareProps(other, ['iconDescription', 'renderIcon'])}
-            />
-          ))
+          .map(({ label, key, kind, custom, ...other }) =>
+            custom ? (
+              custom
+            ) : (
+              <ButtonMenuItem
+                key={key && `button-menu-${key}`}
+                isDelete={kind?.startsWith('danger')}
+                itemText={label}
+                {...prepareProps(other, ['iconDescription', 'renderIcon'])}
+              />
+            )
+          )
           .reverse()}
       </ButtonMenu>
     );
@@ -186,13 +194,19 @@ ButtonSetWithOverflow.propTypes = {
    * Carbon Button API https://react.carbondesignsystem.com/?path=/docs/components-button--default#component-api
    */
   buttons: PropTypes.arrayOf(
-    PropTypes.shape({
-      ...Button.propTypes,
-      key: PropTypes.string.isRequired,
-      kind: Button.propTypes.kind,
-      label: PropTypes.node,
-      onClick: PropTypes.func,
-    })
+    PropTypes.oneOfType([
+      PropTypes.shape({
+        ...Button.propTypes,
+        key: PropTypes.string.isRequired,
+        kind: Button.propTypes.kind,
+        label: PropTypes.node,
+        onClick: PropTypes.func,
+      }),
+      PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        custom: PropTypes.node,
+      }),
+    ])
   ).isRequired,
   /**
    * className

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.stories.js
@@ -6,6 +6,7 @@
 //
 
 import React from 'react';
+import cx from 'classnames';
 
 import { action } from '@storybook/addon-actions';
 
@@ -14,8 +15,13 @@ import {
   prepareStory,
 } from '../../global/js/utils/story-helper';
 import { ButtonSetWithOverflow } from '.';
+// import { ButtonMenu, ButtonMenuItem } from '../ButtonMenu';
+import { ChevronDown16 } from '@carbon/icons-react';
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
 // Carbon and package components we use.
+import { carbon } from '../../settings';
+import styles from './_storybook-styles.scss';
 
 export default {
   title: getStoryTitle(ButtonSetWithOverflow.displayName),
@@ -26,6 +32,9 @@ export default {
     },
   },
   decorators: [(story) => <div className="ccs-sb__display-box">{story()}</div>],
+  parameters: {
+    styles,
+  },
 };
 
 const buttons = [
@@ -63,6 +72,65 @@ const Template = (argsIn) => {
 export const Default = prepareStory(Template, {
   args: {
     buttons,
+    buttonSetOverflowLabel,
+    containerWidth: 600,
+  },
+});
+
+const customButtons = [
+  {
+    key: 'custom item',
+    custom: (
+      <OverflowMenu
+        className="custom-node"
+        menuOptionsClass="custom-node__options"
+        size="field"
+        kind="danger"
+        renderIcon={() => (
+          <div
+            className={cx([
+              'custom-node__trigger',
+              `${carbon.prefix}--btn`,
+              `${carbon.prefix}--btn--danger`,
+              `${carbon.prefix}--btn--field`,
+            ])}>
+            Danger zone
+            <ChevronDown16
+              aria-hidden="true"
+              aria-label="Button menu"
+              className={`${carbon.prefix}--btn__icon`}
+            />
+          </div>
+        )}>
+        <OverflowMenuItem
+          isDelete={true}
+          itemText="Delete"
+          onClick={action(`Delete`)}></OverflowMenuItem>
+        <OverflowMenuItem
+          isDelete={true}
+          kind="danger"
+          itemText="Delete children"
+          onClick={action(`Delete children`)}></OverflowMenuItem>
+      </OverflowMenu>
+    ),
+  },
+  {
+    key: 'secondary-button',
+    kind: 'secondary',
+    onClick: action('Secondary'),
+    label: 'Secondary',
+  },
+  {
+    key: 'primary-button',
+    kind: 'primary',
+    onClick: action('Primary'),
+    label: 'Primary',
+  },
+];
+
+export const Custom = prepareStory(Template, {
+  args: {
+    buttons: customButtons,
     buttonSetOverflowLabel,
     containerWidth: 600,
   },

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/_storybook-styles.scss
@@ -1,0 +1,14 @@
+@import '../../global/styles/carbon-settings';
+
+.custom-node.custom-node {
+  min-width: 160px;
+}
+
+.custom-node.custom-node .custom-node__trigger {
+  width: 100%;
+  padding: 0 $spacing-05;
+}
+
+.custom-node__options.#{$carbon-prefix}--overflow-menu-options::after {
+  content: initial;
+}


### PR DESCRIPTION
Contributes to #1062 

Adds the option of providing a custom component to the ButtonSetWithOverflow. 

- Warnings raised about the `closeMenu` and `handleOverflowMenuItemFocus` not implemented
- Presume above causes a lack of focus in a narrow version
- How to document/support different custom versions. For example, different behaviours when horizontal or vertical space is limited. NOTE: We could accept multiple scenario-based custom props or document the host classes the user will need to check for.

#### What did you change?

ButtonSetWithOverflow and story.

#### How did you test and verify your work?

Storybook