### PR TITLE
fix(pageHeader): breadcrumb scroll without actionbar

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -133,7 +133,7 @@ export let PageHeader = React.forwardRef(
     // state based on props only
     const actionBarItemArray = extractShapesArray(actionBarItems);
     const hasActionBar = actionBarItemArray && actionBarItemArray.length;
-    const hasBreadcrumbRow = !(!breadcrumbs && !actionBarItems);
+    const hasBreadcrumbRow = breadcrumbs || actionBarItems;
 
     /* Title shape is used to allow title to be string or shape */
     const titleShape = getTitleShape();
@@ -606,7 +606,7 @@ export let PageHeader = React.forwardRef(
                 </Row>
               ) : null}
 
-              {!collapseTitle && !(!title && !pageActions) ? (
+              {!collapseTitle && (title || pageActions) ? (
                 <Row
                   className={cx(`${blockClass}__title-row`, {
                     [`${blockClass}__title-row--no-breadcrumb-row`]:

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -133,9 +133,7 @@ export let PageHeader = React.forwardRef(
     // state based on props only
     const actionBarItemArray = extractShapesArray(actionBarItems);
     const hasActionBar = actionBarItemArray && actionBarItemArray.length;
-    const hasBreadcrumbRow = !(
-      breadcrumbs === undefined && actionBarItems === undefined
-    );
+    const hasBreadcrumbRow = !(!breadcrumbs && !actionBarItems);
 
     /* Title shape is used to allow title to be string or shape */
     const titleShape = getTitleShape();
@@ -443,7 +441,7 @@ export let PageHeader = React.forwardRef(
       /* istanbul ignore next */
       return (
         disableBreadcrumbScroll &&
-        actionBarItems === undefined &&
+        !actionBarItems &&
         scrollYValue + metrics.headerTopValue >= 0
       );
     };
@@ -542,15 +540,15 @@ export let PageHeader = React.forwardRef(
                     <Column
                       className={cx(`${blockClass}__breadcrumb-column`, {
                         [`${blockClass}__breadcrumb-column--background`]:
-                          breadcrumbs !== undefined || hasActionBar,
+                          !!breadcrumbs || hasActionBar,
                       })}
                     >
                       {/* keeps actionBar right even if empty */}
 
-                      {breadcrumbs !== undefined ? (
+                      {breadcrumbs ? (
                         <BreadcrumbWithOverflow
                           className={`${blockClass}__breadcrumb`}
-                          noTrailingSlash={title !== undefined}
+                          noTrailingSlash={!!title}
                           overflowAriaLabel={breadcrumbOverflowAriaLabel}
                           breadcrumbs={breadcrumbsInWithTitle}
                         >
@@ -608,8 +606,7 @@ export let PageHeader = React.forwardRef(
                 </Row>
               ) : null}
 
-              {!collapseTitle &&
-              !(title === undefined && pageActions === undefined) ? (
+              {!collapseTitle && !(!title && !pageActions) ? (
                 <Row
                   className={cx(`${blockClass}__title-row`, {
                     [`${blockClass}__title-row--no-breadcrumb-row`]:
@@ -617,16 +614,14 @@ export let PageHeader = React.forwardRef(
                     [`${blockClass}__title-row--under-action-bar`]:
                       hasActionBar,
                     [`${blockClass}__title-row--has-page-actions`]:
-                      pageActions !== undefined,
+                      !!pageActions,
                     [`${blockClass}__title-row--sticky`]:
-                      pageActions !== undefined &&
-                      actionBarItems === undefined &&
-                      hasBreadcrumbRow,
+                      !!pageActions && !actionBarItems && hasBreadcrumbRow,
                   })}
                 >
                   <Column className={`${blockClass}__title-column`}>
                     {/* keeps page actions right even if empty */}
-                    {title !== undefined ? (
+                    {title ? (
                       <div
                         className={cx(`${blockClass}__title`, {
                           [`${blockClass}__title--fades`]: hasBreadcrumbRow,
@@ -651,7 +646,7 @@ export let PageHeader = React.forwardRef(
                 </Row>
               ) : null}
 
-              {subtitle !== undefined ? (
+              {subtitle ? (
                 <Row className={`${blockClass}__subtitle-row`}>
                   <Column className={`${blockClass}__subtitle`}>
                     {subtitle}
@@ -659,7 +654,7 @@ export let PageHeader = React.forwardRef(
                 </Row>
               ) : null}
 
-              {children !== undefined ? (
+              {children ? (
                 <Row className={`${blockClass}__available-row`}>
                   <Column className={`${blockClass}__available-column`}>
                     {children}
@@ -698,7 +693,7 @@ export let PageHeader = React.forwardRef(
                     <Column
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
-                          navigation === undefined,
+                          !navigation,
                       })}
                     >
                       <TagSet
@@ -724,18 +719,18 @@ export let PageHeader = React.forwardRef(
                 <Row
                   className={cx(`${blockClass}__navigation-row`, {
                     [`${blockClass}__navigation-row--spacing-above-06`]:
-                      navigation !== undefined,
+                      !!navigation,
                     [`${blockClass}__navigation-row--has-tags`]: tags,
                   })}
                 >
                   <Column className={`${blockClass}__navigation-tabs`}>
                     {navigation}
                   </Column>
-                  {tags !== undefined ? (
+                  {tags ? (
                     <Column
                       className={cx(`${blockClass}__navigation-tags`, {
                         [`${blockClass}__navigation-tags--tags-only`]:
-                          navigation === undefined,
+                          !navigation,
                       })}
                     >
                       <TagSet


### PR DESCRIPTION
Contributes to #1311 

A number of page header property tests looked like

```js
prop === undefined
prop2 !== undefined
```

The intent appears to have been to simply test for the existence of a property that is falsy or truthy. Changed to

```js
!prop
!!prop2
```

#### What did you change?
A number of tests for undefined

#### How did you test and verify your work?
Ran tests, lint and checked scroll behaviour of pageActions in context when there are no action bar itgems.
