### PR TITLE
feat: adds actions prop to web terminal

### DIFF
--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.js
@@ -15,14 +15,23 @@ import { pkg } from '../../settings';
 
 // Carbon and package components we use.
 import { Close16 as Close, Help16 as Help } from '@carbon/icons-react';
+import { Button } from 'carbon-components-react';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const componentName = 'WebTerminal';
-const blockClass = `${pkg.prefix}-web-terminal`;
+const blockClass = `${pkg.prefix}--web-terminal`;
 
 export let WebTerminal = React.forwardRef(
   (
-    { children, className, closeTerminal, documentationLinks, open, ...rest },
+    {
+      children,
+      className,
+      closeTerminal,
+      documentationLinks,
+      open,
+      actions = [],
+      ...rest
+    },
     ref
   ) => {
     const [shouldRender, setRender] = useState(open);
@@ -79,10 +88,12 @@ export let WebTerminal = React.forwardRef(
         <header className={`${blockClass}__bar`}>
           <div className={`${blockClass}__actions`}>
             {showDocumentationLinks && (
-              <button
+              <Button
+                hasIconOnly
+                kind="ghost"
                 type="button"
+                renderIcon={Help}
                 className={`${blockClass}__bar-icon-container`}>
-                <Help className={`${blockClass}__bar-icon`} />
                 <ul className={`${blockClass}__bar-icon-dropdown`}>
                   {documentationLinks.map(
                     ({ label, onClick, href = null, openInNewTab = true }) => (
@@ -103,21 +114,26 @@ export let WebTerminal = React.forwardRef(
                     )
                   )}
                 </ul>
-              </button>
+              </Button>
             )}
+            {actions.map(({ renderIcon, onClick, iconDescription }) => (
+              <Button
+                key={iconDescription}
+                hasIconOnly
+                renderIcon={renderIcon}
+                onClick={onClick}
+                iconDescription={iconDescription}
+                kind="ghost"
+              />
+            ))}
           </div>
-          <button
-            type="button"
-            className={cx([
-              `${blockClass}__bar-icon-container`,
-              `${blockClass}__close-button`,
-            ])}
+          <Button
+            hasIconOnly
+            renderIcon={Close}
+            kind="ghost"
+            iconDescription="Close terminal"
             onClick={closeTerminal}
-            onKeyDown={closeTerminal}>
-            <Close
-              className={`${blockClass}__bar-icon ${blockClass}__bar-icon--close`}
-            />
-          </button>
+          />
         </header>
         <div className={`${blockClass}__body`}>{children}</div>
       </div>
@@ -136,6 +152,17 @@ WebTerminal.displayName = componentName;
 // in alphabetical order (for consistency).
 // See https://www.npmjs.com/package/prop-types#usage.
 WebTerminal.propTypes = {
+  /**
+   * Provide your own terminal component as children to show up in the web terminal
+   */
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
+      renderIcon: PropTypes.object.isRequired,
+      onClick: PropTypes.func.isRequired,
+      iconDescription: PropTypes.string.isRequired,
+    })
+  ),
+
   /**
    * Provide your own terminal component as children to show up in the web terminal
    */
@@ -177,6 +204,7 @@ WebTerminal.propTypes = {
 // 'undefined' values reasonably. Default values should be provided when the
 // component needs to make a choice or assumption when a prop is not supplied.
 WebTerminal.defaultProps = {
+  actions: [],
   documentationLinks: [],
   className: '',
 };

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.mdx
@@ -67,6 +67,28 @@ of the component.
   <Story id={getStoryId(WebTerminal.displayName, 'with-documentation-links')} />
 </Canvas>
 
+### With actions
+
+<Canvas>
+  <Story id={getStoryId(WebTerminal.displayName, 'with-actions')} />
+</Canvas>
+
+Optionally you can add actions to the web terminal header bar. To add actions
+you need to pass in an array of actions with objects for each object.
+
+```jsx
+<WebTerminal
+  actions={[
+    {
+      renderIcon: Code32,
+      onClick: () => {},
+      iconDescription: 'Create new deployment',
+    },
+  ]}>
+  ...
+</WebTerminal>
+```
+
 ## Component API
 
 <ArgsTable of={WebTerminal} />

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
@@ -8,6 +8,8 @@
 // cspell:words joebob
 
 import React, { useState, useCallback } from 'react';
+// Carbon and package components we use.
+import { Code16 as Code, Copy16 as Copy } from '@carbon/icons-react';
 import { Navigation } from './preview-components';
 import {
   getStoryTitle,
@@ -51,11 +53,28 @@ const Template = (args) => {
 };
 
 export const Default = prepareStory(Template, {
-  args: {},
+  args: { documentationLinks },
 });
 
 export const WithDocumentationLinks = prepareStory(Template, {
   args: { documentationLinks },
+});
+
+export const WithActions = prepareStory(Template, {
+  args: {
+    actions: [
+      {
+        renderIcon: Code,
+        onClick: () => alert('clicked on action'),
+        iconDescription: 'Create new deployment',
+      },
+      {
+        renderIcon: Copy,
+        onClick: () => alert('clicked on action'),
+        iconDescription: 'Copy logs',
+      },
+    ],
+  },
 });
 
 export default {

--- a/packages/cloud-cognitive/src/components/WebTerminal/_web-terminal.scss
+++ b/packages/cloud-cognitive/src/components/WebTerminal/_web-terminal.scss
@@ -2,6 +2,7 @@
 @import '../../global/styles/project-settings';
 
 $web-terminal-width: 36.5rem;
+$block-class: #{$pkg-prefix}--web-terminal;
 
 @keyframes webTerminalEntrance {
   0% {
@@ -33,7 +34,7 @@ $web-terminal-width: 36.5rem;
   despite of which carbon theme the user has.
 */
 
-.#{$pkg-prefix}-web-terminal {
+.#{$block-class} {
   @include carbon--theme($carbon--theme--g90, true);
 
   position: fixed;
@@ -44,7 +45,7 @@ $web-terminal-width: 36.5rem;
   background-color: $gray-100; /* stylelint-disable-line  */
 }
 
-.#{$pkg-prefix}-web-terminal__bar {
+.#{$block-class}__bar {
   display: flex;
   height: 3rem;
   align-items: center;
@@ -52,23 +53,14 @@ $web-terminal-width: 36.5rem;
   background-color: $ui-background;
 }
 
-.#{$pkg-prefix}-web-terminal__bar-icon {
-  cursor: pointer;
-  fill: $text-01;
+.#{$block-class}__actions {
+  display: flex;
 }
 
-.#{$pkg-prefix}-web-terminal__bar-icon-container {
-  position: relative;
-  padding: $spacing-04;
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-}
-
-.#{$pkg-prefix}-web-terminal__bar-icon-dropdown {
+.#{$block-class}__bar-icon-dropdown {
   position: absolute;
-  top: 2.8125rem; /* stylelint-disable-line */
-  left: 0;
+  top: 2.9375rem; /* stylelint-disable-line */
+  left: -1px; /* stylelint-disable-line */
   width: 10rem;
   background-color: $field-01;
 
@@ -79,16 +71,14 @@ $web-terminal-width: 36.5rem;
   visibility: hidden;
 }
 
-.#{$pkg-prefix}-web-terminal__bar-icon-container:hover
-  .#{$pkg-prefix}-web-terminal__bar-icon-dropdown,
-.#{$pkg-prefix}-web-terminal__bar-icon-container:focus
-  .#{$pkg-prefix}-web-terminal__bar-icon-dropdown {
+.#{$block-class}__bar-icon-container:hover .#{$block-class}__bar-icon-dropdown,
+.#{$block-class}__bar-icon-container:focus .#{$block-class}__bar-icon-dropdown {
   opacity: 1;
   transform: translateY(0);
   visibility: visible;
 }
 
-.#{$pkg-prefix}-web-terminal__bar-icon-dropdown-link {
+.#{$block-class}__bar-icon-dropdown-link {
   display: flex;
   width: 100%;
   height: 2.125rem;
@@ -102,18 +92,12 @@ $web-terminal-width: 36.5rem;
   transition: all carbon--motion(standard, productive) $duration--fast-02;
 }
 
-.#{$pkg-prefix}-web-terminal__bar-icon-dropdown-link:hover {
-  //NOTE: The 4c4c4c is a theme token but not a gray value token
+.#{$block-class}__bar-icon-dropdown-link:hover {
   background-color: $hover-ui;
   color: $text-01;
 }
 
-.#{$pkg-prefix}-web-terminal__close-container {
-  padding: $spacing-04;
-  cursor: pointer;
-}
-
 // Terminal body styles
-.#{$pkg-prefix}-web-terminal__body {
+.#{$block-class}__body {
   height: 100%;
 }


### PR DESCRIPTION
Contributes to #1234 

This adds the ability for the user to pass an array of actions to be added to the web terminal header bar. 

#### What did you change?

1. Added the actions property, this allows the user to pass an array of objects with the desired `renderIcon`, `onClick`, and `iconDescription` for each action.  

![Screen Shot 2021-09-21 at 9 54 47 AM](https://user-images.githubusercontent.com/12755042/134183865-37e2a412-24a8-4dc5-b446-25b7b40957eb.png)

2. Talked to the designer about utilizing carbons Icon Buttons instead for the header bar, so some of the components got swapped with those. The documentation dropdown button and the close button are now an icon button.

3. Updated the block class variable in the JSX and CSS.
4. Removed unused CSS styles from the stylesheets.

#### How did you test and verify your work?
Checked to see if the user can successfully pass actions into the web terminal. 
