### PR TITLE
chore: avoid storybook code formatting errors

### DIFF
--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.stories.js
@@ -409,6 +409,15 @@ export const CustomGenerate = prepareStory(MultiStepTemplate, {
     savedResource: '',
     savedPermissions: '',
   },
+  parameters: {
+    docs: {
+      source: {
+        // TODO provide better alternative source code, or remove this once the issue is resolved:
+        // https://github.com/storybookjs/storybook/issues/11554
+        code: 'Sorry, this feature is not currently available for this story',
+      },
+    },
+  },
 });
 
 export const Edit = prepareStory(EditTemplate, {


### PR DESCRIPTION
Contributes to #1445

This workaround for https://github.com/storybookjs/storybook/issues/11554 was suggested on that thread by shilman. It means there is no source code shown for the story, but that seems to stop Storybook trying to format the code which is where the error seems to happen that causes error messages and infinite loop crashes.

#### What did you change?

APIKeyModal.stories.js

#### How did you test and verify your work?

Ran storybook.
