### PR TITLE
fix: keep page header above content on scroll

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -4096,6 +4096,8 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--page-header.exp--page-header {
   /* Bleed class for the background */
   position: sticky;
+  /* z-index used to raise above any position relative content as per Carbon header */
+  z-index: 8000;
   top: var(--exp--page-header--header-top);
   display: inline-block;
   /* cause top/bottom margin to reserve space */

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -495,7 +495,8 @@ export let PageHeader = React.forwardRef(
       <>
         <div
           className={`${blockClass}--offset-top-measuring-element`}
-          ref={offsetTopMeasuringRef}></div>
+          ref={offsetTopMeasuringRef}
+        ></div>
         <section
           {...rest}
           className={cx([
@@ -510,13 +511,15 @@ export let PageHeader = React.forwardRef(
           ])}
           style={pageHeaderStyles}
           ref={headerRef}
-          {...getDevtoolsProps(componentName)}>
+          {...getDevtoolsProps(componentName)}
+        >
           <Grid
             fullWidth={fullWidthGrid === true || fullWidthGrid === 'xl'}
             narrow={narrowGrid}
             className={cx({
               [`${blockClass}--width--xl`]: fullWidthGrid === 'xl',
-            })}>
+            })}
+          >
             <div className={`${blockClass}__non-navigation-row-content`}>
               {hasBreadcrumbRow ? (
                 <Row
@@ -527,13 +530,15 @@ export let PageHeader = React.forwardRef(
                       breadcrumbs,
                     [`${blockClass}__breadcrumb-row--has-action-bar`]:
                       hasActionBar,
-                  })}>
+                  })}
+                >
                   <div className={`${blockClass}__breadcrumb-row--container`}>
                     <Column
                       className={cx(`${blockClass}__breadcrumb-column`, {
                         [`${blockClass}__breadcrumb-column--background`]:
                           breadcrumbs !== undefined || hasActionBar,
-                      })}>
+                      })}
+                    >
                       {/* keeps actionBar right even if empty */}
 
                       {breadcrumbs !== undefined ? (
@@ -541,7 +546,8 @@ export let PageHeader = React.forwardRef(
                           className={`${blockClass}__breadcrumb`}
                           noTrailingSlash={title !== undefined}
                           overflowAriaLabel={breadcrumbOverflowAriaLabel}
-                          breadcrumbs={breadcrumbsInWithTitle}>
+                          breadcrumbs={breadcrumbsInWithTitle}
+                        >
                           {!breadcrumbsIn ? deprecated_breadcrumbItems : null}
                           {!breadcrumbsIn && title ? (
                             <BreadcrumbItem
@@ -552,7 +558,8 @@ export let PageHeader = React.forwardRef(
                                   [`${blockClass}__breadcrumb-title--pre-collapsed`]:
                                     collapseTitle,
                                 },
-                              ])}>
+                              ])}
+                            >
                               <span>
                                 {titleLoading ? <SkeletonText /> : titleText}
                               </span>
@@ -570,10 +577,12 @@ export let PageHeader = React.forwardRef(
                           [`${blockClass}__action-bar-column--influenced-by-collapse-button`]:
                             spaceForCollapseButton,
                         },
-                      ])}>
+                      ])}
+                    >
                       <div
                         className={`${blockClass}__action-bar-column-content`}
-                        ref={sizingContainerRef}>
+                        ref={sizingContainerRef}
+                      >
                         {hasActionBar ? (
                           // Investigate the responsive  behaviour or this and the title also fix the ActionBar Item and PageAction story css
                           <>
@@ -582,7 +591,8 @@ export let PageHeader = React.forwardRef(
                                 className={cx(`${blockClass}__page-actions`, {
                                   [`${blockClass}__page-actions--in-breadcrumb`]:
                                     pageActionsInBreadcrumbRow,
-                                })}>
+                                })}
+                              >
                                 <ButtonSetWithOverflow
                                   className={`${blockClass}__button-set--in-breadcrumb`}
                                   onWidthChange={handleButtonSetWidthChange}
@@ -622,14 +632,16 @@ export let PageHeader = React.forwardRef(
                       pageActions !== undefined &&
                       actionBarItems === undefined &&
                       hasBreadcrumbRow,
-                  })}>
+                  })}
+                >
                   <Column className={`${blockClass}__title-column`}>
                     {/* keeps page actions right even if empty */}
                     {title !== undefined ? (
                       <div
                         className={cx(`${blockClass}__title`, {
                           [`${blockClass}__title--fades`]: hasBreadcrumbRow,
-                        })}>
+                        })}
+                      >
                         {TitleIcon && !titleLoading ? (
                           <TitleIcon className={`${blockClass}__title-icon`} />
                         ) : null}
@@ -651,7 +663,8 @@ export let PageHeader = React.forwardRef(
                       className={cx(`${blockClass}__page-actions`, {
                         [`${blockClass}__page-actions--in-breadcrumb`]:
                           pageActionsInBreadcrumbRow,
-                      })}>
+                      })}
+                    >
                       <ButtonSetWithOverflow
                         className={`${blockClass}__page-actions-container`}
                         onWidthChange={handleButtonSetWidthChange}
@@ -695,7 +708,8 @@ export let PageHeader = React.forwardRef(
                       [`${blockClass}__last-row-buffer--active`]:
                         lastRowBufferActive,
                     },
-                  ])}></div>
+                  ])}
+                ></div>
               )}
 
               {
@@ -704,12 +718,14 @@ export let PageHeader = React.forwardRef(
                   <Row
                     className={cx(`${blockClass}__navigation-row`, {
                       [`${blockClass}__navigation-row--has-tags`]: tags,
-                    })}>
+                    })}
+                  >
                     <Column
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
                           navigation === undefined,
-                      })}>
+                      })}
+                    >
                       <TagSet
                         overflowAlign="end"
                         {...{
@@ -734,7 +750,8 @@ export let PageHeader = React.forwardRef(
                     [`${blockClass}__navigation-row--spacing-above-06`]:
                       navigation !== undefined,
                     [`${blockClass}__navigation-row--has-tags`]: tags,
-                  })}>
+                  })}
+                >
                   <Column className={`${blockClass}__navigation-tabs`}>
                     {navigation}
                   </Column>
@@ -743,7 +760,8 @@ export let PageHeader = React.forwardRef(
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
                           navigation === undefined,
-                      })}>
+                      })}
+                    >
                       <TagSet
                         overflowAlign="end"
                         {...{

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -106,7 +106,9 @@ export let PageHeader = React.forwardRef(
     // handle deprecated props - END
 
     const [metrics, setMetrics] = useState({});
-    const [pageHeaderStyles, setPageHeaderStyles] = useState({});
+    const [pageHeaderStyles, setPageHeaderStyles] = useState({
+      ...rest.style,
+    });
 
     // refs
     const localHeaderRef = useRef(null);
@@ -493,8 +495,7 @@ export let PageHeader = React.forwardRef(
       <>
         <div
           className={`${blockClass}--offset-top-measuring-element`}
-          ref={offsetTopMeasuringRef}
-        ></div>
+          ref={offsetTopMeasuringRef}></div>
         <section
           {...rest}
           className={cx([
@@ -509,15 +510,13 @@ export let PageHeader = React.forwardRef(
           ])}
           style={pageHeaderStyles}
           ref={headerRef}
-          {...getDevtoolsProps(componentName)}
-        >
+          {...getDevtoolsProps(componentName)}>
           <Grid
             fullWidth={fullWidthGrid === true || fullWidthGrid === 'xl'}
             narrow={narrowGrid}
             className={cx({
               [`${blockClass}--width--xl`]: fullWidthGrid === 'xl',
-            })}
-          >
+            })}>
             <div className={`${blockClass}__non-navigation-row-content`}>
               {hasBreadcrumbRow ? (
                 <Row
@@ -528,15 +527,13 @@ export let PageHeader = React.forwardRef(
                       breadcrumbs,
                     [`${blockClass}__breadcrumb-row--has-action-bar`]:
                       hasActionBar,
-                  })}
-                >
+                  })}>
                   <div className={`${blockClass}__breadcrumb-row--container`}>
                     <Column
                       className={cx(`${blockClass}__breadcrumb-column`, {
                         [`${blockClass}__breadcrumb-column--background`]:
                           breadcrumbs !== undefined || hasActionBar,
-                      })}
-                    >
+                      })}>
                       {/* keeps actionBar right even if empty */}
 
                       {breadcrumbs !== undefined ? (
@@ -544,8 +541,7 @@ export let PageHeader = React.forwardRef(
                           className={`${blockClass}__breadcrumb`}
                           noTrailingSlash={title !== undefined}
                           overflowAriaLabel={breadcrumbOverflowAriaLabel}
-                          breadcrumbs={breadcrumbsInWithTitle}
-                        >
+                          breadcrumbs={breadcrumbsInWithTitle}>
                           {!breadcrumbsIn ? deprecated_breadcrumbItems : null}
                           {!breadcrumbsIn && title ? (
                             <BreadcrumbItem
@@ -556,8 +552,7 @@ export let PageHeader = React.forwardRef(
                                   [`${blockClass}__breadcrumb-title--pre-collapsed`]:
                                     collapseTitle,
                                 },
-                              ])}
-                            >
+                              ])}>
                               <span>
                                 {titleLoading ? <SkeletonText /> : titleText}
                               </span>
@@ -575,12 +570,10 @@ export let PageHeader = React.forwardRef(
                           [`${blockClass}__action-bar-column--influenced-by-collapse-button`]:
                             spaceForCollapseButton,
                         },
-                      ])}
-                    >
+                      ])}>
                       <div
                         className={`${blockClass}__action-bar-column-content`}
-                        ref={sizingContainerRef}
-                      >
+                        ref={sizingContainerRef}>
                         {hasActionBar ? (
                           // Investigate the responsive  behaviour or this and the title also fix the ActionBar Item and PageAction story css
                           <>
@@ -589,8 +582,7 @@ export let PageHeader = React.forwardRef(
                                 className={cx(`${blockClass}__page-actions`, {
                                   [`${blockClass}__page-actions--in-breadcrumb`]:
                                     pageActionsInBreadcrumbRow,
-                                })}
-                              >
+                                })}>
                                 <ButtonSetWithOverflow
                                   className={`${blockClass}__button-set--in-breadcrumb`}
                                   onWidthChange={handleButtonSetWidthChange}
@@ -630,16 +622,14 @@ export let PageHeader = React.forwardRef(
                       pageActions !== undefined &&
                       actionBarItems === undefined &&
                       hasBreadcrumbRow,
-                  })}
-                >
+                  })}>
                   <Column className={`${blockClass}__title-column`}>
                     {/* keeps page actions right even if empty */}
                     {title !== undefined ? (
                       <div
                         className={cx(`${blockClass}__title`, {
                           [`${blockClass}__title--fades`]: hasBreadcrumbRow,
-                        })}
-                      >
+                        })}>
                         {TitleIcon && !titleLoading ? (
                           <TitleIcon className={`${blockClass}__title-icon`} />
                         ) : null}
@@ -661,8 +651,7 @@ export let PageHeader = React.forwardRef(
                       className={cx(`${blockClass}__page-actions`, {
                         [`${blockClass}__page-actions--in-breadcrumb`]:
                           pageActionsInBreadcrumbRow,
-                      })}
-                    >
+                      })}>
                       <ButtonSetWithOverflow
                         className={`${blockClass}__page-actions-container`}
                         onWidthChange={handleButtonSetWidthChange}
@@ -706,8 +695,7 @@ export let PageHeader = React.forwardRef(
                       [`${blockClass}__last-row-buffer--active`]:
                         lastRowBufferActive,
                     },
-                  ])}
-                ></div>
+                  ])}></div>
               )}
 
               {
@@ -716,14 +704,12 @@ export let PageHeader = React.forwardRef(
                   <Row
                     className={cx(`${blockClass}__navigation-row`, {
                       [`${blockClass}__navigation-row--has-tags`]: tags,
-                    })}
-                  >
+                    })}>
                     <Column
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
                           navigation === undefined,
-                      })}
-                    >
+                      })}>
                       <TagSet
                         overflowAlign="end"
                         {...{
@@ -748,8 +734,7 @@ export let PageHeader = React.forwardRef(
                     [`${blockClass}__navigation-row--spacing-above-06`]:
                       navigation !== undefined,
                     [`${blockClass}__navigation-row--has-tags`]: tags,
-                  })}
-                >
+                  })}>
                   <Column className={`${blockClass}__navigation-tabs`}>
                     {navigation}
                   </Column>
@@ -758,8 +743,7 @@ export let PageHeader = React.forwardRef(
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
                           navigation === undefined,
-                      })}
-                    >
+                      })}>
                       <TagSet
                         overflowAlign="end"
                         {...{

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.mdx
@@ -33,6 +33,19 @@ The page header is comprised of 6 zones, allowing for the flexibility to include
    tabs, content switcher etc.
 6. **Actions (optional):** This zone is for placing critical page actions.
 
+## Usage Notes for Developers
+
+On scroll the PageHeader can be configured to allow the breadcrumb row and/or
+the navigation row to stick to the top of the page, with content scrolling below
+it.
+
+In order for this to be successful the following conditions must be met:
+
+1. The PageHeader should be a peer of the structure where the content is placed.
+2. The z-index of the content should not exceed that of the PageHeader. This is
+   set by a Carbon SCSS function `z('header')` which currently evaluates
+   to 8000.
+
 ## Main types
 
 ### Page header without background

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -423,7 +423,8 @@ describe('PageHeader', () => {
       <PageHeader
         {...testProps}
         hasCollapseHeaderToggle={true}
-        data-testid={dataTestId}>
+        data-testid={dataTestId}
+      >
         {children}
       </PageHeader>
     );

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -392,8 +392,14 @@ describe('PageHeader', () => {
   const dataTestId = 'data-testid';
 
   it('adds additional properties to the containing node', () => {
-    render(<PageHeader data-testid={dataTestId} />);
-    screen.getByTestId(dataTestId);
+    const testStyle = { name: '--test-this', value: 'test-value' };
+    const styles = { [`${testStyle.name}`]: testStyle.value };
+
+    render(<PageHeader data-testid={dataTestId} style={styles} />);
+    const header = screen.getByTestId(dataTestId);
+
+    // style was failing due to pageHeaderStyles not being initialized
+    expect(header.getAttribute('style')).toContain(testStyle.value);
   });
 
   it('forwards a ref to an appropriate node', () => {
@@ -417,8 +423,7 @@ describe('PageHeader', () => {
       <PageHeader
         {...testProps}
         hasCollapseHeaderToggle={true}
-        data-testid={dataTestId}
-      >
+        data-testid={dataTestId}>
         {children}
       </PageHeader>
     );

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -48,6 +48,8 @@ $raised-z-index: 99;
     &.#{$block-class} {
       /* Bleed class for the background */
       position: sticky;
+      /* z-index used to raise above any position relative content as per Carbon header */
+      z-index: z('header');
       top: var(--#{$block-class}--header-top);
       display: inline-block; /* cause top/bottom margin to reserve space */
       width: 100%;

--- a/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_storybook-styles.scss
@@ -30,6 +30,7 @@ $story-class: 'page-header-stories';
 }
 
 .#{$story-class}__dummy-content {
+  position: relative; // used to raise the stacking context and check it still goes under the page header
   margin-top: $spacing-05;
 }
 


### PR DESCRIPTION
Contributes to #1271

Page content set to `position: relative` was appearing over the top of the PageHeader on scroll. This PR uses the Carbon SCSS function `z('header')` to set the PageHeader to a z-index of 8000. 

In addition it fixes an issue where the 'style' attribute was being thrown away by the PageHeader.

#### What did you change?

PageHeader, test and styles.

#### How did you test and verify your work?

Storybook and addition of a new test for the 'style' attribute.
