### PR TITLE
chore: use sass for security package style snapshot test

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -87,7 +87,6 @@
     "faker": "^5.5.3",
     "jest": "^27.3.1",
     "jest-config-ibm-cloud-cognitive": "^0.19.0",
-    "node-sass": "^6.0.0",
     "npm-check-updates": "^11.8.5",
     "npm-run-all": "^4.1.5",
     "param-case": "^3.0.4",

--- a/packages/security/src/__tests__/scss/styles-test.js
+++ b/packages/security/src/__tests__/scss/styles-test.js
@@ -3,19 +3,41 @@
  * @copyright IBM Security 2020 - 2021
  */
 
-import { renderSync } from 'node-sass';
-import { resolve } from 'path';
+const { resolve } = require('path');
+const { execFileSync } = require('child_process');
 
-import { root } from '../../../config';
+const loadPath1 = resolve(__dirname, '../../../node_modules');
+const loadPath2 = resolve(__dirname, '../../../../../node_modules');
+
+// Compile an SCSS file, and return the compiled CSS as a String. If the SCSS
+// file does not compile this function will throw an Error containing details
+// of the compilation failure.
+const scssCompile = (file) =>
+  // We use the sass cli because this is currently much faster than using
+  // the API owing to the overhead of @import resolution through the API.
+  // When the sass API is revised it may be feasible to switch back to
+  // using the API for SCSS compilation and checking.
+  execFileSync(
+    'sass',
+    [
+      '--style=expanded',
+      '--no-source-map',
+      '--load-path',
+      loadPath1,
+      '--load-path',
+      loadPath2,
+      file,
+    ],
+    {
+      maxBuffer: 1024 * 1024 * 2,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  ).toString();
 
 describe('Styles', () => {
   test('Bundle', () => {
     expect(
-      renderSync({
-        file: resolve(__dirname, '../../index.scss'),
-        includePaths: [resolve(root, 'node_modules')],
-        outputStyle: 'expanded',
-      }).css.toString()
+      scssCompile(resolve(__dirname, '../../index.scss'))
     ).toMatchSnapshot();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14987,7 +14987,7 @@ node-sass@^4.13.1:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-node-sass@^6.0.0, node-sass@^6.0.1:
+node-sass@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-6.0.1.tgz#cad1ccd0ce63e35c7181f545d8b986f3a9a887fe"
   integrity sha512-f+Rbqt92Ful9gX0cGtdYwjTrWAaGURgaK5rZCWOgCNyGWusFYHhbqCCBoFBeat+HKETOU02AyTxNhJV0YZf2jQ==


### PR DESCRIPTION
This is a suggestion, which updates the style snapshot test to use 'sass' rather than node-sass. This has the advantage of using the same sass compiler used for builds, and removing the dependency on the now long-deprecated node-sass. Somewhat surprisingly, it even runs faster for me: a 46s run vs 74s for the node-sass version. Note that this test calls sass at the command line rather than through the API because of the huge performance penalty the sass API currently imposes on compiles that include a large number of @imports.

#### What did you change?

styles-test.js

#### How did you test and verify your work?

Ran tests
