### PR TITLE
fix: long tag rendering in TagSet overflow

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -4078,13 +4078,15 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   font-weight: var(--cds-body-short-01-font-weight, 400);
   line-height: var(--cds-body-short-01-line-height, 1.28572);
   letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
+  display: block;
+  overflow: hidden;
   min-width: initial;
   min-height: initial;
   padding: 0;
   margin: 0;
   background-color: inherit;
   color: inherit;
-  vertical-align: bottom;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -120,8 +120,7 @@ const children = {
           // stylelint-disable-next-line carbon/layout-token-use
           marginRight: '50px',
           maxWidth: '400px',
-        }}
-      >
+        }}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor <strong>incididunt ut labore</strong> et dolore magna aliqua. Ut
         enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
@@ -253,7 +252,11 @@ const tags = {
     { type: 'purple', label: 'Purple' },
     { type: 'red', label: 'Red' },
     { type: 'teal', label: 'Teal' },
-    { type: 'red', label: 'Longer ThanAPieceOfString' },
+    {
+      type: 'red',
+      label:
+        'Longer ThanAPieceOfString it just keeps going and going and going and going',
+    },
     { type: 'high-contrast', label: 'High contrast' },
     { type: 'magenta', label: 'Magenta' },
     { type: 'blue', label: 'Blue 2' },
@@ -262,7 +265,11 @@ const tags = {
     { type: 'purple', label: 'Purple 2' },
     { type: 'red', label: 'Red 2' },
     { type: 'teal', label: 'Teal 2' },
-    { type: 'red', label: 'Longer ThanAPieceOfString 2' },
+    {
+      type: 'red',
+      label:
+        'Longer ThanAPieceOfString 2this one is even longer it is not quite a book but it is working on it. As it would be a little bit silly to be this long we should probably truncate',
+    },
     { type: 'high-contrast', label: 'High contrast 2' },
     { type: 'magenta', label: 'Magenta 2' },
   ],
@@ -402,24 +409,21 @@ const dummyPageContent = (
         sm={1}
         md={2}
         lg={4}
-        className={`${storyClass}__dummy-content-block`}
-      >
+        className={`${storyClass}__dummy-content-block`}>
         <div className={`${storyClass}__dummy-content-text`}>Column #1</div>
       </Column>
       <Column
         sm={1}
         md={2}
         lg={4}
-        className={`${storyClass}__dummy-content-block`}
-      >
+        className={`${storyClass}__dummy-content-block`}>
         <div className={`${storyClass}__dummy-content-text`}>Column #2</div>
       </Column>
       <Column
         sm={2}
         md={4}
         lg={8}
-        className={`${storyClass}__dummy-content-block`}
-      >
+        className={`${storyClass}__dummy-content-block`}>
         <div className={`${storyClass}__dummy-content-text`}>Column #3</div>
       </Column>
     </Row>
@@ -434,8 +438,7 @@ const demoDummyPageContent = (
           sm={4}
           md={8}
           lg={16}
-          className={`${storyClass}__dummy-content-block`}
-        >
+          className={`${storyClass}__dummy-content-block`}>
           <Table>
             <TableHead>
               <TableRow>
@@ -634,8 +637,7 @@ const TemplateDemo = ({ children, storyOptionWholePageScroll, ...props }) => {
           [`${storyClass}__app--whole-page-scroll`]:
             !storyOptionWholePageScroll,
         })}
-        key={storyOptionWholePageScroll ? 'keyYes' : 'keyNo'}
-      >
+        key={storyOptionWholePageScroll ? 'keyYes' : 'keyNo'}>
         <Header aria-label="IBM Platform Name">
           <HeaderName href="#" prefix="IBM">
             Cloud Cognitive application
@@ -646,8 +648,7 @@ const TemplateDemo = ({ children, storyOptionWholePageScroll, ...props }) => {
           style={{
             // stylelint-disable-next-line carbon/layout-token-use
             marginTop: '48px',
-          }}
-        >
+          }}>
           <PageHeader {...props}>{children}</PageHeader>
           {demoDummyPageContent}
         </div>

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -125,13 +125,15 @@ $block-class-modal: #{$block-class}-modal;
     .#{$block-class-overflow}__tag-item .#{$carbon-prefix}--tag {
       @include carbon--type-style('body-short-01');
 
+      display: block;
+      overflow: hidden;
       min-width: initial;
       min-height: initial;
       padding: 0;
       margin: 0;
       background-color: inherit;
       color: inherit;
-      vertical-align: bottom;
+      text-overflow: ellipsis;
       white-space: nowrap;
     }
 


### PR DESCRIPTION
Prevent Tag overflow adding text-overflow ellipsis.

Should now look like...
![image](https://user-images.githubusercontent.com/15086604/135448435-549ea56e-04ea-4dfa-b4cd-cb2091796377.png)

![image](https://user-images.githubusercontent.com/15086604/135448999-18f32419-cc6f-4d59-bdb4-8e011a857c9c.png)

@cameroncalder care to comment on overflow dialog, not sure the TagSet designer is still around. Would you like me to truncate in the modal too?

#### What did you change?

- Updated styling for TagSet overflow popup.
- Amended story long items story to have a very long tag.
- updated scss snapshot

#### How did you test and verify your work?

- Storybook