### PR TITLE
chore(Tearsheet): set default action set for narrow story

### DIFF
--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.stories.js
@@ -236,7 +236,7 @@ export const fullyLoaded = prepareStory(Template, {
     onClose: action('onClose called'),
     title,
     verticalPosition: 'normal',
-    actions: 0,
+    actions: 3,
   },
 });
 


### PR DESCRIPTION
Contributes to #1180 

Sets a default action set to use for the story titled `Narrow tearsheet with all header items`.

#### What did you change?
`TearsheetNarrow.stories.js`
#### How did you test and verify your work?
Storybook