### PR TITLE
fix: use node instead of string for remove modal input label

### DIFF
--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
@@ -65,7 +65,8 @@ export let RemoveModal = forwardRef(
           preventCloseOnClickOutside,
           onClose,
           ...getDevtoolsProps(componentName),
-        }}>
+        }}
+      >
         <ModalHeader
           title={title}
           label={label}
@@ -92,7 +93,8 @@ export let RemoveModal = forwardRef(
             type="submit"
             kind="danger"
             onClick={onRequestSubmit}
-            disabled={primaryButtonDisabled}>
+            disabled={primaryButtonDisabled}
+          >
             {primaryButtonText}
           </Button>
         </ModalFooter>
@@ -124,7 +126,7 @@ RemoveModal.propTypes = {
   /**
    * Label for text box
    */
-  inputLabelText: PropTypes.string,
+  inputLabelText: PropTypes.node,
   /**
    * Placeholder for text box
    */


### PR DESCRIPTION
Contributes to #1125 

updates `inputLabelText` in `RemoveModal` to use `node` proptype instead of `string`, which is what carbon does for the text input label.
