### PR TITLE
chore: separate carbon and dev-dependency updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 4 * * FRI'
 
 jobs:
-  release:
+  carbon:
     runs-on: ubuntu-latest
 
     steps:
@@ -14,10 +14,9 @@ jobs:
       - name: Install
         run: yarn --offline
 
-      - name: Update packages
+      - name: Update Carbon packages
         run: |
-          yarn upgrade:automatic
-          rm yarn.lock
+          yarn upgrade:carbon
           yarn
 
       - name: Create PR
@@ -25,27 +24,23 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
-          commit-message:
-            'fix: update Carbon versions and package dependencies to latest'
+          commit-message: 'fix: update Carbon versions to latest'
           committer: GitHub <noreply@github.com>
           author:
             ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           branch: 'update-packages'
           branch-suffix: random
-          title:
-            'fix: update Carbon versions and package dependencies to latest'
+          title: 'fix: update Carbon versions to latest'
           body: |
-            This PR was automatically generated to update Carbon versions and other package dependencies on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
+            This PR was automatically generated to update Carbon versions on a regular basis. This is not intended to create any breaking changes, and will be reflected as a minor version bump for affected packages. NB we'll run all tests and do visual verifications, but there is always the opportunity for unexpected regressions. If you're using one of the packages in a stable or production context you may want to check this before taking the next minor version, and do let us know ASAP if you see anything problematic.
 
-            The goal is to update to the latest Carbon versions each Wednesday, to ensure we remain up-to-date with the latest changes and to ensure interoperability with other packages that also depend on Carbon. We will normally update all other dependencies at the same time to their latest versions, except for specific cases where we have found the updates to be problematic or require further work before they can be used. By using the latest stable version of each dependency we ensure we get fixes and improvements in a timely fashion and reduce the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
+            The goal is to update to the latest Carbon versions each Friday, to ensure we remain up-to-date with the latest changes (often published on Thursdays) and to ensure interoperability with other packages that also depend on Carbon. We will normally update all other dependencies at the same time to their latest versions, except for specific cases where we have found the updates to be problematic or require further work before they can be used. By using the latest stable version of each dependency we ensure we get fixes and improvements in a timely fashion and reduce the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
 
             #### What did you change?
 
-            This action ran `yarn upgrade:automatic` to upgrade all carbon-related packages to the latest versions and to upgrade most other packages to the latest version, though certain critical packages are intentionally excluded.
+            This action ran `yarn upgrade:carbon` to upgrade all carbon-related packages to the latest versions.
 
-            This action also deleted the `yarn.lock` file in order to recreate it with the latest matching versions of secondary dependencies.
-
-            This PR includes the various `package.json` that pull our dependencies forward to the latest versions, the `yarn.lock` update that maps required versions to the actual versions to be used, and updates the offline mirror.
+            This PR includes the various `package.json` that pull our dependencies forward to the latest versions, and updates the offline mirror.
 
             #### How did you test and verify your work?
 
@@ -69,3 +64,45 @@ jobs:
         run: |
           echo "The PR number was ${{ steps.create-pr.outputs.pull-request-number }}"
           echo "The result was ${{ steps.post-reminder.outputs.slack-result }}"
+
+  dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install
+        run: yarn --offline
+
+      - name: Update packages
+        run: |
+          yarn upgrade:automatic
+          rm yarn.lock
+          yarn
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.CREATE_PR_ACCESS_TOKEN }}
+          commit-message: 'chore: update dev dependencies'
+          committer: GitHub <noreply@github.com>
+          author:
+            ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: 'update-packages'
+          branch-suffix: random
+          title: 'chore: update dev dependencies'
+          body: |
+            This PR was automatically generated to update versions of dev dependencies to their latest versions. This helps ensure we get fixes and improvements in a timely fashion and reduces the impact of updating the versions that can arise if versions are allowed to become stale for an extended period.
+
+            #### What did you change?
+
+            This action ran `yarn upgrade:automatic` to update `package.json` files to request the latest versions of each package. Certain critical packages are intentionally excluded.
+
+            This action also deleted the `yarn.lock` file in order to recreate it with the latest matching versions of secondary dependencies.
+
+            This PR includes the various `package.json` that pull our dependencies forward to the latest versions, the `yarn.lock` update that maps required versions to the actual versions to be used, and updates the offline mirror.
+
+            #### How did you test and verify your work?
+
+            This PR should not normally significantly affect the build outputs or runtime packages. Ensure that `yarn ci-check` runs cleanly and all tests pass (done automatically as part of the PR checks).

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "storybook:start": "cd packages/core && yarn start",
     "sync": "carbon-cli sync",
     "update-gallery-config": "node scripts/example-gallery-builder/index.js; yarn format:prettier:files examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js --write",
-    "upgrade:dependencies:carbon": "npm-check-updates -u --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested), husky (major change in action), eslint (until eslint-config-carbon's babel-eslint supports eslint v8), stylelint (until stylelint-config-carbon supports stylelint v14)",
     "upgrade:dependencies:top": "npm-check-updates -u --reject '/(carbon|^react$|^react-dom$|^husky$|^eslint$|^stylelint$)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
     "upgrade:automatic": "run-s upgrade:dependencies:*",
+    "upgrade:carbon": "npm-check-updates -u --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
     "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR separates the version updates into two tasks, one of which updates the dev-dependencies and the other updates Carbon versions. This will create two PRs. The dev-dependency PR can be readily merged as soon as all tests and CI checks pass. The Carbon-updates PR will do a version bump, and should be carefully tested before merging. This means that when there are no Carbon updates there will not be an unnecessary version bump.

#### What did you change?

top-level package.json, and the update yaml.

#### How did you test and verify your work?

Will do a test run once merged.