### PR TITLE
Fix(Tearsheet): avoid focus traps with stacked tearsheets

### DIFF
--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.stories.js
@@ -241,7 +241,7 @@ const StackedTemplate = ({ actions, ...args }) => {
   return (
     <>
       <style>{`.${pkg.prefix}--tearsheet { opacity: 0 }`};</style>
-      <div
+      <ButtonSet
         style={{
           display: 'flex',
           position: 'fixed',
@@ -250,41 +250,82 @@ const StackedTemplate = ({ actions, ...args }) => {
           zIndex: 10000,
         }}
       >
-        <Button onClick={() => setOpen1(!open1)}>Toggle #1</Button>
-        <Button onClick={() => setOpen2(!open2)}>Toggle #2</Button>
-        <Button onClick={() => setOpen3(!open3)}>Toggle #3</Button>
-      </div>
+        <Button onClick={() => setOpen1(!open1)}>Toggle tearsheet 1</Button>
+        <Button onClick={() => setOpen2(!open2)}>Toggle tearsheet 2</Button>
+        <Button onClick={() => setOpen3(!open3)}>Toggle tearsheet 3</Button>
+      </ButtonSet>
       <Tearsheet
         {...args}
         actions={wiredActions1}
-        title="Tearsheet #1"
+        headerActions={
+          <ButtonSet>
+            <Button
+              kind="primary"
+              size="sm"
+              style={{ width: 'initial' }}
+              onClick={() => setOpen2(true)}
+              disabled={open2}
+            >
+              Open tearsheet 2
+            </Button>
+          </ButtonSet>
+        }
+        title="Tearsheet 1"
         open={open1}
         onClose={() => setOpen1(false)}
+        selectorPrimaryFocus="#stacked-input-1"
       >
         <div className="tearsheet-stories__dummy-content-block">
           Main content 1
+          <TextInput
+            id="stacked-input-1"
+            labelText="Enter an important value here"
+          />
         </div>
       </Tearsheet>
       <Tearsheet
         {...args}
         actions={wiredActions2}
-        title="Tearsheet #2"
+        headerActions={
+          <ButtonSet>
+            <Button
+              kind="primary"
+              size="sm"
+              style={{ width: 'initial' }}
+              onClick={() => setOpen3(true)}
+              disabled={open3}
+            >
+              Open tearsheet 3
+            </Button>
+          </ButtonSet>
+        }
+        title="Tearsheet 2"
         open={open2}
         onClose={() => setOpen2(false)}
+        selectorPrimaryFocus="#stacked-input-2"
       >
         <div className="tearsheet-stories__dummy-content-block">
           Main content 2
+          <TextInput
+            id="stacked-input-2"
+            labelText="Enter an important value here"
+          />
         </div>
       </Tearsheet>
       <Tearsheet
         {...args}
         actions={wiredActions3}
-        title="Tearsheet #3"
+        title="Tearsheet 3"
         open={open3}
         onClose={() => setOpen3(false)}
+        selectorPrimaryFocus="#stacked-input-3"
       >
         <div className="tearsheet-stories__dummy-content-block">
           Main content 3
+          <TextInput
+            id="stacked-input-3"
+            labelText="Enter an important value here"
+          />
         </div>
       </Tearsheet>
     </>
@@ -352,7 +393,6 @@ export const fullyLoaded = prepareStory(Template, {
 export const stacked = prepareStory(StackedTemplate, {
   storyName: 'Stacking tearsheets',
   args: {
-    headerActions: 2,
     closeIconDescription,
     description,
     height: 'lower',

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
@@ -14,6 +14,7 @@ import {
   expectMultipleError,
   deprecated,
   required,
+  invalid,
 } from '../../global/js/utils/test-helper';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
@@ -89,6 +90,7 @@ const title = `Title of the ${uuidv4()} tearsheet`;
 // and also (with extra props and omitting button tests) to CreateTearsheetNarrow
 let tooManyButtonsTestedAlready = false;
 let closeIconDescriptionTestedAlready = false;
+let selectorsFloatingMenusTestedAlready = false;
 const commonTests = (Ts, name, props, testActions) => {
   it(`renders a component ${name}`, () => {
     render(<Ts {...{ ...props, closeIconDescription }} />);
@@ -287,17 +289,37 @@ const commonTests = (Ts, name, props, testActions) => {
   });
 
   it("doesn't render when stacked more than three deep", () =>
-    expectWarn(
-      'Tearsheet not rendered: maximum stacking depth exceeded.',
-      () => {
-        render(<Ts {...props} open />);
-        render(<Ts {...props} open />);
-        render(<Ts {...props} open />);
-        render(<Ts {...props} open />);
-        expect(
-          document.querySelectorAll(`.${carbon.prefix}--modal.is-visible`)
-        ).toHaveLength(3);
-      }
+    expectMultipleError(
+      selectorsFloatingMenusTestedAlready
+        ? []
+        : [
+            invalid(
+              'selectorsFloatingMenus',
+              'ComposedModal',
+              'array',
+              'string'
+            ),
+            [
+              'Warning: React does not recognize the `%s` prop on a DOM element.',
+              'selectorsFloatingMenus',
+              'selectorsfloatingmenus', // cspell:disable-line
+              /.*/,
+            ],
+          ],
+      () =>
+        expectWarn(
+          'Tearsheet not rendered: maximum stacking depth exceeded.',
+          () => {
+            render(<Ts {...props} open />);
+            render(<Ts {...props} open />);
+            render(<Ts {...props} open />);
+            render(<Ts {...props} open />);
+            selectorsFloatingMenusTestedAlready = true;
+            expect(
+              document.querySelectorAll(`.${carbon.prefix}--modal.is-visible`)
+            ).toHaveLength(3);
+          }
+        )
     ));
 };
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -113,6 +113,7 @@ export const TearsheetShell = React.forwardRef(
       // if we are now the topmost tearsheet, ensure we have focus
       if (
         position === depth &&
+        modalRef.current &&
         !modalRef.current.innerModal.current.contains(document.activeElement)
       ) {
         handleStackChange.claimFocus();
@@ -171,6 +172,8 @@ export const TearsheetShell = React.forwardRef(
     }, [open]);
 
     function handleFocus() {
+      // If something within us is receiving focus but we are not the topmost
+      // stacked tearsheet, transfer focus to the topmost tearsheet instead
       if (position < depth) {
         stack.open[stack.open.length - 1].claimFocus();
       }
@@ -216,12 +219,21 @@ export const TearsheetShell = React.forwardRef(
           onFocus={handleFocus}
           preventCloseOnClickOutside={!isPassive}
           ref={modalRef}
-          selectorsFloatingMenus={[
-            `.${carbon.prefix}--overflow-menu-options`,
-            `.${carbon.prefix}--tooltip`,
-            '.flatpickr-calendar',
-            `.${bc}__container`,
-          ]}
+          {...(depth > 1
+            ? // this shenanigans is to ensure that when depth<=1 we don't supply a selectorsFloatingMenus
+              // prop AT ALL -- not even a null -- because even null gets passed through to the div and causes a
+              // React warning. Once that is fixed (see https://github.com/carbon-design-system/carbon/issues/10000)
+              // this could revert to selectorsFloatingMenus: {depth > 1 ? [...] : null}.
+              // NB if .bx__container is added to the default value, this can be removed altogether.
+              {
+                selectorsFloatingMenus: [
+                  `.${carbon.prefix}--overflow-menu-options`,
+                  `.${carbon.prefix}--tooltip`,
+                  '.flatpickr-calendar',
+                  `.${bc}__container`,
+                ],
+              }
+            : {})}
           size="sm"
         >
           {includeHeader && (

--- a/packages/cloud-cognitive/src/global/js/utils/test-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/test-helper.js
@@ -206,3 +206,18 @@ export const required = (propName, componentName) =>
       `^Warning: Failed prop type: The prop \`${propName}\` is marked as required in \`${componentName}\`, but its value is \`(.*)\`.`
     )
   );
+
+/**
+ * Return an expect matcher for an invalid prop, suitable to pass to expectError
+ * or expectMultipleError.
+ * @param {string} propName the prop name that is invalid, or a matching regex
+ * @param {string} componentName the component name on which the prop is defined, or a matching regex
+ * @param {string} suppliedType the type that is being supplied, or a matching regex
+ * @param {string} expectedType the type that is expected, or a matching regex
+ */
+export const invalid = (propName, componentName, suppliedType, expectedType) =>
+  expect.stringMatching(
+    new RegExp(
+      `^Warning: Failed prop type: Invalid prop \`${propName}\` of type \`${suppliedType}\` supplied to \`${componentName}\`, expected \`${expectedType}\`.`
+    )
+  );


### PR DESCRIPTION
Closes #1332

This PR:
- adds tearsheets to the modal exit selector list so that stacking tearsheets do not "trap" the focus in the first tearsheet.
- catches focus entry into a non-topmost tearsheet and transfers focus to the topmost tearsheet.
- checks as each tearsheet becomes topmost that focus is within the tearsheet, and if not claims focus.

This should avoid the focus trap issue and also clean up the handling of focus when multiple tearsheets are being opened and closed.

#### What did you change?

Tearsheet.js, also added to the stacked tearsheet stories so the issue can be verified. Also updated the tests to expect warnings from Carbon -- these should eventually be removed (see https://github.com/carbon-design-system/carbon/issues/10000).

#### How did you test and verify your work?

Ran storybook.
