### PR TITLE
chore: reduce the versions update to a patch release bump

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,14 +26,14 @@ jobs:
         with:
           token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
           commit-message:
-            'feat: update Carbon versions and dependencies to latest'
+            'fix: update Carbon versions and package dependencies to latest'
           committer: GitHub <noreply@github.com>
           author:
             ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: 'update-packages'
           branch-suffix: random
           title:
-            'feat: update Carbon versions and package dependencies to latest'
+            'fix: update Carbon versions and package dependencies to latest'
           body: |
             This PR was automatically generated to update Carbon versions and other package dependencies on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 


### PR DESCRIPTION
We want the versions update PR to include a release bump, so that any package affected by the updates gets a release the next time the release workflow runs. Up to now, this has been a `feat` bump, but this seems excessive: it generates a minor version each time the most trivial dependency changes, and taking on board the latest versions is not really a feature update. Change the workflow to set up a `fix` bump, so only a patch release will be generated (unless there are other `feat` items in the release, of course).

#### What did you change?

update workflow

#### How did you test and verify your work?

Will be seen in action tonight
