### PR TITLE
fix: page header background over lays

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -5821,6 +5821,14 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   justify-content: flex-end;
 }
 
+@keyframes background-appear {
+  from {
+    background-color: var(--from-color);
+  }
+  to {
+    background-color: var(--to-color);
+  }
+}
 .exp--page-header.exp--page-header {
   /* Bleed class for the background */
   position: sticky;
@@ -5845,16 +5853,17 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--page-header.exp--page-header--has-navigation-tags-only {
   --exp--page-header--navigation-buffer-top: $spacing-04;
 }
-.exp--page-header.exp--page-header--show-background::before {
+.exp--page-header::before {
+  --from-color: var(--cds-ui-background, #ffffff);
+  --to-color: var(--cds-ui-01, #f4f4f4);
   position: absolute;
   top: 0;
   left: 0;
   display: block;
   width: 100%;
   height: 100%;
-  background-color: var(--cds-ui-01, #f4f4f4);
+  animation: background-appear 1000ms calc(-1000ms * var(--exp--page-header--background-opacity)) linear paused forwards;
   content: \\"\\";
-  opacity: var(--exp--page-header--background-opacity);
   z-index: -1;
   box-shadow: 0 1px 0 var(--cds-ui-03, #e0e0e0);
 }
@@ -5880,8 +5889,8 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   flex-wrap: nowrap;
 }
 .exp--page-header .exp--page-header__has-page-actions-without-action-bar {
-  min-width: 60%;
-  max-width: 60%;
+  min-width: calc(0.6 * (100% + 2 * var(--cds-spacing-05, 1rem)));
+  max-width: calc(0.6 * (100% + 2 * var(--cds-spacing-05, 1rem)));
 }
 .exp--page-header .exp--page-header__has-page-actions-without-action-bar .exp--page-header__has-page-actions-without-action-bar {
   min-width: 100%;
@@ -5964,17 +5973,17 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
     /* required for ellipsis in title, title not visible in breadcrumb with back arrow */
   }
 }
-.exp--page-header .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
-  max-width: 25%;
-  flex: 0 1 25%;
+.exp--page-header .exp--page-header__breadcrumb-row--has-action-bar .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
+  max-width: 75%;
+  flex: 0 1 75%;
 }
 @media (min-width: 42rem) {
-  .exp--page-header .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
+  .exp--page-header .exp--page-header__breadcrumb-row--has-action-bar .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
     max-width: 60%;
     flex: 0 1 60%;
   }
 }
-.exp--page-header .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column .exp--page-header__has-page-actions-without-action-bar .exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
+.exp--page-header .exp--page-header__has-page-actions-without-action-bar.exp--page-header__breadcrumb-row .exp--page-header__breadcrumb-column {
   max-width: 100%;
   flex: 0 1 100%;
 }
@@ -5982,16 +5991,18 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .exp--page-header .exp--page-header__action-bar-column--background {
   position: relative;
 }
-.exp--page-header.exp--page-header--show-background .exp--page-header__breadcrumb-column--background::before, .exp--page-header.exp--page-header--show-background .exp--page-header__action-bar-column--background::before {
+.exp--page-header .exp--page-header__breadcrumb-column--background::before,
+.exp--page-header .exp--page-header__action-bar-column--background::before {
+  --from-color: var(--cds-ui-background, #ffffff);
+  --to-color: var(--cds-ui-01, #f4f4f4);
   position: absolute;
   top: 0;
   left: 0;
   display: block;
   width: 100%;
   height: 100%;
-  background-color: var(--cds-ui-01, #f4f4f4);
+  animation: background-appear 1000ms calc(-1000ms * var(--exp--page-header--background-opacity)) linear paused forwards;
   content: \\"\\";
-  opacity: var(--exp--page-header--background-opacity);
 }
 .exp--page-header .exp--page-header__action-bar-column--influenced-by-collapse-button {
   padding-right: var(--cds-spacing-08, 2.5rem);
@@ -6145,10 +6156,23 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   }
 }
 .exp--page-header .exp--page-header__title-row .exp--page-header__page-actions {
+  position: relative;
   opacity: 1;
   transition: all 110ms cubic-bezier(0, 0, 0.38, 0.9);
   transition-property: opacity, visibility;
   visibility: visible;
+}
+.exp--page-header .exp--page-header__title-row .exp--page-header__page-actions::before {
+  --from-color: var(--cds-ui-background, #ffffff);
+  --to-color: var(--cds-ui-01, #f4f4f4);
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  animation: background-appear 1000ms calc(-1000ms * var(--exp--page-header--background-opacity)) linear paused forwards;
+  content: \\"\\";
 }
 .exp--page-header .exp--page-header__title-row .exp--page-header__page-actions--in-breadcrumb {
   opacity: 0;
@@ -6221,9 +6245,15 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   align-items: center;
   justify-content: flex-end;
   padding-top: var(--cds-spacing-02, 0.25rem);
+  padding-right: var(--cds-spacing-07, 2rem);
   padding-bottom: var(--cds-spacing-02, 0.25rem);
   text-align: right;
   white-space: nowrap;
+}
+@media (min-width: 42rem) {
+  .exp--page-header .exp--page-header__navigation-tags {
+    padding-right: var(--cds-spacing-05, 1rem);
+  }
 }
 .exp--page-header .exp--page-header__navigation-tags--tags-only {
   justify-content: flex-start;
@@ -6246,14 +6276,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .exp--page-header .exp--page-header__collapse-expand-toggle--collapsed .bx--btn__icon {
   transform: scaleY(-1);
-}
-.exp--page-header.exp--page-header--show-background .exp--page-header__navigation-tags {
-  padding-right: var(--cds-spacing-07, 2rem);
-}
-@media (min-width: 42rem) {
-  .exp--page-header.exp--page-header--show-background .exp--page-header__navigation-tags {
-    padding-right: var(--cds-spacing-05, 1rem);
-  }
 }
 
 :root {

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -142,7 +142,6 @@ export let PageHeader = React.forwardRef(
     const [pageActionsInBreadcrumbRow, setPageActionsInBreadcrumbRow] =
       useState(false);
     const [scrollYValue, setScrollYValue] = useState(0);
-    const [backgroundOpacity, setBackgroundOpacity] = useState(0);
     const [hasCollapseButton, setHasCollapseButton] = useState(false);
     const [spaceForCollapseButton, setSpaceForCollapseButton] = useState(false);
     const [actionBarMaxWidth, setActionBarMaxWidth] = useState(0);
@@ -377,7 +376,7 @@ export let PageHeader = React.forwardRef(
 
     useEffect(() => {
       // Determines if the hasBackgroundAlways should be one based on the header height or scroll
-      let result = hasBackgroundAlways && 1;
+      let result = hasBackgroundAlways ? 1 : 0;
 
       if (
         !result &&
@@ -398,13 +397,10 @@ export let PageHeader = React.forwardRef(
           );
         }
       }
-
       setPageHeaderStyles((prev) => ({
         ...prev,
         [`--${blockClass}--background-opacity`]: result,
       }));
-
-      setBackgroundOpacity(result);
     }, [
       actionBarItems,
       hasBackgroundAlways,
@@ -483,7 +479,6 @@ export let PageHeader = React.forwardRef(
             `${blockClass}--no-margins-below-row`,
             className,
             {
-              [`${blockClass}--show-background`]: backgroundOpacity > 0,
               [`${blockClass}--has-navigation`]: navigation || tags,
               [`${blockClass}--has-navigation-tags-only`]: !navigation && tags,
             },

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -251,8 +251,6 @@ describe('PageHeader', () => {
     const header = screen.getByTestId(dataTestId);
     expect(header).toHaveClass(blockClass);
 
-    expect(header).toHaveClass(`${blockClass}--show-background`);
-
     expect(header).not.toHaveClass(classNames[0]);
     expect(header).not.toHaveClass(classNames[1]);
 
@@ -288,7 +286,6 @@ describe('PageHeader', () => {
     const header = screen.getByTestId(dataTestId);
     expect(header).toHaveClass(blockClass);
 
-    expect(header).toHaveClass(`${blockClass}--show-background`);
     expect(header).toHaveClass(classNames[0]);
     expect(header).toHaveClass(classNames[1]);
     expect(
@@ -671,7 +668,6 @@ describe('PageHeader', () => {
     // check for rendered items
     screen.getByLabelText(testProps.actionBarOverflowAriaLabel);
     screen.getByText(availableSpaceTextContent);
-    expect(header).toHaveClass(`${blockClass}--show-background`);
     expect(header.querySelectorAll(`.${blockClass}__breadcrumb`)).toHaveLength(
       1
     );

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -60,10 +60,11 @@ $right-section-alt-width: 100% - $left-section-alt-width;
   height: 100%;
 
   // This transitions the background-color between from-color and to-color
+  $duration: 1000ms;
   // stylelint-disable-next-line carbon/motion-token-use
-  animation: background-appear 1
-    calc((var(--#{$block-class}--background-opacity)) * -1) linear paused
-    forwards;
+  animation: background-appear $duration
+    calc((-1 * $duration * var(--#{$block-class}--background-opacity))) linear
+    paused forwards;
 
   content: '';
 }

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -37,16 +37,35 @@ $right-section-std-width: 100% - $left-section-std-width;
 $left-section-alt-width: 75%;
 $right-section-alt-width: 100% - $left-section-alt-width;
 
-@mixin appearingBackground() {
+@keyframes background-appear {
+  from {
+    background-color: var(--from-color);
+  }
+  to {
+    background-color: var(--to-color);
+  }
+}
+
+@mixin appearingBackground($from-color: $ui-background, $to-color: $ui-01) {
+  // stylelint-disable-next-line carbon/theme-token-use
+  --from-color: #{$from-color};
+  // stylelint-disable-next-line carbon/theme-token-use
+  --to-color: #{$to-color};
+
   position: absolute;
   top: 0;
   left: 0;
   display: block;
   width: 100%;
   height: 100%;
-  background-color: $ui-01;
+
+  // This transitions the background-color between from-color and to-color
+  // stylelint-disable-next-line carbon/motion-token-use
+  animation: background-appear 1
+    calc((var(--#{$block-class}--background-opacity)) * -1) linear paused
+    forwards;
+
   content: '';
-  opacity: var(--#{$block-class}--background-opacity);
 }
 
 @mixin page-header {
@@ -77,7 +96,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       --#{$block-class}--navigation-buffer-top: $spacing-04;
     }
 
-    &.#{$block-class}--show-background::before {
+    &::before {
       @include appearingBackground();
 
       z-index: -1;
@@ -112,8 +131,9 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     }
 
     .#{$block-class}__has-page-actions-without-action-bar {
-      min-width: $left-section-std-width;
-      max-width: $left-section-std-width;
+      // NOTE: the extra spacing accounts for carbon margins
+      min-width: calc(0.6 * (100% + 2 * #{$spacing-05}));
+      max-width: calc(0.6 * (100% + 2 * #{$spacing-05}));
     }
 
     .#{$block-class}__has-page-actions-without-action-bar
@@ -216,22 +236,24 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       }
     }
 
-    .#{$block-class}__breadcrumb-row .#{$block-class}__breadcrumb-column {
+    .#{$block-class}__breadcrumb-row--has-action-bar
+      .#{$block-class}__breadcrumb-row
+      .#{$block-class}__breadcrumb-column {
       // back button displayed only
-      max-width: $right-section-alt-width;
-      flex: 0 1 $right-section-alt-width;
+      max-width: $left-section-alt-width;
+      flex: 0 1 $left-section-alt-width;
 
       @include carbon--breakpoint(md) {
         max-width: $left-section-std-width;
         flex: 0 1 $left-section-std-width;
       }
+    }
 
-      .#{$block-class}__has-page-actions-without-action-bar
-        .#{$block-class}__breadcrumb-row
-        .#{$block-class}__breadcrumb-column {
-        max-width: 100%;
-        flex: 0 1 100%;
-      }
+    .#{$block-class}__has-page-actions-without-action-bar.#{$block-class}__breadcrumb-row
+      .#{$block-class}__breadcrumb-column {
+      // the width of the breadcrumb column is adjusted elsewhere to compensate
+      max-width: 100%;
+      flex: 0 1 100%;
     }
 
     .#{$block-class}__breadcrumb-column--background,
@@ -239,10 +261,8 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       position: relative;
     }
 
-    &.#{$block-class}--show-background
-      .#{$block-class}__breadcrumb-column--background::before,
-    &.#{$block-class}--show-background
-      .#{$block-class}__action-bar-column--background::before {
+    .#{$block-class}__breadcrumb-column--background::before,
+    .#{$block-class}__action-bar-column--background::before {
       @include appearingBackground();
     }
 
@@ -433,11 +453,16 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     }
 
     .#{$block-class}__title-row .#{$block-class}__page-actions {
+      position: relative;
       opacity: 1;
       transition: all $duration--fast-02
         carbon--motion('entrance', 'productive');
       transition-property: opacity, visibility;
       visibility: visible;
+    }
+
+    .#{$block-class}__title-row .#{$block-class}__page-actions::before {
+      @include appearingBackground();
     }
 
     .#{$block-class}__title-row .#{$block-class}__page-actions--in-breadcrumb {
@@ -517,9 +542,15 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       align-items: center;
       justify-content: flex-end;
       padding-top: $spacing-02;
+      // allow space for expand/collapse if we have a background
+      padding-right: $spacing-07;
       padding-bottom: $spacing-02;
       text-align: right;
       white-space: nowrap;
+
+      @include carbon--breakpoint(md) {
+        padding-right: $spacing-05;
+      }
     }
 
     .#{$block-class}__navigation-tags--tags-only {
@@ -550,15 +581,6 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       .#{$carbon-prefix}--btn__icon {
       // transform: rotate(90deg);
       transform: scaleY(-1);
-    }
-
-    &.#{$block-class}--show-background .#{$block-class}__navigation-tags {
-      // allow space for expand/collapse if we have a background
-      padding-right: $spacing-07;
-
-      @include carbon--breakpoint(md) {
-        padding-right: $spacing-05;
-      }
     }
   }
 


### PR DESCRIPTION
#### What did you change?

- Previously the page header had a background that appeared (opacity: 0 to $ui-01). This did not work when the background was turned off (on is the default). Changed this to transition between $ui-background and $ui-01.
- The Breadcrumb was only 60% of 60% of 100% width when shown with a pageAction, corrected to 60% of 100%;
- The breadcrumb was not quite wide enough to cover the row background (excluding pageActions, without actionBar) due to grid margins. Corrected.
- The pageActions when stuck to top (no action bar) did not cover the background. Updated to do so.

#### How did you test and verify your work?

Storybook, lint and tests