### PR TITLE
chore: fix coverage inclusion

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/index.js
+++ b/config/jest-config-ibm-cloud-cognitive/index.js
@@ -8,11 +8,7 @@
 'use strict';
 
 module.exports = {
-  collectCoverageFrom: [
-    'packages/**/src/**/*.js',
-    '!packages/**/{examples,stories}/**',
-    '!**/*.stories.js',
-  ],
+  collectCoverageFrom: ['src/**/*.js', '!**/*.stories.js'],
   coverageReporters: [['html', 'text', { skipEmpty: true }]],
   moduleFileExtensions: ['js', 'json', 'node'],
   reporters: ['default'],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "audit": "node scripts/audit.js dependencies moderate",
     "build": "run-s build:* storybook:build:storybook",
     "build:packages": "yarn run-all --include-dependencies --ignore \"@carbon/ibm-cloud-cognitive-core\" build",
-    "ccs-coverage": "cd packages/cloud-cognitive && yarn test:js src/components --coverage --collectCoverageFrom=packages/cloud-cognitive/src/components/**/*.js --collectCoverageFrom=!packages/cloud-cognitive/src/components/**/*.stories.js",
     "ci-check": "run-s ci-check:* storybook:build",
     "ci-check:build": "run-s build:* 'run-all --no-sort ci-check'",
     "ci-check:lint": "run-p audit lint",


### PR DESCRIPTION
Since we switched to running tests on a per-package basis the coverage paths need to be updated. This PR does that. `yarn test:c4p --coverage` will now work.

#### What did you change?

#### How did you test and verify your work?
