### PR TITLE
feat(devtools): add attribute to numerous released components (3 / 3)

### DIFF
--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+
 import {
   Misuse16,
   Misuse20,
@@ -49,6 +50,8 @@ import {
   Time24,
   Time32,
 } from '@carbon/icons-react';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';
 
 const icons = {
@@ -133,7 +136,11 @@ export let StatusIcon = React.forwardRef(
 
     return (
       IconComponent && (
-        <IconComponent {...rest} className={classNames} ref={ref}>
+        <IconComponent
+          {...rest}
+          className={classNames}
+          ref={ref}
+          {...getDevtoolsProps(componentName)}>
           <title>{iconDescription}</title>
         </IconComponent>
       )

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.test.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.test.js
@@ -14,7 +14,9 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { StatusIcon } from '.';
 
-const blockClass = `${pkg.prefix}--status-icon`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--status-icon`;
 const componentName = StatusIcon.displayName;
 const className = `class-${uuidv4()}`;
 const dataTestId = uuidv4();
@@ -79,6 +81,15 @@ describe(componentName, () => {
   it('adds additional properties to the containing node', () => {
     renderComponent({ 'data-testid': dataTestId });
     screen.getByTestId(dataTestId);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(componentName)
+    );
   });
 
   iconTypes.forEach((kind) => {

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -15,8 +15,9 @@ import { TagSetModal } from './TagSetModal';
 import { Tag } from 'carbon-components-react';
 import { useResizeDetector } from 'react-resize-detector';
 
-import { pkg } from '../../settings';
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { prepareProps, isRequiredIf } from '../../global/js/utils/props-helper';
+import { pkg } from '../../settings';
 
 const componentName = 'TagSet';
 const blockClass = `${pkg.prefix}--tag-set`;
@@ -197,7 +198,11 @@ export let TagSet = React.forwardRef(
     });
 
     return (
-      <div {...rest} className={cx([blockClass, className])} ref={tagSetRef}>
+      <div
+        {...rest}
+        className={cx([blockClass, className])}
+        ref={tagSetRef}
+        {...getDevtoolsProps(componentName)}>
         <div
           className={cx([
             `${blockClass}__space`,

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
@@ -11,11 +11,14 @@ import userEvent from '@testing-library/user-event';
 import { pkg, carbon } from '../../settings';
 import { TagSet } from '.';
 import { TagSetModal } from './TagSetModal';
+
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-const blockClass = `${pkg.prefix}--tag-set`;
-const blockClassOverflow = `${pkg.prefix}--tag-set-overflow`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--tag-set`;
+const blockClassOverflow = `${prefix}--tag-set-overflow`;
 
 const tagLabel = (index) => `Tag ${index + 1}`;
 const types = ['red', 'blue', 'cyan', 'high-contrast'];
@@ -203,8 +206,9 @@ describe(TagSet.displayName, () => {
     ).toEqual(5);
   });
 
+  const dataTestId = uuidv4();
+
   it('adds additional properties to the containing node', () => {
-    const dataTestId = uuidv4();
     window.innerWidth = tagWidth * 10 + 1;
 
     render(<TagSet data-testid={dataTestId} tags={tags10} />);
@@ -220,21 +224,20 @@ describe(TagSet.displayName, () => {
     expect(ref.current).not.toBeNull();
   });
 
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<TagSet data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(TagSet.displayName)
+    );
+  });
+
   it('copes with no tags', () => {
-    const dataTestId = uuidv4();
     window.innerWidth = tagWidth * 10 + 1;
 
     render(<TagSet data-testid={dataTestId} />);
     screen.getByTestId(dataTestId);
-  });
-
-  it('forwards a ref to an appropriate node', () => {
-    const ref = React.createRef();
-    window.innerWidth = tagWidth * 10 + 1;
-
-    render(<TagSet ref={ref} tags={tags10} />);
-
-    expect(ref.current).not.toBeNull();
   });
 
   describe(TagSetModal.displayName, () => {

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.js
@@ -10,12 +10,16 @@ import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+
 import {
   allPropTypes,
   deprecateProp,
   prepareProps,
 } from '../../global/js/utils/props-helper';
+
+import { pkg } from '../../settings';
 
 // Carbon and package components we use.
 import { Button } from 'carbon-components-react';
@@ -40,7 +44,10 @@ const componentName = 'Tearsheet';
  * action buttons.
  */
 export let Tearsheet = React.forwardRef((props, ref) => (
-  <TearsheetShell {...prepareProps(props, [], { ref, size: 'wide' })} />
+  <TearsheetShell
+    {...prepareProps(props, [], { ref, size: 'wide' })}
+    {...getDevtoolsProps(componentName)}
+  />
 ));
 
 // Return a placeholder if not released and not enabled by feature flag

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
@@ -9,15 +9,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { carbon, pkg } from '../../settings';
-
 import uuidv4 from '../../global/js/utils/uuidv4';
+import { carbon, pkg } from '../../settings';
 
 import { Button, ButtonSet, Tab, Tabs } from 'carbon-components-react';
 import { Tearsheet, TearsheetNarrow } from '.';
 import { CreateTearsheetNarrow } from '../CreateTearsheetNarrow';
 
-const blockClass = `${pkg.prefix}--tearsheet`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}--tearsheet`;
 const componentName = Tearsheet.displayName;
 const componentNameNarrow = TearsheetNarrow.displayName;
 const componentNameCreateNarrow = CreateTearsheetNarrow.displayName;
@@ -256,6 +257,15 @@ const commonTests = (Ts, name, props, testActions) => {
     const ref = React.createRef();
     render(<Ts {...{ ...props, ref }} />);
     expect(ref.current.outerModal.current).toHaveClass(blockClass);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<Ts {...props} data-testid={dataTestId} />);
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(name)
+    );
   });
 
   it("doesn't render when stacked more than three deep", () => {

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetNarrow.js
@@ -10,12 +10,16 @@ import React from 'react';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+
 import {
   allPropTypes,
   deprecateProp,
   prepareProps,
 } from '../../global/js/utils/props-helper';
+
+import { pkg } from '../../settings';
 
 // Carbon and package components we use.
 import { Button } from 'carbon-components-react';
@@ -40,7 +44,10 @@ const componentName = 'TearsheetNarrow';
  * main content area, and a set of action buttons.
  */
 export let TearsheetNarrow = React.forwardRef((props, ref) => (
-  <TearsheetShell {...prepareProps(props, blocked, { ref, size: 'narrow' })} />
+  <TearsheetShell
+    {...getDevtoolsProps(componentName)}
+    {...prepareProps(props, blocked, { ref, size: 'narrow' })}
+  />
 ));
 
 // Return a placeholder if not released and not enabled by feature flag

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
@@ -11,8 +11,10 @@ import React from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { pkg } from '../../settings';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import '../../global/js/utils/props-helper';
+import { pkg } from '../../settings';
 
 // Carbon and package components we use.
 import {
@@ -104,7 +106,8 @@ export let UserProfileImage = React.forwardRef(
           `${blockClass}--${size}`,
           `${blockClass}--${theme}`,
           `${blockClass}--${backgroundColor}`,
-        ])}>
+        ])}
+        {...getDevtoolsProps(componentName)}>
         <FillItem />
       </div>
     );

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
@@ -8,13 +8,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { pkg, carbon } from '../../settings';
-
 import uuidv4 from '../../global/js/utils/uuidv4';
+import { pkg, carbon } from '../../settings';
 
 import { UserProfileImage } from '.';
 
-const blockClass = `${pkg.prefix}-user-profile-avatar`;
+const { devtoolsAttribute, getDevtoolsId, prefix } = pkg;
+
+const blockClass = `${prefix}-user-profile-avatar`;
 const dataTestId = uuidv4();
 const kind = 'user';
 const size = 'xlg';
@@ -76,6 +77,15 @@ describe(name, () => {
     const ref = React.createRef();
     renderComponent({ ref });
     expect(ref.current.classList.contains(blockClass)).toBeTruthy();
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    renderComponent({ 'data-testid': dataTestId });
+
+    expect(screen.getByTestId(dataTestId)).toHaveAttribute(
+      devtoolsAttribute,
+      getDevtoolsId(UserProfileImage.displayName)
+    );
   });
 
   it('applies className to the containing node', () => {


### PR DESCRIPTION
Contributes to #1178 

#### Description

PR to add Devtools support and tests to remaining released components:

- `StatusIcon`
- `TagSet`
- `Tearsheet`
- `TearsheetNarrow`
- `UserProfileImage`

##### Other proposed change

Remove duplicate `ref` test for `TagSet`