### PR TITLE
chore: relax restriction on sass version

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -42,8 +42,8 @@
     "test": "run-p test:*",
     "test:js": "jest --colors",
     "test:scss": "bundler check 'src/**/*.scss'",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency), sass (until Carbon fixes deprecation warnings)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$|^sass$)/'"
+    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency)",
+    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$)/'"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",
@@ -60,7 +60,7 @@
     "npm-check-updates": "^11.8.3",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "sass": "1.32.x",
+    "sass": "^1.32.13",
     "yargs": "^17.1.1"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,8 @@
     "clean": "rimraf storybook-static css",
     "start": "run-s build:carbon start:storybook",
     "start:storybook": "start-storybook -p 3000",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react (not tested), sass (until Carbon fixes deprecation warnings)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$|^sass$)/'"
+    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react (not tested)",
+    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$)/'"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
@@ -67,7 +67,7 @@
     "react-dom": "^16.14.0",
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
-    "sass": "1.32.x",
+    "sass": "^1.32.13",
     "style-loader": "^3.2.1",
     "typescript": "^4.4.2",
     "webpack": "^5.51.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18045,7 +18045,7 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass@1.32.x:
+sass@^1.32.13:
   version "1.32.13"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.13.tgz#8d29c849e625a415bce71609c7cf95e15f74ed00"
   integrity sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==


### PR DESCRIPTION
We previously avoided upgrading sass, as from v1.33 onwards it produced a large number of deprecation warnings in Carbon. Carbon have now fixed these warnings, and their fix *requires* v1.33 or later, so this PR relaxes the version restriction on sass so that tomorrow's version update can bring in the latest sass and the updated Carbon together.

#### What did you change?

package.json in cloud-cognitive and core

#### How did you test and verify your work?

This doesn't actually change anything yet -- the testing (and fixing, if needed) will be done on tomorrow's version-update PR.