### PR TITLE
feat(devtools): add support to released components (1 / 3)

### DIFF
--- a/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
+++ b/docs/reviews/RELEASE_REVIEW_GUIDELINES.md
@@ -52,17 +52,18 @@ responds to the currently set Carbon theme.\
 `- [ ]` Components are functional components using hooks.\
 `- [ ]` Public components which produce DOM structures support className.\
 `- [ ]` Public components support a ref (via React.forwardRef).\
+`- [ ]` Public component supports a [Devtools attribute](https://github.com/carbon-design-system/ibm-cloud-cognitive/search?l=JavaScript&q=devtools&type=)
+\
 `- [ ]` All significant DOM elements have meaningful classes.\
-`- [ ]` Additional attributes that are not identified as props (such as title,
-aria-\*, etc) are passed through to an appropriate DOM node of the component as
-HTML attributes.\
+`- [ ]` Additional attributes that are not identified as props (such as title, aria-\*,
+etc) are passed through to an appropriate DOM node of the component as HTML attributes.\
 `- [ ]` No warnings, errors or log messages in the console.\
-`- [ ]` Each public component JS is exported in /src/components/index.js, each
-public component SCSS is included in /src/components/\_index.scss, and each
-public component has a flag in package-settings.js.\
- `- [ ]` Each public component SCSS lists all of the Carbon and C&CS components
-imported and used by the JavaScript code and explicitly imports the SCSS for
-each of these components.
+`- [ ]` Each public component JS is exported in /src/components/index.js, each public
+component SCSS is included in /src/components/\_index.scss, and each public component
+has a flag in package-settings.js.\
+ `- [ ]` Each public component SCSS lists all of the Carbon and C&CS components imported
+and used by the JavaScript code and explicitly imports the SCSS for each of these
+components.
 
 `###` Standards
 

--- a/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.test.js
+++ b/packages/cloud-cognitive/scripts/generate/templates/DISPLAY_NAME.test.js
@@ -56,7 +56,7 @@ describe(componentName, () => {
     expect(ref.current).toHaveClass(blockClass);
   });
 
-  it('adds the Devtools prop to the containing node', () => {
+  it('adds the Devtools attribute to the containing node', () => {
     render(<DISPLAY_NAME data-testid={dataTestId}> </DISPLAY_NAME>);
 
     expect(screen.getByTestId(dataTestId)).toHaveAttribute(

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.js
@@ -26,8 +26,11 @@ import {
 } from '@carbon/icons-react';
 import { APIKeyDownloader } from './APIKeyDownloader';
 import { pkg } from '../../settings';
-import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { isRequiredIf } from '../../global/js/utils/props-helper';
+import uuidv4 from '../../global/js/utils/uuidv4';
+
 const componentName = 'APIKeyModal';
 
 export let APIKeyModal = forwardRef(
@@ -185,7 +188,7 @@ export let APIKeyModal = forwardRef(
     return (
       <ComposedModal
         {...rest}
-        {...{ open, ref }}
+        {...{ open, ref, ...getDevtoolsProps(componentName) }}
         className={cx(className, blockClass)}
         onClose={onCloseHandler}
         size="sm"

--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
@@ -8,7 +8,12 @@
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+
+import { pkg } from '../../settings';
+
 import { APIKeyModal } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 Object.assign(navigator, {
   clipboard: {
@@ -307,14 +312,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass(defaultProps.className);
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    render(<APIKeyModal {...defaultProps} data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<APIKeyModal {...defaultProps} data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<APIKeyModal {...defaultProps} ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<APIKeyModal {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
@@ -210,7 +210,7 @@ describe(componentName, () => {
     expect(ref.current.outerModal.current).toHaveClass(blockClass);
   });
 
-  it('adds the Devtools prop to the containing node', () => {
+  it('adds the Devtools attribute to the containing node', () => {
     renderComponent({ 'data-testid': dataTestId });
 
     expect(screen.getByTestId(dataTestId)).toHaveAttribute(

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -11,7 +11,10 @@ import React, { useEffect, useCallback, useState } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
+
 import { CREATE_FULL_PAGE_SECTION, CREATE_FULL_PAGE_STEP } from './constants';
 
 // Carbon and package components we use.
@@ -326,7 +329,11 @@ export let CreateFullPage = React.forwardRef(
     // currently, we are not supporting the use of 'view all' toggle state or CreateFullPageSection -- this may be a future feature
     /* istanbul ignore next */
     return (
-      <div {...rest} ref={ref} className={cx(blockClass, className)}>
+      <div
+        {...rest}
+        ref={ref}
+        className={cx(blockClass, className)}
+        {...getDevtoolsProps(componentName)}>
         <div className={`${blockClass}__influencer`}>
           <CreateInfluencer
             activeSectionIndex={activeSectionIndex}

--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.test.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.test.js
@@ -16,8 +16,10 @@ import { CreateFullPageStep } from './CreateFullPageStep';
 
 import { TextInput } from 'carbon-components-react';
 
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
 const componentName = CreateFullPage.displayName;
-const blockClass = `${pkg.prefix}--create-full-page`;
+const blockClass = `${prefix}--create-full-page`;
 const nextButtonText = 'Next';
 const backButtonText = 'Back';
 const cancelButtonText = 'Cancel';
@@ -159,6 +161,15 @@ describe(componentName, () => {
   it('adds additional properties to the containing node', () => {
     renderCreateFullPage({ 'data-testid': dataTestId });
     screen.getByTestId(dataTestId);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderCreateFullPage({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 
   it('renders the CreateFullPage component', () => {

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.js
@@ -18,10 +18,11 @@ import {
   Button,
 } from 'carbon-components-react';
 
-// Other standard imports.
-import { pkg } from '../../settings';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg } from '../../settings';
 
 const componentName = 'CreateModal';
 const blockClass = `${pkg.prefix}--create-modal`;
@@ -69,7 +70,8 @@ export let CreateModal = React.forwardRef(
         onClose={() => {
           onRequestClose?.();
           return false;
-        }}>
+        }}
+        {...getDevtoolsProps(componentName)}>
         <ModalHeader title={title} titleClassName={`${blockClass}__title`}>
           {subtitle && <p className={`${blockClass}__subtitle`}>{subtitle}</p>}
         </ModalHeader>

--- a/packages/cloud-cognitive/src/components/CreateModal/CreateModal.test.js
+++ b/packages/cloud-cognitive/src/components/CreateModal/CreateModal.test.js
@@ -14,7 +14,9 @@ import { pkg } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-const blockClass = `${pkg.prefix}--create-modal`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--create-modal`;
 
 import { CreateModal } from '.';
 const componentName = CreateModal.displayName;
@@ -91,6 +93,15 @@ describe(componentName, () => {
   it('adds additional properties to the containing node', () => {
     renderComponent({ 'data-testid': dataTestId });
     screen.getByTestId(dataTestId);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 
   it('has no accessibility violations', async () => {

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.js
@@ -12,6 +12,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { deprecateProp } from '../../global/js/utils/props-helper';
 
 // Carbon and package components we use.
@@ -78,6 +80,7 @@ export let CreateSidePanel = React.forwardRef(
             subtitle,
             actions,
             selectorPrimaryFocus,
+            ...getDevtoolsProps(componentName),
           }}
           placement="right"
           slideIn

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
@@ -14,6 +14,8 @@ import { pkg } from '../../settings';
 
 import { CreateSidePanel } from '.';
 
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
 const componentName = CreateSidePanel.displayName;
 
 const title = 'Test Create Side panel';
@@ -22,7 +24,7 @@ const formDescription =
   'This is a test description. It has several lines. It should render a side panel.';
 const selectorPrimaryFocus = '.bx--text-input';
 const formTitle = 'This is a test form title';
-const blockClass = `${pkg.prefix}--create-side-panel`;
+const blockClass = `${prefix}--create-side-panel`;
 
 const renderComponent = ({ ...rest }, children = <p>test</p>) =>
   render(
@@ -131,8 +133,9 @@ describe(componentName, () => {
     expect(screen.getByRole('complementary')).toHaveClass(className);
   });
 
+  const dataTestId = uuidv4();
+
   it('adds additional properties to the containing node', () => {
-    const dataTestId = uuidv4();
     renderComponent({ 'data-testid': dataTestId });
     screen.getByTestId(dataTestId);
   });
@@ -141,5 +144,14 @@ describe(componentName, () => {
     const ref = React.createRef();
     renderComponent({ ref: ref });
     expect(ref.current).toEqual(screen.getByRole('complementary'));
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Form } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
+
 import { TearsheetNarrow } from '../Tearsheet/TearsheetNarrow';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -82,7 +85,8 @@ export let CreateTearsheetNarrow = React.forwardRef(
         label={label}
         selectorPrimaryFocus={selectorPrimaryFocus}
         verticalPosition={verticalPosition}
-        role="presentation">
+        role="presentation"
+        {...getDevtoolsProps(componentName)}>
         <h3 className={cx(`${blockClass}__form-title-text`, formTextClass)}>
           {formTitle}
         </h3>

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.test.js
@@ -14,7 +14,9 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { CreateTearsheetNarrow } from '.';
 
-const blockClass = `${pkg.prefix}--create-tearsheet-narrow`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--create-tearsheet-narrow`;
 const componentName = CreateTearsheetNarrow.displayName;
 
 // values to use
@@ -96,6 +98,15 @@ describe(componentName, () => {
     const ref = React.createRef();
     renderComponent({ ref });
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 
   it('should disable the primary action button', () => {

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
@@ -12,8 +12,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import '../../global/js/utils/props-helper';
+import { pkg } from '../../settings';
+
 import { EmptyStateContent } from './EmptyStateContent';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -55,7 +58,8 @@ export let EmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         {illustration && renderIllustration()}
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.test.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.test.js
@@ -19,9 +19,11 @@ import { NotificationsEmptyState } from './NotificationsEmptyState';
 import { UnauthorizedEmptyState } from './UnauthorizedEmptyState';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
 const dataTestId = uuidv4();
 const className = uuidv4();
-const blockClass = `${pkg.prefix}--empty-state`;
+const blockClass = `${prefix}--empty-state`;
 const { name } = EmptyState;
 
 const defaultProps = {
@@ -110,6 +112,15 @@ describe(name, () => {
     const ref = React.createRef();
     render(<EmptyState {...defaultProps} ref={ref} />);
     expect(ref.current.classList.contains(blockClass)).toBeTruthy();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<EmptyState {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(EmptyState.displayName)
+    );
   });
 
   it('applies className to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Link } from 'carbon-components-react';
 import cx from 'classnames';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { ErrorIllustration } from '../assets/ErrorIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let ErrorEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <ErrorIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
@@ -21,8 +21,10 @@ import {
 import cx from 'classnames';
 import { ErrorFilled16, CheckmarkFilled16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import uuidv4 from '../../global/js/utils/uuidv4';
+import { pkg } from '../../settings';
 
 const componentName = 'ExportModal';
 
@@ -105,7 +107,7 @@ export let ExportModal = forwardRef(
         aria-label={title}
         size="sm"
         preventCloseOnClickOutside
-        {...{ open, ref, onClose }}>
+        {...{ open, ref, onClose, ...getDevtoolsProps(componentName) }}>
         <ModalHeader className={`${blockClass}__header`} title={title} />
         <ModalBody className={`${blockClass}__body-container`}>
           {!submitted && (

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
@@ -9,9 +9,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { pkg } from '../../settings';
+
 import { ExportModal } from '.';
 
+const { devtoolsAttribute, getDevtoolsId } = pkg;
+
 const componentName = ExportModal.displayName;
+
 const defaultProps = {
   body: 'body content',
   className: 'test-class',
@@ -165,14 +170,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass(defaultProps.className);
   });
 
+  const dataTestId = 'dataTestId';
+
   it('adds additional properties to the containing node', () => {
-    render(<ExportModal {...defaultProps} data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<ExportModal {...defaultProps} data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<ExportModal {...defaultProps} ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<ExportModal {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.js
@@ -8,8 +8,11 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '../Card';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { prepareProps } from '../../global/js/utils/props-helper';
+import { pkg } from '../../settings';
+
 const componentName = 'ExpressiveCard';
 
 export let ExpressiveCard = forwardRef((props, ref) => {
@@ -19,7 +22,10 @@ export let ExpressiveCard = forwardRef((props, ref) => {
     'productive',
     'titleSize',
   ]);
-  return <Card ref={ref} {...validProps} />;
+
+  return (
+    <Card ref={ref} {...validProps} {...getDevtoolsProps(componentName)} />
+  );
 });
 
 // Return a placeholder if not released and not enabled by feature flag

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.test.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.test.js
@@ -8,7 +8,11 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { pkg } from '../../settings';
+
 import { ExpressiveCard } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 const componentName = ExpressiveCard.displayName;
 
@@ -28,14 +32,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass('test-class');
   });
 
+  const dataTestId = 'dataTestId';
+
   it('adds additional properties to the containing node', () => {
-    render(<ExpressiveCard data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<ExpressiveCard data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<ExpressiveCard ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<ExpressiveCard data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError403/HTTPError403.js
@@ -13,6 +13,8 @@ import cx from 'classnames';
 import { arrayOf, shape, string } from 'prop-types';
 import { HTTPErrorSvg403 } from '../assets/HTTPErrorSvg403';
 import { HTTPErrorContent } from '../HTTPErrorContent';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -22,7 +24,11 @@ const componentName = 'HTTPError403';
 export let HTTPError403 = React.forwardRef(
   ({ className, description, errorCodeLabel, links, title, ...rest }, ref) => {
     return (
-      <div {...rest} className={cx(blockClass, className)} ref={ref}>
+      <div
+        {...rest}
+        className={cx(blockClass, className)}
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <HTTPErrorContent {...{ description, errorCodeLabel, title, links }} />
         <HTTPErrorSvg403 className={`${blockClass}__image`} />
       </div>

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPError404/HTTPError404.js
@@ -13,6 +13,8 @@ import cx from 'classnames';
 import { arrayOf, shape, string } from 'prop-types';
 import { HTTPErrorSvg404 } from '../assets/HTTPErrorSvg404';
 import { HTTPErrorContent } from '../HTTPErrorContent';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -22,7 +24,11 @@ const componentName = 'HTTPError404';
 export let HTTPError404 = React.forwardRef(
   ({ className, description, errorCodeLabel, links, title, ...rest }, ref) => {
     return (
-      <div {...rest} className={cx(blockClass, className)} ref={ref}>
+      <div
+        {...rest}
+        className={cx(blockClass, className)}
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <HTTPErrorContent {...{ description, errorCodeLabel, title, links }} />
         <HTTPErrorSvg404 className={`${blockClass}__image`} />
       </div>

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrorOther/HTTPErrorOther.js
@@ -13,6 +13,8 @@ import cx from 'classnames';
 import { arrayOf, shape, string } from 'prop-types';
 import { HTTPErrorSvgOther } from '../assets/HTTPErrorSvgOther';
 import { HTTPErrorContent } from '../HTTPErrorContent';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -22,7 +24,11 @@ const componentName = 'HTTPErrorOther';
 export let HTTPErrorOther = React.forwardRef(
   ({ className, description, errorCodeLabel, links, title, ...rest }, ref) => {
     return (
-      <div {...rest} className={cx(blockClass, className)} ref={ref}>
+      <div
+        {...rest}
+        className={cx(blockClass, className)}
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <HTTPErrorContent {...{ description, errorCodeLabel, title, links }} />
         <HTTPErrorSvgOther className={`${blockClass}__image`} />
       </div>

--- a/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrors.test.js
+++ b/packages/cloud-cognitive/src/components/HTTPErrors/HTTPErrors.test.js
@@ -16,7 +16,9 @@ import { HTTPError404 } from './HTTPError404';
 import { HTTPError403 } from './HTTPError403';
 import { HTTPErrorOther } from './HTTPErrorOther';
 
-const blockClass = `${pkg.prefix}--http-errors`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--http-errors`;
 const componentName = HTTPError404.displayName;
 
 const dataTestId = uuidv4();
@@ -77,6 +79,16 @@ describe(componentName, () => {
       container.querySelector(`.${blockClass}[data-testid="${dataTestId}"]`)
     ).toBeInTheDocument();
   });
+
+  it("adds the Devtools attribute to the `HTTPError404`'s containing node", () => {
+    render(<HTTPError404 {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
+  });
+
   it('should render the HTTPError403 component', () => {
     const { container } = render(<HTTPError403 {...defaultProps} />);
     expect(screen.getByText(errorCodeLabel));
@@ -87,6 +99,16 @@ describe(componentName, () => {
       container.querySelector(`.${blockClass}[data-testid="${dataTestId}"]`)
     ).toBeInTheDocument();
   });
+
+  it("adds the Devtools attribute to the `HTTPError403`'s containing node", () => {
+    render(<HTTPError403 {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(HTTPError403.displayName)
+    );
+  });
+
   it('should render the HTTPErrorOther component', () => {
     const { container } = render(<HTTPErrorOther {...defaultProps} />);
     expect(screen.getByText(errorCodeLabel));
@@ -96,5 +118,14 @@ describe(componentName, () => {
     expect(
       container.querySelector(`.${blockClass}[data-testid="${dataTestId}"]`)
     ).toBeInTheDocument();
+  });
+
+  it("adds the Devtools attribute to the `HTTPErrorOther`'s containing node", () => {
+    render(<HTTPErrorOther {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(HTTPErrorOther.displayName)
+    );
   });
 });


### PR DESCRIPTION
Contributes to #1178 

#### Description

PR to add Devtools support and tests to numerous released components:
  - `APIKeyModal`
  - `CreateFullPage`
  - `CreateModal`
  - `CreateSidePanel`
  - `CreateTearsheetNarrow`
  - `EmptyState`
  - `ErrorEmptyState`
  - `ExportModal`
  - `ExpressiveCard`
  - `HTTPError403`
  - `HTTPError404`
  - `HTTPErrorOther`

##### Other proposed changes

- Add Devtools guidance to release documentation
- Update Devtools test description to better reflect DOM attributes instead of props