### PR TITLE
fix(HTTPErrors): explicitly set text color and update snapshot

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -988,6 +988,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   margin-bottom: var(--cds-spacing-06, 1.5rem);
 }
 
+.exp--http-errors .exp--http-errors__error-code-label,
+.exp--http-errors .exp--http-errors__title,
+.exp--http-errors .exp--http-errors__description {
+  color: var(--cds-text-01, #161616);
+}
+
 .exp--http-errors .exp--http-errors__link {
   display: block;
   margin-bottom: var(--cds-spacing-02, 0.25rem);

--- a/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/_http-errors.scss
@@ -46,6 +46,11 @@
 
     margin-bottom: $spacing-06;
   }
+  .#{$block-class} .#{$block-class}__error-code-label,
+  .#{$block-class} .#{$block-class}__title,
+  .#{$block-class} .#{$block-class}__description {
+    color: $text-01;
+  }
   .#{$block-class} .#{$block-class}__link {
     display: block;
     margin-bottom: $spacing-02;


### PR DESCRIPTION
Contributes to #1150 

This PR explicitly sets the text color for the HTTPError label, title, and description.

#### What did you change?
`_http-errors.scss`
#### How did you test and verify your work?
Storybook and ran `yarn jest styles -u`