### PR TITLE
chore: fix cspell for linting

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -59,8 +59,7 @@
     "*.snap",
     "storybook-static",
     "yarn-error.log",
-    "CHANGELOG.md",
-    "**/.*"
+    "CHANGELOG.md"
   ],
   "words": [
     "apikey",
@@ -68,6 +67,7 @@
     "classname",
     "data-testid",
     "divs",
+    "loglevel",
     "overridable",
     "pconsole",
     "readme",


### PR DESCRIPTION
cspell wasn't actually doing anything at all during `yarn lint`, but was working properly during commit-lint. It was caused by a dodgy glob in the cspell.json. I'm not sure why, but removing the glob sorts it so whatevs.

#### What did you change?

cspell.json

#### How did you test and verify your work?

Ran `yarn lint` after making a spelling error.
