### PR TITLE
fix(Tearsheet): set text color so theming works as expected

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -314,6 +314,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--action-set {
   align-items: stretch;
   justify-content: flex-end;
+  background-color: var(--cds-ui-01, #f4f4f4);
 }
 
 .exp--action-set .exp--action-set__action-button {

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1820,6 +1820,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--tearsheet.exp--tearsheet {
   z-index: 9001;
   align-items: flex-end;
+  color: var(--cds-text-01, #161616);
   transition: visibility 0s linear 240ms, background-color 240ms cubic-bezier(0.4, 0.14, 1, 1), opacity 240ms cubic-bezier(0.4, 0.14, 1, 1);
   --exp--tearsheet--stacking-scale-factor-single: 0.95;
   --exp--tearsheet--stacking-scale-factor-double: 0.9;

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -19,6 +19,7 @@
   .#{$block-class} {
     align-items: stretch;
     justify-content: flex-end;
+    background-color: $ui-01;
   }
 
   .#{$block-class} .#{$block-class}__action-button {

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.js
@@ -65,7 +65,8 @@ export let RemoveModal = forwardRef(
           preventCloseOnClickOutside,
           onClose,
           ...getDevtoolsProps(componentName),
-        }}>
+        }}
+      >
         <ModalHeader
           title={title}
           label={label}
@@ -92,7 +93,8 @@ export let RemoveModal = forwardRef(
             type="submit"
             kind="danger"
             onClick={onRequestSubmit}
-            disabled={primaryButtonDisabled}>
+            disabled={primaryButtonDisabled}
+          >
             {primaryButtonText}
           </Button>
         </ModalFooter>
@@ -124,7 +126,7 @@ RemoveModal.propTypes = {
   /**
    * Label for text box
    */
-  inputLabelText: PropTypes.string,
+  inputLabelText: PropTypes.node,
   /**
    * Placeholder for text box
    */

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -31,6 +31,7 @@
     &.#{$block-class} {
       z-index: z('modal') + 1;
       align-items: flex-end;
+      color: $text-01;
       // stylelint-disable-next-line carbon/motion-token-use
       transition: visibility 0s linear $motion-duration,
         background-color $motion-duration motion(exit, expressive),


### PR DESCRIPTION
Addresses theming issue with the tearsheet description.

https://ibm-cloud.slack.com/archives/C013ZTX0N6B/p1632124708127100

Also, added a background color on the action set component to avoid issues with ghost buttons when switching themes. See screenshot below from `CreateFullPage` code sandbox

![Screen Shot 2021-09-20 at 10 31 11 AM](https://user-images.githubusercontent.com/10215203/134020447-09b37ba0-3065-46b8-aef8-f4ca4b652659.png)

#### What did you change?
`_tearsheet.scss`
`_action-set.scss`
Snapshot
#### How did you test and verify your work?
Storybook