### PR TITLE
fix(SidePanel): center close svg in close button

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -837,6 +837,14 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   z-index: 5;
   top: var(--cds-spacing-03, 0.5rem);
   right: var(--cds-spacing-03, 0.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.exp--side-panel__container .bx--btn.exp--side-panel__close-button
+.bx--btn__icon {
+  margin: 0;
 }
 
 .exp--side-panel__container .exp--side-panel__body-content {

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -335,23 +335,30 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       }
     }
 
-    .bx--btn.#{$block-class}__navigation-back-button {
+    .#{$carbon-prefix}--btn.#{$block-class}__navigation-back-button {
       position: relative;
       z-index: 5;
       top: calc(-1 * #{$spacing-03});
       left: calc(-1 * #{$spacing-03});
     }
-    .bx--btn.#{$block-class}__navigation-back-button,
-    .bx--btn.#{$block-class}__close-button {
+    .#{$carbon-prefix}--btn.#{$block-class}__navigation-back-button,
+    .#{$carbon-prefix}--btn.#{$block-class}__close-button {
       min-width: 2rem;
       padding: 0;
       color: $text-01;
     }
-    .bx--btn.#{$block-class}__close-button {
+    .#{$carbon-prefix}--btn.#{$block-class}__close-button {
       position: absolute;
       z-index: 5;
       top: $spacing-03;
       right: $spacing-03;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .#{$carbon-prefix}--btn.#{$block-class}__close-button
+      .#{$carbon-prefix}--btn__icon {
+      margin: 0;
     }
     .#{$block-class}__body-content {
       padding: $spacing-05;


### PR DESCRIPTION
Fixes the placement of the close svg within the close button of the side panel

#### What did you change?
`_side-panel.scss`
#### How did you test and verify your work?
Storybook and updates styles snapshot