### PR TITLE
fix(SidePanel): give default scroll height if no subtitle

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -198,11 +198,11 @@ export let SidePanel = React.forwardRef(
         // because there is not enough scrolling distance to complete it).
         sidePanelSubtitleElementHeight =
           totalScrollingContentHeight - panelOuterHeight <
-            sidePanelSubtitleElementHeight
+          sidePanelSubtitleElementHeight
             ? totalScrollingContentHeight - panelOuterHeight
             : sidePanelSubtitleElementHeight === 0
-              ? 16
-              : sidePanelSubtitleElementHeight;
+            ? 16
+            : sidePanelSubtitleElementHeight;
         sidePanelSubtitleElementHeight =
           sidePanelSubtitleElementHeight < 0
             ? sidePanelScrollArea?.scrollHeight -

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -198,10 +198,11 @@ export let SidePanel = React.forwardRef(
         // because there is not enough scrolling distance to complete it).
         sidePanelSubtitleElementHeight =
           totalScrollingContentHeight - panelOuterHeight <
-            sidePanelSubtitleElementHeight ||
-          sidePanelSubtitleElementHeight === 0
+            sidePanelSubtitleElementHeight
             ? totalScrollingContentHeight - panelOuterHeight
-            : sidePanelSubtitleElementHeight;
+            : sidePanelSubtitleElementHeight === 0
+              ? 16
+              : sidePanelSubtitleElementHeight;
         sidePanelSubtitleElementHeight =
           sidePanelSubtitleElementHeight < 0
             ? sidePanelScrollArea?.scrollHeight -

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -193,7 +193,7 @@ const ChildrenContent = () => {
   const [notesValue, setNotesValue] = useState('');
   return (
     <div className={`${prefix}body-content`}>
-      <h5>Subtitle</h5>
+      <h5>Section</h5>
       <div className={`${prefix}text-inputs`}>
         <TextInput
           labelText="Input A"
@@ -238,7 +238,7 @@ const ChildrenContent = () => {
           onChange={(event) => setNotesValue(event.target.value)}
         />
       </div>
-      <h5 className={`${prefix}content-subtitle`}>Subtitle</h5>
+      <h5 className={`${prefix}content-subtitle`}>Section</h5>
       {renderDataTable()}
     </div>
   );


### PR DESCRIPTION
Contributes to #1314 

If a subtitle is not provided, the scrolling title animation's duration gets set to the entire scrolling content of the panel. By default, the duration of the scrolling animation is set to the height of the subtitle, but in this case when there is no subtitle the scrolling animation needs a set value.

#### What did you change?
`SidePanel.js`
`SidePanel.stories.js`
#### How did you test and verify your work?
Ran tests and verified via storybook