### PR TITLE
feat: page header props to influence grid width

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -68,7 +68,9 @@ export let PageHeader = React.forwardRef(
       disableBreadcrumbScroll,
       expandHeaderIconDescription,
       expandHeaderLabel: deprecated_expandHeaderLabel,
+      fullWidthGrid,
       hasCollapseHeaderToggle,
+      narrowGrid,
       navigation,
       pageActions,
       pageActionsOverflowLabel,
@@ -495,7 +497,7 @@ export let PageHeader = React.forwardRef(
           ])}
           style={pageHeaderStyles}
           ref={headerRef}>
-          <Grid>
+          <Grid fullWidth={fullWidthGrid} narrow={narrowGrid}>
             <div className={`${blockClass}__non-navigation-row-content`}>
               {hasBreadcrumbRow ? (
                 <Row
@@ -1030,6 +1032,10 @@ PageHeader.propTypes = {
       hasBackgroundAlways && hasCollapseHeaderToggle
   ),
   /**
+   * The PageHeader is hosted in a Carbon grid, this value is passed through to the Carbon grid fullWidth prop
+   */
+  fullWidthGrid: PropTypes.bool,
+  /**
    * Specifies if the PageHeader should have a background always on and defaults to the preferred `true`.
    * When false some parts of the header gain a background if they stick to the top of the PageHeader on scroll.
    */
@@ -1041,6 +1047,10 @@ PageHeader.propTypes = {
    * Collapsing has no effect if there is insufficient content to scroll.
    */
   hasCollapseHeaderToggle: PropTypes.bool,
+  /**
+   * The PageHeader is hosted in a Carbon grid, this value is passed through to the Carbon grid narrow prop
+   */
+  narrowGrid: PropTypes.bool,
   /**
    * Content for the navigation area in the PageHeader. Should
    * be a React element that is normally a Carbon Tabs component. Optional.
@@ -1127,7 +1137,9 @@ PageHeader.propTypes = {
 };
 
 PageHeader.defaultProps = {
+  fullWidthGrid: false,
   hasBackgroundAlways: true,
+  narrowGrid: false,
 };
 
 PageHeader.displayName = componentName;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -725,4 +725,15 @@ describe('PageHeader', () => {
 
     warn.mockRestore(); // Remove mock
   });
+
+  test.only('PageHeader grid settings narrow and fullWidth', () => {
+    const dataTestId = uuidv4();
+    const { container } = render(
+      <PageHeader data-testid={dataTestId} narrowGrid fullWidthGrid />
+    );
+
+    const grid = container.querySelector(`.${carbon.prefix}--grid`);
+    expect(grid).toHaveClass(`${carbon.prefix}--grid--narrow`);
+    expect(grid).toHaveClass(`${carbon.prefix}--grid--full-width`);
+  });
 });

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -726,7 +726,7 @@ describe('PageHeader', () => {
     warn.mockRestore(); // Remove mock
   });
 
-  test.only('PageHeader grid settings narrow and fullWidth', () => {
+  test('PageHeader grid settings narrow and fullWidth', () => {
     const dataTestId = uuidv4();
     const { container } = render(
       <PageHeader data-testid={dataTestId} narrowGrid fullWidthGrid />


### PR DESCRIPTION
#### What did you change?

The PageHeader is hosted in a grid but was missing properties influencing the width of the grid "narrow" and "fullWidth". This PR adds the props "narrowGrid" and "fullWidthGrid".

#### How did you test and verify your work?

Storybook and additional tests for grid width classes.