### PR TITLE
feat(security): update configuration, refactor `package.json` and dependencies

### DIFF
--- a/packages/core/.storybook/index.scss
+++ b/packages/core/.storybook/index.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2020
+// Copyright IBM Corp. 2020, 2021
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -12,8 +12,7 @@
 // to ensure we are resilient against different CSS loading orders and our
 // styles have the specificity necessary to override Carbon styles when needed.
 @import '../../cloud-cognitive/src/index-without-carbon';
-
-// Load other package styles here, eg security...
+@import '../../security/src/index';
 
 // Load all Carbon styles now
 @import '../css/carbon';

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -1,11 +1,10 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-const { sync } = require('glob');
 const { resolve } = require('path');
 const { merge } = require('webpack-merge');
 
@@ -28,12 +27,7 @@ module.exports = {
     //fastRefresh: true, -- this option would be nice, but seems to cause errors, see https://github.com/storybookjs/storybook/issues/13745
     strictMode: true,
   },
-
-  stories: sync(resolve(__dirname, '..', '..', '**/*.stories.*')).filter(
-    (story) =>
-      !story.includes('node_modules') && !story.includes('DISPLAY_NAME')
-  ),
-
+  stories: ['../../**/+(docs|src)/**/*+(-story|.stories).*'],
   webpackFinal: async (configuration) =>
     merge(configuration, {
       cache: {

--- a/packages/security/.babelrc.js
+++ b/packages/security/.babelrc.js
@@ -1,1 +1,16 @@
-module.exports = require('babel-preset-ibm-cloud-cognitive')();
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = require('deepmerge')(
+  require('babel-preset-ibm-cloud-cognitive')(),
+  {
+    plugins: [
+      '@babel/plugin-proposal-export-default-from',
+      'babel-plugin-macros',
+    ],
+  }
+);

--- a/packages/security/.stylelintrc.js
+++ b/packages/security/.stylelintrc.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  extends: '../../.stylelintrc',
+  ignoreFiles: ['**/css-gridish/**'],
+  rules: {
+    'declaration-property-value-disallowed-list': null,
+    'property-no-unknown': [
+      true,
+      {
+        ignoreProperties: ['/^spacing-/'],
+      },
+    ],
+    'selector-pseudo-class-no-unknown': [
+      true,
+      {
+        ignorePseudoClasses: ['export'],
+      },
+    ],
+  },
+};

--- a/packages/security/config.js
+++ b/packages/security/config.js
@@ -1,8 +1,8 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-export const sectionTitle = 'Legacy/Security';
+export const sectionTitle = 'Security';

--- a/packages/security/jest.config.js
+++ b/packages/security/jest.config.js
@@ -1,8 +1,13 @@
 /**
- * Copyright IBM Corp. 2020, 2020
+ * Copyright IBM Corp. 2020, 2021
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = require('jest-config-ibm-cloud-cognitive');
+module.exports = {
+  ...require('deepmerge')(require('jest-config-ibm-cloud-cognitive'), {
+    setupFilesAfterEnv: ['./setup/setupFilesAfterEnv'],
+  }),
+  transformIgnorePatterns: ['node_modules/(?!carbon-components-react)'],
+};

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -33,15 +33,19 @@
     "build:css": "bundler bundle:scss src/index.scss",
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js:modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js:modules -d lib",
-    "build:js:modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js'",
+    "build:js:modules": "babel src --ignore '**/_mocks_','**/__tests__','**/*+(-story|.stories).*'",
     "build:scss": "copyfiles 'src/**/*.scss' scss -u 1",
     "ci-check": "node scripts/import",
     "clean": "rimraf css es lib scss",
     "test": "run-p test:*",
     "test:js": "jest --colors",
-    "test:scss": "bundler check 'src/**/*.scss'",
+    "test:scss": "bundler check 'src/**/*.scss' -i '**/css-gridish/**'",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
     "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon)/'"
+  },
+  "peerDependencies": {
+    "react": "^16.8.6 || ^17.0.1",
+    "react-dom": "^16.8.6 || ^17.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.15.3",
@@ -52,10 +56,15 @@
     "carbon-components": "^10.41.0",
     "carbon-components-react": "^7.41.0",
     "carbon-icons": "^7.0.7",
-    "classnames": "^2.3.1"
+    "classnames": "^2.3.1",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-export-default-from": "^7.14.5",
     "@carbon/bundler": "^10.11.0",
+    "babel-plugin-macros": "^3.1.0",
+    "babel-preset-ibm-cloud-cognitive": "^0.9.0",
+    "deepmerge": "^4.2.2",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "jest": "^27.0.6",

--- a/packages/security/setup/setupFilesAfterEnv.js
+++ b/packages/security/setup/setupFilesAfterEnv.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright IBM Corp. 2021, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const { fn } = jest;
+
+window.ResizeObserver = fn().mockImplementation(() => ({
+  disconnect: fn(),
+  observe: fn(),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,7 +379,7 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-dynamic-import" "^7.8.3"
 
-"@babel/plugin-proposal-export-default-from@^7.12.1":
+"@babel/plugin-proposal-export-default-from@^7.12.1", "@babel/plugin-proposal-export-default-from@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.14.5.tgz#8931a6560632c650f92a8e5948f6e73019d6d321"
   integrity sha512-T8KZ5abXvKMjF6JcoXjgac3ElmXf0AWzJwi2O/42Jk+HmCky3D9+i1B7NPP1FblyceqTevKeV/9szeikFoaMDg==
@@ -5636,7 +5636,7 @@ babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.4.2, babel-plugin-macros@^2.8
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-macros@^3.0.1:
+babel-plugin-macros@^3.0.1, babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
   integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-security/issues/973

#### Proposed changes

- Add Babel, Jest, and Stylelint, and update Storybook configuration to support [`security` migration to `ibm-cloud-cognitive`](https://github.com/carbon-design-system/ibm-cloud-cognitive/pull/918)
- Refactor `security/package.json` and include missing dependency declarations
- - Reintroduce `security` style entry point to Storybook
