### PR TITLE
feat(CreateTearsheet): #1076 create tearsheet custom step

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
+++ b/packages/cloud-cognitive/src/components/CreateInfluencer/CreateInfluencer.js
@@ -91,6 +91,7 @@ export let CreateInfluencer = ({
         labelB={viewAllToggleOnLabelText}
         onToggle={(value) => handleViewAllToggle(value)}
         className={`${blockClass}__view-all-toggle`}
+        defaultToggled={false}
       />
     );
   };

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -70,6 +70,26 @@ export let CreateTearsheet = forwardRef(
     const previousState = usePreviousValue({ currentStep, open });
     const contentRef = useRef();
 
+    // check if child is a tearsheet step component
+    const isTearsheetStep = (child) => {
+      if (child && child.props && child.props.type === CREATE_TEARSHEET_STEP) {
+        return true;
+      }
+      return false;
+    };
+
+    // check if child is a tearsheet section component
+    const isTearsheetSection = (child) => {
+      if (
+        child &&
+        child.props &&
+        child.props.type === CREATE_TEARSHEET_SECTION
+      ) {
+        return true;
+      }
+      return false;
+    };
+
     // returns an array of tearsheet steps
     const getTearsheetSteps = useCallback(() => {
       const steps = [];
@@ -93,7 +113,13 @@ export let CreateTearsheet = forwardRef(
       blockClass
     );
     useValidCreateStepCount(getTearsheetSteps, componentName);
-    useResetCreateComponent(previousState, open, setCurrentStep, initialStep);
+    useResetCreateComponent(
+      previousState,
+      open,
+      setCurrentStep,
+      initialStep,
+      getTearsheetSteps().length
+    );
     useCreateComponentStepChange({
       setCurrentStep,
       setIsSubmitting,
@@ -181,26 +207,6 @@ export let CreateTearsheet = forwardRef(
         });
       }
     }, [includeViewAllToggle, shouldViewAll, children]);
-
-    // check if child is a tearsheet step component
-    const isTearsheetStep = (child) => {
-      if (child && child.props && child.props.type === CREATE_TEARSHEET_STEP) {
-        return true;
-      }
-      return false;
-    };
-
-    // check if child is a tearsheet section component
-    const isTearsheetSection = (child) => {
-      if (
-        child &&
-        child.props &&
-        child.props.type === CREATE_TEARSHEET_SECTION
-      ) {
-        return true;
-      }
-      return false;
-    };
 
     const getTearsheetComponents = (childrenElements) => {
       let childrenArray = Array.isArray(childrenElements)

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -116,9 +116,7 @@ export let CreateTearsheet = forwardRef(
     // Log a warning to the console in the event there are no CreateTearsheetSection components
     // inside of the CreateTearsheetSteps when the viewAll toggle is provided and turned on.
     useEffect(() => {
-      console.log({ shouldViewAll });
       if (includeViewAllToggle && shouldViewAll) {
-        console.log('do we get here?');
         let childrenArray =
           typeof children !== 'undefined'
             ? children.length

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -45,6 +45,7 @@ export let CreateTearsheet = forwardRef(
       description,
       includeViewAllToggle,
       influencerWidth,
+      initialStep,
       label,
       nextButtonText,
       onClose,
@@ -92,7 +93,7 @@ export let CreateTearsheet = forwardRef(
       blockClass
     );
     useValidCreateStepCount(getTearsheetSteps, componentName);
-    useResetCreateComponent(previousState, open, setCurrentStep);
+    useResetCreateComponent(previousState, open, setCurrentStep, initialStep);
     useCreateComponentStepChange({
       setCurrentStep,
       setIsSubmitting,
@@ -115,7 +116,9 @@ export let CreateTearsheet = forwardRef(
     // Log a warning to the console in the event there are no CreateTearsheetSection components
     // inside of the CreateTearsheetSteps when the viewAll toggle is provided and turned on.
     useEffect(() => {
+      console.log({ shouldViewAll });
       if (includeViewAllToggle && shouldViewAll) {
+        console.log('do we get here?');
         let childrenArray =
           typeof children !== 'undefined'
             ? children.length
@@ -470,6 +473,13 @@ CreateTearsheet.propTypes = {
    * Used to set the size of the influencer
    */
   influencerWidth: PropTypes.oneOf(['narrow', 'wide']),
+
+  /**
+   * This can be used to open the component to a step other than the first step.
+   * For example, a create flow was previously in progress, data was saved, and
+   * is now being completed.
+   */
+  initialStep: PropTypes.number,
 
   /**
    * A label for the tearsheet, displayed in the header area of the tearsheet

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -113,13 +113,14 @@ export let CreateTearsheet = forwardRef(
       blockClass
     );
     useValidCreateStepCount(getTearsheetSteps, componentName);
-    useResetCreateComponent(
+    useResetCreateComponent({
       previousState,
       open,
       setCurrentStep,
       initialStep,
-      getTearsheetSteps().length
-    );
+      totalSteps: getTearsheetSteps().length,
+      componentName,
+    });
     useCreateComponentStepChange({
       setCurrentStep,
       setIsSubmitting,

--- a/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
@@ -12,15 +12,21 @@ import { useEffect } from 'react';
  * @param {object} previousState
  * @param {boolean} open
  * @param {Function} setCurrentStep
+ * @param {number} initialStep
  */
 export const useResetCreateComponent = (
   previousState,
   open,
-  setCurrentStep
+  setCurrentStep,
+  initialStep
 ) => {
   useEffect(() => {
     if (!previousState?.open && open) {
-      setCurrentStep(1);
+      if (initialStep) {
+        setCurrentStep(initialStep);
+      } else {
+        setCurrentStep(1);
+      }
     }
-  }, [open, previousState, setCurrentStep]);
+  }, [open, previousState, setCurrentStep, initialStep]);
 };

--- a/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
@@ -13,20 +13,27 @@ import { useEffect } from 'react';
  * @param {boolean} open
  * @param {Function} setCurrentStep
  * @param {number} initialStep
+ * @param {number} totalSteps
  */
 export const useResetCreateComponent = (
   previousState,
   open,
   setCurrentStep,
-  initialStep
+  initialStep,
+  totalSteps
 ) => {
   useEffect(() => {
     if (!previousState?.open && open) {
-      if (initialStep) {
+      if (
+        initialStep &&
+        totalSteps &&
+        initialStep <= totalSteps &&
+        initialStep > 0
+      ) {
         setCurrentStep(initialStep);
       } else {
         setCurrentStep(1);
       }
     }
-  }, [open, previousState, setCurrentStep, initialStep]);
+  }, [open, previousState, setCurrentStep, initialStep, totalSteps]);
 };

--- a/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useResetCreateComponent.js
@@ -9,31 +9,53 @@ import { useEffect } from 'react';
 
 /**
  * Resets the current step of the create component if it has been closed.
- * @param {object} previousState
- * @param {boolean} open
- * @param {Function} setCurrentStep
- * @param {number} initialStep
- * @param {number} totalSteps
+ * @param {object} useResetCreateComponent - Create component that uses this custom hook
+ * @param {object} useResetCreateComponent.previousState
+ * @param {boolean} useResetCreateComponent.open
+ * @param {Function} useResetCreateComponent.setCurrentStep
+ * @param {number} useResetCreateComponent.initialStep
+ * @param {number} useResetCreateComponent.totalSteps
+ * @param {string} useResetCreateComponent.componentName
  */
-export const useResetCreateComponent = (
+export const useResetCreateComponent = ({
   previousState,
   open,
   setCurrentStep,
   initialStep,
-  totalSteps
-) => {
+  totalSteps,
+  componentName,
+}) => {
   useEffect(() => {
     if (!previousState?.open && open) {
       if (
         initialStep &&
         totalSteps &&
-        initialStep <= totalSteps &&
-        initialStep > 0
+        Number(initialStep) <= Number(totalSteps) &&
+        Number(initialStep) > 0
       ) {
-        setCurrentStep(initialStep);
+        setCurrentStep(Number(initialStep));
       } else {
         setCurrentStep(1);
       }
+
+      // An invalid initialStep value was provided, we'll default to rendering the first step in this scenario
+      if (
+        (initialStep &&
+          totalSteps &&
+          Number(initialStep) > Number(totalSteps)) ||
+        Number(initialStep) <= 0
+      ) {
+        console.warn(
+          `${componentName}: An invalid \`initialStep\` prop was supplied. The \`initialStep\` prop should be a number that is greater than 0 or less than or equal to the number of steps your ${componentName} has.`
+        );
+      }
     }
-  }, [open, previousState, setCurrentStep, initialStep, totalSteps]);
+  }, [
+    open,
+    previousState,
+    setCurrentStep,
+    initialStep,
+    totalSteps,
+    componentName,
+  ]);
 };


### PR DESCRIPTION
Contributes to #1076 

This PR adds a new prop, `initialStep`, that allows for opening the create tearsheet to a custom step.

#### What did you change?
`CreateTearsheet.js`
`CreateTearsheet.test.js`
`CreateInfluencer.js`
`useResetCreateComponent.js`
#### How did you test and verify your work?
Storybook, `yarn test /CreateTearsheet/`