### PR TITLE
fix(SidePanel): #1191 allow side panel title to be optional

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -679,6 +679,19 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   top: var(--cds-spacing-09, 3rem);
 }
 
+.exp--side-panel__container .exp--side-panel__title-container.exp--side-panel__title-container-without-title {
+  padding: 0;
+}
+
+.exp--side-panel__container .exp--side-panel__title-container.exp--side-panel__title-container-without-title.exp--side-panel__on-detail-step-without-title {
+  height: calc(var(--cds-spacing-08, 2.5rem) + var(--cds-spacing-02, 0.25rem));
+  padding: var(--cds-spacing-05, 1rem) var(--cds-spacing-05, 1rem) var(--cds-spacing-03, 0.5rem) var(--cds-spacing-05, 1rem);
+}
+
+.exp--side-panel__container .exp--side-panel__title-container.exp--side-panel__title-container-without-title::before {
+  background-color: transparent;
+}
+
 .exp--side-panel__container .exp--side-panel__title-text {
   font-size: var(--cds-productive-heading-03-font-size, 1.25rem);
   font-weight: var(--cds-productive-heading-03-font-weight, 400);

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -737,6 +737,11 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   top: var(--exp--side-panel--title-container-height);
 }
 
+.exp--side-panel__container .exp--side-panel__subtitle-text.exp--side-panel__subtitle-without-title {
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-right: var(--cds-spacing-07, 2rem);
+}
+
 .exp--side-panel__container .exp--side-panel__title-container.exp--side-panel__title-container--no-animation.exp--side-panel__title-container-is-animating {
   top: 0;
 }
@@ -836,10 +841,11 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   position: absolute;
   z-index: 5;
   top: var(--cds-spacing-03, 0.5rem);
-  right: var(--cds-spacing-03, 0.5rem);
+  right: var(--cds-spacing-05, 1rem);
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: var(--cds-ui-01, #f4f4f4);
 }
 
 .exp--side-panel__container .bx--btn.exp--side-panel__close-button

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -76,7 +76,10 @@ export let SidePanel = React.forwardRef(
     useEffect(() => {
       const panelRef = ref || sidePanelRef;
       if (panelRef && panelRef.current) {
-        panelRef.current.scrollTop = 0;
+        const scrollableSection = panelRef.current.querySelector(
+          `.${blockClass}__inner-content`
+        );
+        scrollableSection.scrollTop = 0;
       }
     }, [currentStep, ref]);
 
@@ -116,6 +119,16 @@ export let SidePanel = React.forwardRef(
         );
       }
     }, [actions, condensedActions, open, animationComplete]);
+
+    // Add console warning if labelText is provided without a title.
+    // This combination is not allowed.
+    useEffect(() => {
+      if (!title && labelText) {
+        console.warn(
+          `${componentName}: The prop \`labelText\` was provided without a \`title\`. It is required to have a \`title\` when using the \`labelText\` prop.`
+        );
+      }
+    }, [labelText, title]);
 
     /* istanbul ignore next */
     const handleResize = (width, height) => {
@@ -459,32 +472,33 @@ export let SidePanel = React.forwardRef(
 
     const renderHeader = () => (
       <>
-        {title && title.length && (
-          <div
-            className={cx(`${blockClass}__title-container`, {
-              [`${blockClass}__on-detail-step`]: currentStep > 0,
-              [`${blockClass}__title-container--no-animation`]: !animateTitle,
-              [`${blockClass}__title-container-is-animating`]:
-                !animationComplete && animateTitle,
-            })}>
-            {currentStep > 0 && (
-              <Button
-                aria-label={navigationBackIconDescription}
-                kind="ghost"
-                size="small"
-                disabled={false}
-                renderIcon={ArrowLeft20}
-                iconDescription={navigationBackIconDescription}
-                className={`${blockClass}__navigation-back-button`}
-                onClick={onNavigationBack}
-              />
-            )}
-            {labelText && labelText.length && (
-              <p className={`${blockClass}__label-text`}>{labelText}</p>
-            )}
-            {renderTitle()}
-          </div>
-        )}
+        <div
+          className={cx(`${blockClass}__title-container`, {
+            [`${blockClass}__on-detail-step`]: currentStep > 0,
+            [`${blockClass}__on-detail-step-without-title`]:
+              currentStep > 0 && !title,
+            [`${blockClass}__title-container--no-animation`]: !animateTitle,
+            [`${blockClass}__title-container-is-animating`]:
+              !animationComplete && animateTitle,
+            [`${blockClass}__title-container-without-title`]: !title,
+          })}>
+          {currentStep > 0 && (
+            <Button
+              aria-label={navigationBackIconDescription}
+              kind="ghost"
+              size="small"
+              disabled={false}
+              renderIcon={ArrowLeft20}
+              iconDescription={navigationBackIconDescription}
+              className={`${blockClass}__navigation-back-button`}
+              onClick={onNavigationBack}
+            />
+          )}
+          {title && title.length && labelText && labelText.length && (
+            <p className={`${blockClass}__label-text`}>{labelText}</p>
+          )}
+          {title && title.length && renderTitle()}
+        </div>
         <Button
           aria-label={closeIconDescription}
           kind="ghost"
@@ -746,7 +760,7 @@ SidePanel.propTypes = {
   /**
    * Sets the close button icon description
    */
-  closeIconDescription: PropTypes.string,
+  closeIconDescription: PropTypes.string.isRequired,
 
   /**
    * Determines whether the side panel should render the condensed version (affects action buttons primarily)

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -140,7 +140,7 @@ export let SidePanel = React.forwardRef(
 
     // Title and subtitle scroll animation
     useEffect(() => {
-      if (open && animateTitle && animationComplete) {
+      if (open && animateTitle && animationComplete && title && title.length) {
         const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
         const sidePanelScrollArea = document.querySelector(
           `#${blockClass}-outer .${blockClass}__inner-content`
@@ -312,7 +312,14 @@ export let SidePanel = React.forwardRef(
           `${sidePanelActionBarElementHeight}px`
         );
       }
-    }, [open, animateTitle, animationComplete, shouldRender, panelHeight]);
+    }, [
+      open,
+      animateTitle,
+      animationComplete,
+      shouldRender,
+      panelHeight,
+      title,
+    ]);
 
     // click outside functionality if `includeOverlay` prop is set
     useEffect(() => {
@@ -452,40 +459,42 @@ export let SidePanel = React.forwardRef(
 
     const renderHeader = () => (
       <>
-        <div
-          className={cx(`${blockClass}__title-container`, {
-            [`${blockClass}__on-detail-step`]: currentStep > 0,
-            [`${blockClass}__title-container--no-animation`]: !animateTitle,
-            [`${blockClass}__title-container-is-animating`]:
-              !animationComplete && animateTitle,
-          })}>
-          {currentStep > 0 && (
-            <Button
-              aria-label={navigationBackIconDescription}
-              kind="ghost"
-              size="small"
-              disabled={false}
-              renderIcon={ArrowLeft20}
-              iconDescription={navigationBackIconDescription}
-              className={`${blockClass}__navigation-back-button`}
-              onClick={onNavigationBack}
-            />
-          )}
-          {labelText && labelText.length && (
-            <p className={`${blockClass}__label-text`}>{labelText}</p>
-          )}
-          {renderTitle()}
-          <Button
-            aria-label={closeIconDescription}
-            kind="ghost"
-            size="small"
-            renderIcon={Close20}
-            iconDescription={closeIconDescription}
-            className={`${blockClass}__close-button`}
-            onClick={onRequestClose}
-            ref={sidePanelCloseRef}
-          />
-        </div>
+        {title && title.length && (
+          <div
+            className={cx(`${blockClass}__title-container`, {
+              [`${blockClass}__on-detail-step`]: currentStep > 0,
+              [`${blockClass}__title-container--no-animation`]: !animateTitle,
+              [`${blockClass}__title-container-is-animating`]:
+                !animationComplete && animateTitle,
+            })}>
+            {currentStep > 0 && (
+              <Button
+                aria-label={navigationBackIconDescription}
+                kind="ghost"
+                size="small"
+                disabled={false}
+                renderIcon={ArrowLeft20}
+                iconDescription={navigationBackIconDescription}
+                className={`${blockClass}__navigation-back-button`}
+                onClick={onNavigationBack}
+              />
+            )}
+            {labelText && labelText.length && (
+              <p className={`${blockClass}__label-text`}>{labelText}</p>
+            )}
+            {renderTitle()}
+          </div>
+        )}
+        <Button
+          aria-label={closeIconDescription}
+          kind="ghost"
+          size="small"
+          renderIcon={Close20}
+          iconDescription={closeIconDescription}
+          className={`${blockClass}__close-button`}
+          onClick={onRequestClose}
+          ref={sidePanelCloseRef}
+        />
         {subtitle && subtitle.length && (
           <p
             className={cx(`${blockClass}__subtitle-text`, {
@@ -495,6 +504,7 @@ export let SidePanel = React.forwardRef(
                 (!actionToolbarButtons || !actionToolbarButtons.length),
               [`${blockClass}__subtitle-text-is-animating`]:
                 !animationComplete && animateTitle,
+              [`${blockClass}__subtitle-without-title`]: !title,
             })}>
             {subtitle}
           </p>
@@ -822,7 +832,7 @@ SidePanel.propTypes = {
   /**
    * Sets the title text
    */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   ...deprecatedProps,
 };
 

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -249,7 +249,7 @@ const ChildrenContentWithSteps = ({ currentStep, setCurrentStep }) => {
     <>
       {currentStep === 0 && (
         <div className={`${prefix}body-content`}>
-          <h5 className={`${prefix}content-subtitle`}>Step 1</h5>
+          <h5 className={`${prefix}content-subtitle`}>Main view</h5>
           {renderDataTable()}
           <Button
             kind="tertiary"
@@ -260,7 +260,7 @@ const ChildrenContentWithSteps = ({ currentStep, setCurrentStep }) => {
       )}
       {currentStep === 1 && (
         <div className={`${prefix}body-content`}>
-          <h5 className={`${prefix}content-subtitle`}>Step 2</h5>
+          <h5 className={`${prefix}content-subtitle`}>Detail view</h5>
           {renderDataTable()}
         </div>
       )}
@@ -446,14 +446,6 @@ export const SpecifyElementToHaveInitialFocus = prepareStory(
   }
 );
 
-export const WithMinimalContent = prepareStory(SlideOverTemplate, {
-  args: {
-    ...defaultStoryProps,
-    actions: 0,
-    minimalContent: true,
-  },
-});
-
 export const WithStaticTitle = prepareStory(SlideOverTemplate, {
   args: {
     ...defaultStoryProps,
@@ -486,5 +478,14 @@ export const WithStaticTitleAndActionToolbar = prepareStory(SlideOverTemplate, {
         onClick: action('Action toolbar button clicked: Delete'),
       },
     ],
+  },
+});
+
+export const WithoutTitle = prepareStory(SlideOverTemplate, {
+  args: {
+    ...defaultStoryProps,
+    actions: 0,
+    title: null,
+    includeOverlay: true,
   },
 });

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -253,9 +253,7 @@ const ChildrenContentWithSteps = ({ currentStep, setCurrentStep }) => {
           {renderDataTable()}
           <Button
             kind="tertiary"
-            onClick={() => setCurrentStep((prev) => prev + 1)}
-            // onClick={() => {}}
-          >
+            onClick={() => setCurrentStep((prev) => prev + 1)}>
             View all
           </Button>
         </div>

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -243,6 +243,11 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       top: var(--#{$block-class}--title-container-height);
     }
 
+    .#{$block-class}__subtitle-text.#{$block-class}__subtitle-without-title {
+      padding-top: $spacing-05;
+      padding-right: $spacing-07;
+    }
+
     .#{$block-class}__title-container.#{$block-class}__title-container--no-animation.#{$block-class}__title-container-is-animating {
       top: 0;
     }
@@ -351,10 +356,11 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       position: absolute;
       z-index: 5;
       top: $spacing-03;
-      right: $spacing-03;
+      right: $spacing-05;
       display: flex;
       align-items: center;
       justify-content: center;
+      background-color: $ui-01;
     }
     .#{$carbon-prefix}--btn.#{$block-class}__close-button
       .#{$carbon-prefix}--btn__icon {

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -196,6 +196,16 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       &.#{$block-class}__on-detail-step .#{$block-class}__collapsed-title-text {
         top: $spacing-09;
       }
+      &.#{$block-class}__title-container-without-title {
+        padding: 0;
+      }
+      &.#{$block-class}__title-container-without-title.#{$block-class}__on-detail-step-without-title {
+        height: calc(#{$spacing-08} + #{$spacing-02});
+        padding: $spacing-05 $spacing-05 $spacing-03 $spacing-05;
+      }
+      &.#{$block-class}__title-container-without-title::before {
+        background-color: transparent;
+      }
     }
     .#{$block-class}__title-text {
       @include carbon--type-style('productive-heading-03');


### PR DESCRIPTION
Contributes to #1191 

This PR allows for the SidePanel `title` prop to now be optional, I've removed the story title "Minimal content" and added a new one that is an example of a panel without a `title`.

#### What did you change?
`SidePanel.js`
`SidePanel.stories.js`
`_side-panel.scss`
`styles.test.js.snap`
#### How did you test and verify your work?
Storybook