### PR TITLE
fix(SidePanel): add overflow hidden to body if includeOverlay exists

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -380,6 +380,12 @@ export let SidePanel = React.forwardRef(
           onRequestClose();
         }
       };
+      const bodyElement = document.body;
+      if (includeOverlay && open) {
+        bodyElement.style.overflow = 'hidden';
+      } else if (includeOverlay && !open) {
+        bodyElement.style.overflow = 'initial';
+      }
       if (includeOverlay) {
         document.addEventListener('click', handleOutsideClick);
       }


### PR DESCRIPTION
Bug that was reported via slack, regarding content scrolling behind the panel. With this change, the content behind the panel, will not be able to scroll anymore.

https://ibm-casdesign.slack.com/archives/C013ZTX0N6B/p1630682475035300

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook