### PR TITLE
fix: ensure internal components don't render as canary placeholders

### DIFF
--- a/packages/cloud-cognitive/src/settings.js
+++ b/packages/cloud-cognitive/src/settings.js
@@ -31,12 +31,15 @@ pkgSettings.checkComponentEnabled = (component, name) => {
     // The component is a forward-ref, so make a stub forward-ref.
     const forward = React.forwardRef((props, ref) =>
       // Replace the stub's render fn so this test only happens once.
-      (forward.render = pkgSettings.isComponentEnabled(name)
-        ? // Replace the stub's render fn with the component's render fn.
-          component.render
-        : // Note that Canary is a direct render fn (not a forward-ref) and
-          // will ignore the passed props and ref (if any)
-          Canary.bind(undefined, { componentName: name }))(
+      (forward.render =
+        pkgSettings.isComponentEnabled(name) ||
+        !pkgSettings.isComponentPublic(name)
+          ? // If the component is enabled, or if it's not a public component,
+            // replace the stub's render fn with the component's render fn.
+            component.render
+          : // Note that Canary is a direct render fn (not a forward-ref) and
+            // will ignore the passed props and ref (if any)
+            Canary.bind(undefined, { componentName: name }))(
         // Call it now (after this it will be directly called).
         props,
         ref
@@ -51,12 +54,15 @@ pkgSettings.checkComponentEnabled = (component, name) => {
     // The component is a direct render fn, so make a stub render fn.
     let render = (props) =>
       // Replace the stub render fn so this test only happens once.
-      (render = pkgSettings.isComponentEnabled(name)
-        ? // Replace the stub render fn with the component render fn.
-          component
-        : // Replace the stub render fn with the Canary render fn, which will
-          // ignore the passed props.
-          Canary.bind(undefined, { componentName: name }))(
+      (render =
+        pkgSettings.isComponentEnabled(name) ||
+        !pkgSettings.isComponentPublic(name)
+          ? // If the component is enabled, or if it's not a public component,
+            // replace the stub render fn with the component render fn.
+            component
+          : // Replace the stub render fn with the Canary render fn, which will
+            // ignore the passed props.
+            Canary.bind(undefined, { componentName: name }))(
         // Call it now (after this it will be directly called).
         props
       );


### PR DESCRIPTION
The `checkComponentEnabled` helper function applied to components was correctly rendering components as themselves if the component was flagged as released and as a canary placeholder if the component was flagged as not yet released (canary). However, if the component was not an exported component at all, it was wrongly rendering it as a canary placeholder. This PR fixes this so that internal components can include a `checkComponentEnabled` without becoming canaries.

#### What did you change?

Just the one function in `settings.js`

#### How did you test and verify your work?

Ran tests and storybook. I also commented out the enable-all-components from storybook, so I could see the BreadcrumbWithOverflow and ActionBar becoming canary placeholders in the PageHeader stories, and checked that this PR fixes that.