### PR TITLE
fix(CreateTearsheet): remove grid margin

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/_create-tearsheet.scss
@@ -72,6 +72,7 @@
 
   .#{$block-class} .#{$block-class}__content .#{$carbon-prefix}--grid {
     padding: 0;
+    margin: 0;
   }
 
   .#{$block-class} .#{$block-class}__step--heading {


### PR DESCRIPTION
The main content of the create tearsheet should remain left aligned, this PR removes the margin from the grid component that was previously preventing this.

#### What did you change?
`_create-tearsheet.scss

#### How did you test and verify your work?
Storybook