### PR TITLE
feat(SidePanel): allow actionToolbarButtons to be a bit more flexible

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -525,7 +525,13 @@ export let SidePanel = React.forwardRef(
                       action.leading,
                   },
                 ])}
-                onClick={() => action.onClick()}>
+                onClick={(event) =>
+                  action.onClick
+                    ? action.onClick(event)
+                    : action.onActionToolbarButtonClick
+                    ? action.onActionToolbarButtonClick(event)
+                    : null
+                }>
                 {action.leading && action.label}
               </Button>
             ))}
@@ -673,7 +679,11 @@ SidePanel.propTypes = {
       label: PropTypes.string,
       leading: PropTypes.bool,
       icon: PropTypes.object,
-      onActionToolbarButtonClick: PropTypes.func,
+      onActionToolbarButtonClick: deprecateProp(
+        PropTypes.func,
+        'This prop will be removed in the future. Please use `onClick` instead'
+      ),
+      onClick: PropTypes.func,
       kind: PropTypes.oneOf(['ghost', 'tertiary', 'secondary', 'primary']),
     })
   ),

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -456,7 +456,8 @@ export let SidePanel = React.forwardRef(
           className={cx(`${blockClass}__title-container`, {
             [`${blockClass}__on-detail-step`]: currentStep > 0,
             [`${blockClass}__title-container--no-animation`]: !animateTitle,
-            [`${blockClass}__title-container-is-animating`]: !animationComplete,
+            [`${blockClass}__title-container-is-animating`]:
+              !animationComplete && animateTitle,
           })}>
           {currentStep > 0 && (
             <Button
@@ -492,7 +493,8 @@ export let SidePanel = React.forwardRef(
               [`${blockClass}__subtitle-text-no-animation-no-action-toolbar`]:
                 !animateTitle &&
                 (!actionToolbarButtons || !actionToolbarButtons.length),
-              [`${blockClass}__subtitle-text-is-animating`]: !animationComplete,
+              [`${blockClass}__subtitle-text-is-animating`]:
+                !animationComplete && animateTitle,
             })}>
             {subtitle}
           </p>
@@ -505,23 +507,25 @@ export let SidePanel = React.forwardRef(
             {actionToolbarButtons.map((action) => (
               <Button
                 key={action.label}
-                kind={action.leading ? action.kind : 'ghost'}
+                kind={action.kind || 'ghost'}
                 size="small"
-                disabled={false}
                 renderIcon={action.icon}
                 iconDescription={action.label}
                 tooltipPosition="bottom"
                 tooltipAlignment="center"
+                hasIconOnly={!action.leading}
+                disabled={action.disabled}
                 className={cx([
                   `${blockClass}__action-toolbar-button`,
+                  action.className,
                   {
                     [`${blockClass}__action-toolbar-icon-only-button`]:
-                      action.icon,
+                      action.icon && !action.leading,
                     [`${blockClass}__action-toolbar-leading-button`]:
-                      !action.icon,
+                      action.leading,
                   },
                 ])}
-                onClick={() => action.onActionToolbarButtonClick()}>
+                onClick={() => action.onClick()}>
                 {action.leading && action.label}
               </Button>
             ))}

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -407,19 +407,21 @@ export const WithActionToolbar = prepareStory(SlideOverTemplate, {
   args: {
     actionToolbarButtons: [
       {
+        leading: true,
         label: 'Copy',
         icon: Copy20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Toolbar button clicked: Copy'),
+        kind: 'primary',
       },
       {
         label: 'Settings',
         icon: Settings20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Toolbar button clicked: Settings'),
       },
       {
         label: 'Delete',
         icon: Delete20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Toolbar button clicked: Delete'),
       },
     ],
     ...defaultStoryProps,
@@ -473,17 +475,17 @@ export const WithStaticTitleAndActionToolbar = prepareStory(SlideOverTemplate, {
       {
         label: 'Copy',
         icon: Copy20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Action toolbar button clicked: Copy'),
       },
       {
         label: 'Settings',
         icon: Settings20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Action toolbar button clicked: Settings'),
       },
       {
         label: 'Delete',
         icon: Delete20,
-        onActionToolbarButtonClick: () => {},
+        onClick: action('Action toolbar button clicked: Delete'),
       },
     ],
   },

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -350,11 +350,11 @@ describe('SidePanel', () => {
         {
           leading: true,
           label: 'Copy 1',
-          onActionToolbarButtonClick: onActionToolbarButtonClickFn,
+          onClick: onActionToolbarButtonClickFn,
         },
         {
           label: 'Copy 2',
-          onActionToolbarButtonClick: onActionToolbarButtonClickFn,
+          onClick: onActionToolbarButtonClickFn,
         },
       ],
     });


### PR DESCRIPTION
Contributes to #1177 

Adds some flexibility to the action toolbar buttons in the side panel and properly displays the tooltip via `hasIconOnly` prop on buttons.

#### What did you change?
`SidePanel.js`
`SidePanel.test.js`
`SidePanel.stories.js`
#### How did you test and verify your work?
Storybook and updated tests