### PR TITLE
feat(devtools): add support to released components (2 / 3)

### DIFF
--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.test.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.test.js
@@ -19,9 +19,11 @@ import { NotificationsEmptyState } from './NotificationsEmptyState';
 import { UnauthorizedEmptyState } from './UnauthorizedEmptyState';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
 const dataTestId = uuidv4();
 const className = uuidv4();
-const blockClass = `${pkg.prefix}--empty-state`;
+const blockClass = `${prefix}--empty-state`;
 const { name } = EmptyState;
 
 const defaultProps = {
@@ -145,6 +147,15 @@ describe(name, () => {
     expect(container.querySelector('svg')).toBeTruthy();
   });
 
+  it("adds the Devtools attribute to the `NoDataEmptyState`'s containing node", () => {
+    render(<NoDataEmptyState {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(NoDataEmptyState.displayName)
+    );
+  });
+
   it('should render the ErrorEmptyState component', () => {
     const { container, rerender } = render(
       <ErrorEmptyState {...defaultProps} />
@@ -152,6 +163,15 @@ describe(name, () => {
     expect(container.querySelector('svg')).toBeTruthy();
     rerender(<ErrorEmptyState {...defaultProps} illustrationTheme="dark" />);
     expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it("adds the Devtools attribute to the `ErrorEmptyState`'s containing node", () => {
+    render(<ErrorEmptyState {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(ErrorEmptyState.displayName)
+    );
   });
 
   it('should render the NoTagsEmptyState component', () => {
@@ -162,6 +182,16 @@ describe(name, () => {
     rerender(<NoTagsEmptyState {...defaultProps} illustrationTheme="dark" />);
     expect(container.querySelector('svg')).toBeTruthy();
   });
+
+  it("adds the Devtools attribute to the `NoTagsEmptyState`'s containing node", () => {
+    render(<NoTagsEmptyState {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(NoTagsEmptyState.displayName)
+    );
+  });
+
   it('should render the NotFoundEmptyState component', () => {
     const { container, rerender } = render(
       <NotFoundEmptyState {...defaultProps} />
@@ -170,6 +200,16 @@ describe(name, () => {
     rerender(<NotFoundEmptyState {...defaultProps} illustrationTheme="dark" />);
     expect(container.querySelector('svg')).toBeTruthy();
   });
+
+  it("adds the Devtools attribute to the `NotFoundEmptyState`'s containing node", () => {
+    render(<NotFoundEmptyState {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(NotFoundEmptyState.displayName)
+    );
+  });
+
   it('should render the NotificationsEmptyState component', () => {
     const { container, rerender } = render(
       <NotificationsEmptyState {...defaultProps} />
@@ -180,6 +220,18 @@ describe(name, () => {
     );
     expect(container.querySelector('svg')).toBeTruthy();
   });
+
+  it("adds the Devtools attribute to the `NotificationsEmptyState`'s containing node", () => {
+    render(
+      <NotificationsEmptyState {...defaultProps} data-testid={dataTestId} />
+    );
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(NotificationsEmptyState.displayName)
+    );
+  });
+
   it('should render the UnauthorizedEmptyState component', () => {
     const { container, rerender } = render(
       <UnauthorizedEmptyState {...defaultProps} />
@@ -190,6 +242,18 @@ describe(name, () => {
     );
     expect(container.querySelector('svg')).toBeTruthy();
   });
+
+  it("adds the Devtools attribute to the `UnauthorizedEmptyState`'s containing node", () => {
+    render(
+      <UnauthorizedEmptyState {...defaultProps} data-testid={dataTestId} />
+    );
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(UnauthorizedEmptyState.displayName)
+    );
+  });
+
   it('should throw a custom prop type validation error when an illustration is used without an illustrationDescription prop', () => {
     jest.spyOn(console, 'error').mockImplementation(jest.fn());
     render(<EmptyState {...defaultProps} illustration={CustomIllustration} />);

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { NoDataIllustration } from '../assets/NoDataIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let NoDataEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <NoDataIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { NoTagsIllustration } from '../assets/NoTagsIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let NoTagsEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <NoTagsIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { NotFoundIllustration } from '../assets/NotFoundIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let NotFoundEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <NotFoundIllustration theme={illustrationTheme} size={size} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { NotificationsIllustration } from '../assets/NotificationsIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let NotificationsEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <NotificationsIllustration size={size} theme={illustrationTheme} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
@@ -12,7 +12,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Button, Link } from 'carbon-components-react';
+
+import { getDevtoolsProps } from '../../../global/js/utils/devtools';
 import { pkg } from '../../../settings';
+
 import { EmptyStateContent } from '../EmptyStateContent';
 import { UnauthorizedIllustration } from '../assets/UnauthorizedIllustration';
 import { EmptyStateDefaultProps } from '../EmptyState';
@@ -42,7 +45,8 @@ export let UnauthorizedEmptyState = React.forwardRef(
           ...rest
         }
         className={cx(blockClass, className)}
-        ref={ref}>
+        ref={ref}
+        {...getDevtoolsProps(componentName)}>
         <UnauthorizedIllustration size={size} theme={illustrationTheme} />
         <EmptyStateContent
           action={action}

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
@@ -18,7 +18,10 @@ import {
 } from 'carbon-components-react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import uuidv4 from '../../global/js/utils/uuidv4';
+
 import { pkg } from '../../settings';
 const componentName = 'ImportModal';
 
@@ -160,7 +163,7 @@ export let ImportModal = forwardRef(
     return (
       <ComposedModal
         {...rest}
-        {...{ open, ref, onClose }}
+        {...{ open, ref, onClose, ...getDevtoolsProps(componentName) }}
         aria-label={title}
         className={cx(blockClass, className)}
         size="sm"

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.test.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.test.js
@@ -9,8 +9,10 @@ import { fireEvent, render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { carbon } from '../../settings';
+import { carbon, pkg } from '../../settings';
 import { ImportModal } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
@@ -320,14 +322,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass(defaultProps.className);
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    render(<ImportModal {...defaultProps} data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<ImportModal {...defaultProps} data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<ImportModal {...defaultProps} ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<ImportModal {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
@@ -11,9 +11,12 @@ import React, { useEffect, useState, useRef } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { useClickOutside } from '../../global/js/hooks';
 import { pkg } from '../../settings';
 import { timeAgo } from './utils';
+
 import { NotificationsEmptyState } from '../EmptyStates/NotificationsEmptyState';
 
 // Carbon and package components we use.
@@ -333,7 +336,8 @@ export let NotificationsPanel = React.forwardRef(
           animation: `${open ? 'fadeIn 250ms' : 'fadeOut 250ms'}`,
         }}
         onAnimationEnd={onAnimationEnd}
-        ref={ref || notificationPanelRef}>
+        ref={ref || notificationPanelRef}
+        {...getDevtoolsProps(componentName)}>
         <div className={`${blockClass}__header-container`}>
           <div className={`${blockClass}__header-flex`}>
             <h1 className={`${blockClass}__header`}>{title}</h1>

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.test.js
@@ -9,12 +9,16 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import React from 'react';
-import { pkg } from '../../settings';
+
 import uuidv4 from '../../global/js/utils/uuidv4';
+import { pkg } from '../../settings';
+
 import { NotificationsPanel } from '.';
 import data from './NotificationsPanel_data';
 
-const blockClass = `${pkg.prefix}--notifications-panel`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--notifications-panel`;
 const dataTestId = uuidv4();
 const onNotificationClickFn = jest.fn();
 const onDismissSingleNotificationFn = jest.fn();
@@ -201,6 +205,18 @@ describe('Notifications', () => {
       data: [],
     });
     expect(ref.current.classList.contains(blockClass)).toBeTruthy();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderNotifications({
+      data: [],
+      'data-testid': dataTestId,
+    });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(NotificationsPanel.displayName)
+    );
   });
 
   it('should close the notifications panel when click is detected outside', () => {

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -7,11 +7,10 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { extractShapesArray } from '../../global/js/utils/props-helper';
 import { layout05, baseFontSize } from '@carbon/layout';
 import cx from 'classnames';
 import { useResizeDetector } from 'react-resize-detector';
-import { useWindowResize, useNearestScroll } from '../../global/js/hooks';
+
 import {
   BreadcrumbItem,
   Grid,
@@ -21,17 +20,24 @@ import {
   SkeletonText,
   Tag,
 } from 'carbon-components-react';
+
+import { useWindowResize, useNearestScroll } from '../../global/js/hooks';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+
+import {
+  deprecateProp,
+  deprecatePropUsage,
+  extractShapesArray,
+  prepareProps,
+} from '../../global/js/utils/props-helper';
+
+import { pkg } from '../../settings';
+
 import { ActionBar } from '../ActionBar/';
 import { BreadcrumbWithOverflow } from '../BreadcrumbWithOverflow';
 import { TagSet, string_required_if_more_than_10_tags } from '../TagSet/TagSet';
 import { ButtonSetWithOverflow } from '../ButtonSetWithOverflow';
-import { pkg } from '../../settings';
 import { ChevronUp16 } from '@carbon/icons-react';
-import {
-  deprecateProp,
-  deprecatePropUsage,
-  prepareProps,
-} from '../../global/js/utils/props-helper';
 
 const componentName = 'PageHeader';
 
@@ -494,7 +500,8 @@ export let PageHeader = React.forwardRef(
             },
           ])}
           style={pageHeaderStyles}
-          ref={headerRef}>
+          ref={headerRef}
+          {...getDevtoolsProps(componentName)}>
           <Grid>
             <div className={`${blockClass}__non-navigation-row-content`}>
               {hasBreadcrumbRow ? (

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -18,7 +18,9 @@ import { PageHeader } from '.';
 import { ActionBarItem } from '../ActionBar';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
-const blockClass = `${pkg.prefix}--page-header`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--page-header`;
 
 /* Test properties. */
 const actionBarOverflowAriaLabel = 'Show additional action bar items';
@@ -387,8 +389,9 @@ describe('PageHeader', () => {
     warn.mockRestore(); // Remove mock
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    const dataTestId = uuidv4();
     render(<PageHeader data-testid={dataTestId} />);
     screen.getByTestId(dataTestId);
   });
@@ -397,6 +400,15 @@ describe('PageHeader', () => {
     const ref = React.createRef();
     render(<PageHeader ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<PageHeader data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(PageHeader.displayName)
+    );
   });
 
   test('collapse button works', () => {

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
@@ -8,8 +8,11 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '../Card';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { prepareProps } from '../../global/js/utils/props-helper';
+import { pkg } from '../../settings';
+
 const componentName = 'ProductiveCard';
 
 export let ProductiveCard = forwardRef((props, ref) => {
@@ -23,7 +26,15 @@ export let ProductiveCard = forwardRef((props, ref) => {
     'secondaryButtonKind',
     'secondaryButtonText',
   ]);
-  return <Card {...validProps} ref={ref} productive />;
+
+  return (
+    <Card
+      {...validProps}
+      ref={ref}
+      productive
+      {...getDevtoolsProps(componentName)}
+    />
+  );
 });
 
 // Return a placeholder if not released and not enabled by feature flag

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.test.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.test.js
@@ -8,7 +8,10 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { pkg } from '../../settings';
 import { ProductiveCard } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 const componentName = ProductiveCard.displayName;
 
@@ -28,14 +31,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass('test-class');
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    render(<ProductiveCard data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<ProductiveCard data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<ProductiveCard ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<ProductiveCard data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
@@ -16,9 +16,11 @@ import {
   TextInput,
 } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-import uuidv4 from '../../global/js/utils/uuidv4';
 
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg } from '../../settings';
+
 const componentName = 'RemoveModal';
 
 export let RemoveModal = forwardRef(
@@ -57,7 +59,13 @@ export let RemoveModal = forwardRef(
         {...rest}
         className={cx(blockClass, className)}
         size="sm"
-        {...{ open, ref, preventCloseOnClickOutside, onClose }}>
+        {...{
+          open,
+          ref,
+          preventCloseOnClickOutside,
+          onClose,
+          ...getDevtoolsProps(componentName),
+        }}>
         <ModalHeader
           title={title}
           label={label}

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.test.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.test.js
@@ -9,7 +9,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { pkg } from '../../settings';
 import { RemoveModal } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 const componentName = RemoveModal.displayName;
 const resourceName = 'bx1001';
@@ -121,14 +124,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass(defaultProps.className);
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    render(<RemoveModal {...defaultProps} data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<RemoveModal {...defaultProps} data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<RemoveModal {...defaultProps} ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<RemoveModal {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/Saving/Saving.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.js
@@ -15,7 +15,10 @@ import {
   ErrorFilled16,
 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
+
 const componentName = 'Saving';
 
 export let Saving = forwardRef(
@@ -64,7 +67,11 @@ export let Saving = forwardRef(
     const blockClass = `${pkg.prefix}--saving`;
 
     return (
-      <div {...rest} ref={ref} className={cx(blockClass, className)}>
+      <div
+        {...rest}
+        ref={ref}
+        className={cx(blockClass, className)}
+        {...getDevtoolsProps(componentName)}>
         {type === 'auto' ? (
           <div className={`${blockClass}__message`}>
             {status === 'fail' && (

--- a/packages/cloud-cognitive/src/components/Saving/Saving.test.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.test.js
@@ -9,7 +9,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { pkg } from '../../settings';
+
 import { Saving } from '.';
+
+const { devtoolsAttribute, getDevtoolsId } = pkg;
 
 const componentName = Saving.displayName;
 const defaultProps = {
@@ -82,14 +86,25 @@ describe(componentName, () => {
     expect(container.firstChild).toHaveClass(defaultProps.className);
   });
 
+  const dataTestId = 'data-testid';
+
   it('adds additional properties to the containing node', () => {
-    render(<Saving {...defaultProps} data-testid="test-id" />);
-    screen.getByTestId('test-id');
+    render(<Saving {...defaultProps} data-testid={dataTestId} />);
+    screen.getByTestId(dataTestId);
   });
 
   it('forwards a ref to an appropriate node', () => {
     const ref = React.createRef();
     render(<Saving {...defaultProps} ref={ref} />);
     expect(ref.current).not.toBeNull();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<Saving {...defaultProps} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 });

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -13,11 +13,18 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { useResizeDetector } from 'react-resize-detector';
 import { moderate02 } from '@carbon/motion';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+
+import {
+  allPropTypes,
+  deprecateProp,
+} from '../../global/js/utils/props-helper';
+
 import wrapFocus from '../../global/js/utils/wrapFocus';
 import { pkg } from '../../settings';
-import { allPropTypes } from '../../global/js/utils/props-helper';
+
 import { SIDE_PANEL_SIZES } from './constants';
-import { deprecateProp } from '../../global/js/utils/props-helper';
 
 // Carbon and package components we use.
 import { Button } from 'carbon-components-react';
@@ -651,7 +658,8 @@ export let SidePanel = React.forwardRef(
             onBlur={handleBlur}
             ref={contentRef}
             role="complementary"
-            aria-label={title}>
+            aria-label={title}
+            {...getDevtoolsProps(componentName)}>
             <span
               ref={startTrapRef}
               tabIndex="0"

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -15,8 +15,10 @@ import { pkg } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { SidePanel } from '.';
 
-const blockClass = `${pkg.prefix}--side-panel`;
-const actionSetBlockClass = `${pkg.prefix}--action-set`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--side-panel`;
+const actionSetBlockClass = `${prefix}--action-set`;
 const sizes = ['xs', 'sm', 'md', 'lg', 'max'];
 
 const dataTestId = uuidv4();
@@ -27,6 +29,7 @@ const pageContentSelectorValue = '#side-panel-test-page-content';
 
 const onRequestCloseFn = jest.fn();
 const onUnmountFn = jest.fn();
+
 const renderSidePanel = ({ ...rest }, children = <p>test</p>) =>
   render(
     <SidePanel
@@ -374,6 +377,15 @@ describe('SidePanel', () => {
     const ref = React.createRef();
     renderSidePanel({ ref });
     expect(ref.current).toEqual(screen.getByRole('complementary'));
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderSidePanel({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(SidePanel.displayName)
+    );
   });
 
   it('should call the onRequestClose event handler', () => {


### PR DESCRIPTION
#### Affected issues

- Blocked by #1220 
- Contributes to #1178 

#### Description

PR to add Devtools support and tests to numerous released components:

- `ImportModal`
- `NotificationsPanel`
- `NoDataEmptyState`
- `NoTagsEmptyState`
- `NotFoundEmptyState`
- `NotificationsEmptyState`
- `PageHeader`
- `UnauthorizedEmptyState`
- `ProductiveCard`
- `RemoveModal`
- `Saving`
- `SidePanel`

##### Other proposed change

Add test to `ErrorEmptyState` overlooked in #1220 