### PR TITLE
chore(CreateTearsheet): add tests to cover custom hooks

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.js
@@ -32,7 +32,7 @@ import {
 } from '../../global/js/hooks';
 import { hasValidChildType } from '../../global/js/utils/hasValidChildType';
 
-const componentName = 'CreateTearsheet';
+export const componentName = 'CreateTearsheet';
 const blockClass = `${pkg.prefix}--tearsheet-create`;
 
 export let CreateTearsheet = forwardRef(

--- a/packages/cloud-cognitive/src/global/js/hooks/useCreateComponentFocus.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useCreateComponentFocus.js
@@ -26,13 +26,15 @@ export const useCreateComponentFocus = (
       const visibleStepInnerContent = document.querySelector(
         `.${componentBlockClass}__step.${componentBlockClass}__step--visible-step`
       );
-      const fullPageSteps = getCreateComponentSteps();
+      const createComponentSteps = getCreateComponentSteps();
       const focusableStepElements =
-        fullPageSteps &&
-        fullPageSteps.length &&
+        createComponentSteps &&
+        createComponentSteps.length &&
         getFocusableElements(visibleStepInnerContent);
       const activeStepComponent =
-        fullPageSteps && fullPageSteps.length && fullPageSteps[currentStep - 1];
+        createComponentSteps &&
+        createComponentSteps.length &&
+        createComponentSteps[currentStep - 1];
       if (activeStepComponent && activeStepComponent.props.onMount) {
         activeStepComponent.props.onMount();
       }


### PR DESCRIPTION
Contributes to #1195 

Adds tests for the `initialStep` prop and the `onMount` prop that can be optionally called on a per step basis.

#### What did you change?
`CreateTearsheet.test.js`
`useCreateComponentFocus.js`
#### How did you test and verify your work?
Ran tests