### PR TITLE
chore: #1123 create components custom hook

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -426,7 +426,6 @@ export let CreateFullPage = React.forwardRef(
             includeViewAllToggle={includeViewAllToggle}
             handleToggleState={(toggleState) => setShouldViewAll(toggleState)}
             handleActiveSectionIndex={(index) => setActiveSectionIndex(index)}
-            open={open}
             previousState={previousState}
             sideNavAriaLabel={sideNavAriaLabel}
             toggleState={shouldViewAll}

--- a/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
+++ b/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
@@ -6,7 +6,7 @@
  */
 
 // Import portions of React that are needed.
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import {
@@ -38,6 +38,8 @@ export let CreateInfluencer = ({
   handleToggleState,
   handleActiveSectionIndex,
   includeViewAllToggle,
+  open,
+  previousState,
   sideNavAriaLabel,
   toggleState,
   viewAllToggleLabelText,
@@ -46,6 +48,15 @@ export let CreateInfluencer = ({
 }) => {
   const [progressIndicatorState, setProgressIndicatorState] = useState('');
   const [sideNavState, setSideNavState] = useState('');
+
+  // Animating states need to be reset here otherwise things won't render
+  // the way they should after the component mounts/unmounts
+  useEffect(() => {
+    if (!previousState?.open && open) {
+      setSideNavState('');
+      setProgressIndicatorState('');
+    }
+  }, [open, previousState]);
 
   const handleViewAllToggle = (newToggleValue) => {
     if (newToggleValue) {
@@ -217,6 +228,18 @@ CreateInfluencer.propTypes = {
    * Used to optionally include view all toggle
    */
   includeViewAllToggle: PropTypes.bool,
+
+  /**
+   * This is the open state of the CreateComponent in which the CreateInfluencer is used from
+   */
+  open: PropTypes.bool,
+
+  /**
+   * This is the open state of the CreateComponent in which the CreateInfluencer is used from
+   */
+  previousState: PropTypes.shape({
+    open: PropTypes.bool,
+  }),
 
   /**
    * The aria label to be used for the UI Shell SideNav Carbon component

--- a/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
+++ b/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
@@ -237,9 +237,7 @@ CreateInfluencer.propTypes = {
   /**
    * This is the open state of the CreateComponent in which the CreateInfluencer is used from
    */
-  previousState: PropTypes.shape({
-    open: PropTypes.bool,
-  }),
+  previousState: PropTypes.object,
 
   /**
    * The aria label to be used for the UI Shell SideNav Carbon component

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -42,6 +42,7 @@ export let CreateTearsheet = forwardRef(
       className,
       description,
       includeViewAllToggle,
+      influencerWidth,
       label,
       nextButtonText,
       onClose,
@@ -397,7 +398,7 @@ export let CreateTearsheet = forwardRef(
           />
         }
         influencerPosition="left"
-        influencerWidth="narrow"
+        influencerWidth={influencerWidth}
         label={label}
         onClose={onClose}
         open={open}
@@ -462,6 +463,11 @@ CreateTearsheet.propTypes = {
    * Used to optionally include view all toggle
    */
   includeViewAllToggle: PropTypes.bool,
+
+  /**
+   * Used to set the size of the influencer
+   */
+  influencerWidth: PropTypes.oneOf(['narrow', 'wide']),
 
   /**
    * A label for the tearsheet, displayed in the header area of the tearsheet
@@ -548,4 +554,5 @@ CreateTearsheet.propTypes = {
 CreateTearsheet.defaultProps = {
   verticalPosition: 'normal',
   includeViewAllToggle: false,
+  influencerWidth: 'narrow',
 };

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -20,34 +20,18 @@ import { extractShapesArray } from '../../global/js/utils/props-helper';
 import wrapFocus from '../../global/js/utils/wrapFocus';
 import { TearsheetShell } from '../Tearsheet/TearsheetShell';
 import { CreateInfluencer } from '../CreateInfluencer';
+import { CreateTearsheetDivider } from './CreateTearsheetDivider';
 import { carbon, pkg } from '../../settings';
 import { CREATE_TEARSHEET_SECTION, CREATE_TEARSHEET_STEP } from './constants';
 import { usePreviousValue } from '../../global/js/use/usePreviousValue';
 import { useValidCreateStepCount } from '../../global/js/use/useValidCreateStepCount';
 import { useResetCreateComponent } from '../../global/js/use/useResetCreateComponent';
+import { useCreateComponentFocus } from '../../global/js/use/useCreateComponentFocus';
 import { useCreateComponentStepChange } from '../../global/js/use/useCreateComponentStepChange';
+import { isValidChildren } from './utils/isValidChildren';
 
 const componentName = 'CreateTearsheet';
 const blockClass = `${pkg.prefix}--tearsheet-create`;
-
-// Custom PropType validator which checks and ensures that the children property has no more than 4 nodes
-const isValidChildren =
-  () =>
-  ({ children }) => {
-    children.length > 1 &&
-      children.map((child) => {
-        if (
-          child &&
-          child.props &&
-          child.props.type !== CREATE_TEARSHEET_STEP
-        ) {
-          throw new Error(
-            `Each child of ${componentName} is required to be a ${CREATE_TEARSHEET_STEP}. Please remove the HTML element, or wrap it around the ${CREATE_TEARSHEET_STEP} component.`
-          );
-        }
-        return;
-      });
-  };
 
 export let CreateTearsheet = forwardRef(
   (
@@ -98,7 +82,7 @@ export let CreateTearsheet = forwardRef(
       return steps;
     }, [children]);
 
-    useCreateComponentStepChange(
+    useCreateComponentFocus(
       previousState,
       currentStep,
       getTearsheetSteps,
@@ -106,6 +90,24 @@ export let CreateTearsheet = forwardRef(
     );
     useValidCreateStepCount(getTearsheetSteps, componentName);
     useResetCreateComponent(previousState, open, setCurrentStep);
+    useCreateComponentStepChange({
+      setCurrentStep,
+      setIsSubmitting,
+      setShouldViewAll,
+      onClose,
+      onRequestSubmit,
+      componentName,
+      getComponentSteps: getTearsheetSteps,
+      currentStep,
+      shouldViewAll,
+      backButtonText,
+      cancelButtonText,
+      submitButtonText,
+      nextButtonText,
+      isSubmitting,
+      componentBlockClass: blockClass,
+      setCreateComponentActions: setCreateTearsheetActions,
+    });
 
     // Log a warning to the console in the event there are no CreateTearsheetSection components
     // inside of the CreateTearsheetSteps when the viewAll toggle is provided and turned on.
@@ -175,131 +177,6 @@ export let CreateTearsheet = forwardRef(
         });
       }
     }, [includeViewAllToggle, shouldViewAll, children]);
-
-    // useEffect to handle multi step logic
-    useEffect(() => {
-      const onUnmount = () => {
-        setCurrentStep(0);
-        setIsSubmitting(false);
-        setShouldViewAll(false);
-        onClose();
-      };
-      const handleOnRequestSubmit = async () => {
-        // check if onRequestSubmit returns a promise
-        try {
-          await onRequestSubmit();
-          onUnmount();
-        } catch (error) {
-          setIsSubmitting(false);
-          console.warn(`${componentName} submit error: ${error}`);
-        }
-      };
-      const isSubmitDisabled = () => {
-        let step = 0;
-        let submitDisabled = false;
-        let viewAllSubmitDisabled = false;
-        const tearsheetSteps = getTearsheetSteps();
-        tearsheetSteps.forEach((child) => {
-          step++;
-          if (currentStep === step) {
-            submitDisabled = child.props.disableSubmit;
-          }
-          if (shouldViewAll && child.props.disableSubmit) {
-            viewAllSubmitDisabled = true;
-          }
-        });
-        if (!shouldViewAll) {
-          return submitDisabled;
-        }
-        return viewAllSubmitDisabled;
-      };
-      const handleNext = async () => {
-        setIsSubmitting(true);
-        const createSteps = getTearsheetSteps();
-        if (createSteps[currentStep - 1].props.onNext) {
-          try {
-            await createSteps[currentStep - 1].props.onNext();
-            continueToNextStep();
-          } catch (error) {
-            setIsSubmitting(false);
-            console.warn(`${componentName} onNext error: ${error}`);
-          }
-        } else {
-          continueToNextStep();
-        }
-      };
-      const handleSubmit = async () => {
-        setIsSubmitting(true);
-        const createSteps = getTearsheetSteps();
-        // last step should have onNext as well
-        if (createSteps[currentStep - 1].props.onNext) {
-          try {
-            await createSteps[currentStep - 1].props.onNext();
-            await handleOnRequestSubmit();
-          } catch (error) {
-            setIsSubmitting(false);
-            console.warn(`${componentName} onNext error: ${error}`);
-          }
-        } else {
-          await handleOnRequestSubmit();
-        }
-      };
-      if (getTearsheetSteps()?.length) {
-        const createSteps = getTearsheetSteps();
-        const total = createSteps.length;
-        const buttons = [];
-        if (total > 1 && !shouldViewAll) {
-          buttons.push({
-            key: 'create-tearsheet-action-button-back',
-            label: backButtonText,
-            onClick: () => setCurrentStep((prev) => prev - 1),
-            kind: 'secondary',
-            disabled: currentStep === 1,
-          });
-        }
-        buttons.push({
-          key: 'create-tearsheet-action-button-cancel',
-          label: cancelButtonText,
-          onClick: onUnmount,
-          kind: 'ghost',
-        });
-        buttons.push({
-          key: 'create-tearsheet-action-button-submit',
-          label: shouldViewAll
-            ? submitButtonText
-            : currentStep < total
-            ? nextButtonText
-            : submitButtonText,
-          onClick: shouldViewAll
-            ? handleSubmit
-            : currentStep < total
-            ? handleNext
-            : handleSubmit,
-          disabled: isSubmitDisabled(),
-          kind: 'primary',
-          loading: isSubmitting,
-          className: `${blockClass}__create-button`,
-        });
-        setCreateTearsheetActions(buttons);
-      }
-    }, [
-      getTearsheetSteps,
-      children,
-      backButtonText,
-      cancelButtonText,
-      currentStep,
-      onClose,
-      nextButtonText,
-      submitButtonText,
-      onRequestSubmit,
-      isSubmitting,
-      shouldViewAll,
-    ]);
-
-    const continueToNextStep = () => {
-      setIsSubmitting(false);
-      setCurrentStep((prev) => prev + 1);
-    };
 
     // check if child is a tearsheet step component
     const isTearsheetStep = (child) => {
@@ -440,7 +317,7 @@ export let CreateTearsheet = forwardRef(
               <>
                 {child}
                 {shouldViewAll && !isLastSectionOfLastStep && (
-                  <span className={`${blockClass}__section--divider`} />
+                  <CreateTearsheetDivider />
                 )}
               </>
             );
@@ -487,45 +364,6 @@ export let CreateTearsheet = forwardRef(
       );
     };
 
-    // track scrolling/intersection of create sections so that we know
-    // which section is active (updates the SideNavItems `isActive` prop)
-    useEffect(() => {
-      if (shouldViewAll) {
-        const tearsheetMainContent = document.querySelector(
-          `.${pkg.prefix}--tearsheet__content`
-        );
-        let options = {
-          root: tearsheetMainContent,
-          rootMargin: '0px',
-          threshold: 0,
-        };
-        // Convert NodeList to array so we can find the index
-        // of the section that should be marked as `active`.
-        const viewAllSections = Array.from(
-          document.querySelectorAll(
-            `.${pkg.prefix}--tearsheet-create__section.${pkg.prefix}--tearsheet-create__step--visible-section`
-          )
-        );
-        /* istanbul ignore next */
-        const observer = new IntersectionObserver((entries) => {
-          // isIntersecting is true when element and viewport/options.root are overlapping
-          // isIntersecting is false when element and viewport/options.root don't overlap
-          if (entries[0].isIntersecting) {
-            // DOM element that is intersecting
-            const visibleTarget = entries[0].target;
-            // Get visible element index
-            const visibleTargetIndex = viewAllSections.findIndex(
-              (item) => item.id === visibleTarget.id
-            );
-            setActiveSectionIndex(visibleTargetIndex);
-          }
-        }, options);
-        viewAllSections.forEach((section) => {
-          observer.observe(section);
-        });
-      }
-    }, [shouldViewAll]);
-
     useResizeDetector({
       handleWidth: true,
       onResize: handleResize,
@@ -549,6 +387,8 @@ export let CreateTearsheet = forwardRef(
             includeViewAllToggle={includeViewAllToggle}
             handleToggleState={(toggleState) => setShouldViewAll(toggleState)}
             handleActiveSectionIndex={(index) => setActiveSectionIndex(index)}
+            open={open}
+            previousState={previousState}
             sideNavAriaLabel={sideNavAriaLabel}
             toggleState={shouldViewAll}
             viewAllToggleLabelText={viewAllToggleLabelText}
@@ -603,7 +443,10 @@ CreateTearsheet.propTypes = {
   /**
    * The main content of the tearsheet
    */
-  children: isValidChildren(),
+  children: isValidChildren({
+    componentName,
+    stepType: CREATE_TEARSHEET_STEP,
+  }),
 
   /**
    * An optional class or classes to be added to the outermost element.

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js
@@ -42,6 +42,7 @@ const createTearsheetProps = {
   nextButtonText: 'Next',
   className: 'test-class-name',
   label: '',
+  influencerWidth: 'narrow',
 };
 
 export const multiStepTearsheet = prepareStory(MultiStepTearsheet, {

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js
@@ -28,6 +28,7 @@ export const MultiStepTearsheet = ({
   cancelButtonText,
   className,
   description,
+  influencerWidth,
   label,
   nextButtonText,
   submitButtonText,
@@ -63,6 +64,7 @@ export const MultiStepTearsheet = ({
         {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
       </Button>
       <CreateTearsheet
+        influencerWidth={influencerWidth}
         label={label}
         className={cx(blockClass, className)}
         submitButtonText={submitButtonText}

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
@@ -188,7 +188,7 @@ export const MultiStepWithSectionsTearsheet = ({
           <h4 className={`${componentBlockClass}__step--title`}>Meta data</h4>
           <fieldset className={`${componentBlockClass}__step--fieldset`}>
             <TextInput
-              labelText="Topic meta data"
+              labelText="Topic meta data (optional)"
               id="tearsheet-multi-step-story-text-input-multi-step-1-input-4"
               value={topicMetaData}
               placeholder="Enter topic meta data"

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js
@@ -30,6 +30,7 @@ export const MultiStepWithSectionsTearsheet = ({
   cancelButtonText,
   className,
   description,
+  influencerWidth,
   label,
   nextButtonText,
   submitButtonText,
@@ -70,6 +71,7 @@ export const MultiStepWithSectionsTearsheet = ({
         {open ? 'Close CreateTearsheet' : 'Open CreateTearsheet'}
       </Button>
       <CreateTearsheet
+        influencerWidth={influencerWidth}
         label={label}
         className={cx(blockClass, className)}
         submitButtonText={submitButtonText}

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/utils/isValidChildren.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/utils/isValidChildren.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Custom PropType validator which checks and ensures that the children of the create component are indeed all CreateStep components.
+export const isValidChildren =
+  ({ componentName, stepType }) =>
+  ({ children }) => {
+    children.length > 1 &&
+      children.map((child) => {
+        if (child && child.props && child.props.type !== stepType) {
+          throw new Error(
+            `Each child of ${componentName} is required to be a ${stepType}. Please remove the HTML element, or wrap it around the ${stepType} component.`
+          );
+        }
+        return;
+      });
+  };

--- a/packages/cloud-cognitive/src/global/js/use/useCreateComponentFocus.js
+++ b/packages/cloud-cognitive/src/global/js/use/useCreateComponentFocus.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect } from 'react';
+import { getFocusableElements } from '../utils/getFocusableElements';
+
+/**
+ * Returns the previous state values included in the param
+ * @param {object} previousState
+ * @param {number} currentStep
+ * @param {Function} getCreateComponentSteps
+ * @param {string} componentBlockClass
+ */
+export const useCreateComponentFocus = (
+  previousState,
+  currentStep,
+  getCreateComponentSteps,
+  componentBlockClass
+) => {
+  useEffect(() => {
+    if (previousState?.currentStep !== currentStep && currentStep > 0) {
+      const visibleStepInnerContent = document.querySelector(
+        `.${componentBlockClass}__step.${componentBlockClass}__step--visible-step`
+      );
+      const fullPageSteps = getCreateComponentSteps();
+      const focusableStepElements =
+        fullPageSteps &&
+        fullPageSteps.length &&
+        getFocusableElements(visibleStepInnerContent);
+      const activeStepComponent =
+        fullPageSteps && fullPageSteps.length && fullPageSteps[currentStep - 1];
+      if (activeStepComponent && activeStepComponent.props.onMount) {
+        activeStepComponent.props.onMount();
+      }
+      if (focusableStepElements && focusableStepElements.length) {
+        focusableStepElements[0].focus();
+      } else {
+        const nextButton = document.querySelector(
+          `.${componentBlockClass}__create-button`
+        );
+        nextButton?.focus();
+      }
+    }
+  }, [
+    currentStep,
+    getCreateComponentSteps,
+    previousState,
+    componentBlockClass,
+  ]);
+};


### PR DESCRIPTION
Contributes to #1123

Extracts more logic out of CreateTearsheet and CreateFullPage so that it can be shared across these two components.

#### What did you change?
`packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js`
`packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.stories.js`
`packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepTearsheet.js`
`packages/cloud-cognitive/src/components/CreateTearsheet/preview-components/MultiStepWithSectionsTearsheet.js`
`packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js`
`packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js`
`packages/cloud-cognitive/src/global/js/utils/hasValidChildType.js`
`packages/cloud-cognitive/src/global/js/use/useCreateComponentFocus.js`
`packages/cloud-cognitive/src/global/js/use/useCreateComponentStepChange.js`

#### How did you test and verify your work?
Storybook and ran tests