### PR TITLE
fix(CreateFullPage): explicitly set bg color for page content

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -633,6 +633,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   overflow: auto;
   flex-grow: 1;
   background-color: var(--cds-ui-background, #ffffff);
+  color: var(--cds-text-01, #161616);
   overflow-x: hidden;
 }
 

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -632,6 +632,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--create-full-page .exp--create-full-page__content {
   overflow: auto;
   flex-grow: 1;
+  background-color: var(--cds-ui-background, #ffffff);
   overflow-x: hidden;
 }
 

--- a/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
@@ -107,6 +107,7 @@
   .#{$block-class} .#{$block-class}__content {
     overflow: auto;
     flex-grow: 1;
+    background-color: $ui-background;
     overflow-x: hidden;
   }
 

--- a/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
@@ -108,6 +108,7 @@
     overflow: auto;
     flex-grow: 1;
     background-color: $ui-background;
+    color: $text-01;
     overflow-x: hidden;
   }
 


### PR DESCRIPTION
In working on adding theme switching capabilities to the code sandboxes, I noticed that the CreateFullPage was not setting the background color of the main content area so when I changed themes the background remained white.

#### What did you change?
`_create-full-page.scss`
Update snapshot
#### How did you test and verify your work?
Storybook

_Unexpected background color behavior in code sandbox_
![Screen Shot 2021-09-09 at 1 23 22 PM](https://user-images.githubusercontent.com/10215203/132733393-2a5f649e-a1c7-4cca-aaf1-fd2ce2e63b76.png)
