### PR TITLE
chore(SidePanel)!: remove deprecated actionToolbarButtonClick

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -612,7 +612,7 @@ export let SidePanel = React.forwardRef(
                       [`${blockClass}__action-toolbar-leading-button`]: leading,
                     },
                   ])}
-                  onClick={(event) => onClick(event)}
+                  onClick={onClick}
                 >
                   {leading && label}
                 </Button>

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -590,7 +590,6 @@ export let SidePanel = React.forwardRef(
                 disabled,
                 className,
                 onClick,
-                onActionToolbarButtonClick,
                 ...rest
               }) => (
                 <Button
@@ -613,12 +612,7 @@ export let SidePanel = React.forwardRef(
                       [`${blockClass}__action-toolbar-leading-button`]: leading,
                     },
                   ])}
-                  onClick={(event) =>
-                    onClick
-                      ? onClick(event)
-                      : onActionToolbarButtonClick &&
-                        onActionToolbarButtonClick(event)
-                  }
+                  onClick={(event) => onClick(event)}
                 >
                   {leading && label}
                 </Button>
@@ -764,10 +758,6 @@ SidePanel.propTypes = {
       label: PropTypes.string,
       leading: PropTypes.bool,
       icon: PropTypes.object,
-      onActionToolbarButtonClick: deprecateProp(
-        PropTypes.func,
-        'This prop will be removed in the future. Please use `onClick` instead'
-      ),
       onClick: PropTypes.func,
       kind: PropTypes.oneOf(['ghost', 'tertiary', 'secondary', 'primary']),
     })

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -9,7 +9,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
-  expectWarn,
   expectMultipleWarn,
   expectError,
   expectMultipleError,
@@ -362,39 +361,32 @@ describe('SidePanel', () => {
     expect(onClick).toBeCalled();
   });
 
-  it('should click an action toolbar button', () =>
-    expectWarn(
-      deprecated(
-        'actionToolbarButtons\\[1\\].onActionToolbarButtonClick',
-        'SidePanel'
-      ),
-      () => {
-        const { click } = userEvent;
-        const toolbarButtonFn1 = jest.fn();
-        const toolbarButtonFn2 = jest.fn();
-        const { container } = renderSidePanel({
-          actionToolbarButtons: [
-            {
-              leading: true,
-              label: 'Copy 1',
-              onClick: toolbarButtonFn1,
-            },
-            {
-              label: 'Copy 2',
-              icon: Add16,
-              onActionToolbarButtonClick: toolbarButtonFn2,
-            },
-          ],
-        });
-        const toolbarButtons = container.querySelectorAll(
-          `.${blockClass}__action-toolbar-button`
-        );
-        click(toolbarButtons[0]);
-        expect(toolbarButtonFn1).toHaveBeenCalledTimes(1);
-        click(toolbarButtons[1]);
-        expect(toolbarButtonFn2).toHaveBeenCalledTimes(1);
-      }
-    ));
+  it('should click an action toolbar button', () => {
+    const { click } = userEvent;
+    const toolbarButtonFn1 = jest.fn();
+    const toolbarButtonFn2 = jest.fn();
+    const { container } = renderSidePanel({
+      actionToolbarButtons: [
+        {
+          leading: true,
+          label: 'Copy 1',
+          onClick: toolbarButtonFn1,
+        },
+        {
+          label: 'Copy 2',
+          icon: Add16,
+          onClick: toolbarButtonFn2,
+        },
+      ],
+    });
+    const toolbarButtons = container.querySelectorAll(
+      `.${blockClass}__action-toolbar-button`
+    );
+    click(toolbarButtons[0]);
+    expect(toolbarButtonFn1).toHaveBeenCalledTimes(1);
+    click(toolbarButtons[1]);
+    expect(toolbarButtonFn2).toHaveBeenCalledTimes(1);
+  });
 
   it('adds additional properties to the containing node', () => {
     renderSidePanel({ 'data-testid': dataTestId });


### PR DESCRIPTION
Contributes to #1385 

This PR removes the deprecated `actionToolbarButtonClick` prop, replaced by just `onClick`.

#### What did you change?
`packages/cloud-cognitive/src/components/SidePanel/SidePanel.js`
`packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js`
#### How did you test and verify your work?
Storybook and ran tests