### PR TITLE
fix(SidePanel): fix animating state of panel

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -679,6 +679,22 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   top: var(--cds-spacing-09, 3rem);
 }
 
+.exp--side-panel__container.exp--side-panel__container-is-animating {
+  pointer-events: none;
+}
+
+.exp--side-panel__container.exp--side-panel__container-is-animating .exp--side-panel__title-container.exp--side-panel__title-container--no-animation {
+  top: 0;
+}
+
+.exp--side-panel__container.exp--side-panel__container-is-animating .exp--side-panel__subtitle-text.exp--side-panel__subtitle-text-no-animation {
+  top: var(--exp--side-panel--title-container-height);
+}
+
+.exp--side-panel__container.exp--side-panel__container-is-animating .exp--side-panel__action-toolbar.exp--side-panel__action-toolbar-no-animation {
+  top: calc( var(--exp--side-panel--title-container-height) + var(--exp--side-panel--subtitle-container-height));
+}
+
 .exp--side-panel__container .exp--side-panel__title-text {
   font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
   font-weight: var(--cds-productive-heading-03-font-weight, 400);

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -12,6 +12,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { useResizeDetector } from 'react-resize-detector';
+import { moderate02 } from '@carbon/motion';
 import wrapFocus from '../../global/js/utils/wrapFocus';
 import { pkg } from '../../settings';
 import { allPropTypes } from '../../global/js/utils/props-helper';
@@ -377,11 +378,11 @@ export let SidePanel = React.forwardRef(
         );
         if (placement && placement === 'right' && pageContentElement) {
           pageContentElement.style.marginRight = 0;
-          pageContentElement.style.transition = 'margin-right 250ms';
+          pageContentElement.style.transition = `margin-right ${moderate02}`;
           pageContentElement.style.marginRight = SIDE_PANEL_SIZES[size];
         } else if (pageContentElement) {
           pageContentElement.style.marginLeft = 0;
-          pageContentElement.style.transition = 'margin-left 250ms';
+          pageContentElement.style.transition = `margin-left ${moderate02}`;
           pageContentElement.style.marginLeft = SIDE_PANEL_SIZES[size];
         }
       }
@@ -447,6 +448,7 @@ export let SidePanel = React.forwardRef(
           actionToolbarButtons && actionToolbarButtons.length,
         [`${blockClass}__container-without-overlay`]:
           !includeOverlay && !slideIn,
+        [`${blockClass}__container-is-animating`]: !animationComplete,
       },
     ]);
 
@@ -583,11 +585,11 @@ export let SidePanel = React.forwardRef(
               animation: `${
                 open
                   ? placement === 'right'
-                    ? 'sidePanelEntranceRight 250ms'
-                    : 'sidePanelEntranceLeft 250ms'
+                    ? `sidePanelEntranceRight ${moderate02}`
+                    : `sidePanelEntranceLeft ${moderate02}`
                   : placement === 'right'
-                  ? 'sidePanelExitRight 250ms'
-                  : 'sidePanelExitLeft 250ms'
+                  ? `sidePanelExitRight ${moderate02}`
+                  : `sidePanelExitLeft ${moderate02}`
               }`,
             }}
             onAnimationEnd={onAnimationEnd}

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -197,6 +197,25 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
         top: $spacing-09;
       }
     }
+    &.#{$block-class}__container-is-animating {
+      pointer-events: none;
+    }
+    &.#{$block-class}__container-is-animating
+      .#{$block-class}__title-container.#{$block-class}__title-container--no-animation {
+      top: 0;
+    }
+    &.#{$block-class}__container-is-animating
+      .#{$block-class}__subtitle-text.#{$block-class}__subtitle-text-no-animation {
+      top: var(--#{$block-class}--title-container-height);
+    }
+    &.#{$block-class}__container-is-animating
+      .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation {
+      // stylelint-disable-next-line carbon/layout-token-use
+      top: calc(
+        var(--#{$block-class}--title-container-height) +
+          var(--#{$block-class}--subtitle-container-height)
+      );
+    }
     .#{$block-class}__title-text {
       @include carbon--type-style('productive-heading-03');
       @include setCommonTitleStyles();


### PR DESCRIPTION
I have noticed a visual defect when looking at the static title side panel stories (which this also includes the CreateSidePanel as it uses this variation of the SidePanel). The title, subtitle, and if provided action toolbar buttons jump into place after the animation of the side panel first opening. They should remain in the same place the entire time which this PR fixes.

For example, see this [story](https://ibm-cloud-cognitive.netlify.app/?path=/story/cloud-cognitive-components-side-panel-sidepanel--with-static-title-and-action-toolbar) to view the problem.

#### What did you change?
`SidePanel.js`
`_side-panel.scss`
#### How did you test and verify your work?
Storybook