### PR TITLE
feat: adds svg support to buttons in productive card

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6415,6 +6415,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   justify-content: space-between;
   border-top: 1px solid var(--cds-ui-03, #e0e0e0);
 }
+.c4p--card__productive .c4p--card__footer .bx--btn svg {
+  margin-left: var(--cds-spacing-03, 0.5rem);
+}
 .c4p--card__productive .c4p--card__footer-no-button {
   justify-content: flex-end;
 }

--- a/packages/cloud-cognitive/src/components/Card/Card.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.js
@@ -240,7 +240,7 @@ Card.propTypes = {
   primaryButtonHref: PropTypes.string,
   primaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   primaryButtonKind: PropTypes.oneOf(['primary', 'ghost']),
-  primaryButtonText: PropTypes.string,
+  primaryButtonText: PropTypes.node,
   productive: PropTypes.bool,
   secondaryButtonHref: PropTypes.string,
   secondaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
@@ -107,7 +107,7 @@ ProductiveCard.propTypes = {
   /**
    * The text that's displayed in the primary button
    */
-  primaryButtonText: PropTypes.string,
+  primaryButtonText: PropTypes.node,
   /**
    * Title that's displayed at the top of the card
    */

--- a/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
@@ -36,6 +36,10 @@
       align-items: center;
       justify-content: space-between;
       border-top: 1px solid $ui-03;
+
+      .#{$carbon-prefix}--btn svg {
+        margin-left: $spacing-03;
+      }
     }
 
     .#{$block-class}__footer-no-button {


### PR DESCRIPTION
Contributes to #1243 

changes `primaryButtonText` propType in `ProductiveCard` to node to allow svg support.

<img width="358" alt="Screen Shot 2021-09-07 at 1 49 10 PM" src="https://user-images.githubusercontent.com/6370760/144101656-14d7f695-3b8c-4d28-aeea-4b22715bb4cc.png">
