### PR TITLE
chore: add the examples gallery to the storybook

### DIFF
--- a/examples/carbon-for-ibm-products/example-gallery/src/GalleryCard.scss
+++ b/examples/carbon-for-ibm-products/example-gallery/src/GalleryCard.scss
@@ -5,20 +5,20 @@
 
 $baseClass: 'gallery-card';
 
-.#{$baseClass} {
+.#{$baseClass}.#{$baseClass} {
   position: relative;
   display: inline-flex;
   flex-direction: column;
 }
 
-.#{$baseClass}__thumbnail {
+.#{$baseClass} .#{$baseClass}__thumbnail {
   flex: 1 1 80%;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
 }
 
-.#{$baseClass}__title {
+.#{$baseClass} .#{$baseClass}__title {
   @include carbon--type-style('productive-heading-03');
 
   overflow: hidden;

--- a/examples/carbon-for-ibm-products/example-gallery/src/_storybook-styles.scss
+++ b/examples/carbon-for-ibm-products/example-gallery/src/_storybook-styles.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2021, 2021
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@import 'App';
+@import 'GalleryCard';

--- a/examples/carbon-for-ibm-products/example-gallery/src/example-gallery.stories.js
+++ b/examples/carbon-for-ibm-products/example-gallery/src/example-gallery.stories.js
@@ -7,12 +7,18 @@
 
 import React from 'react';
 import { getPathForComponent } from '../../../../packages/core/story-structure';
+
 import App from './App';
 
+import styles from './_storybook-styles.scss';
+
 export default {
-  title: getPathForComponent('o', 'Examples on CodePen.io'),
+  title: getPathForComponent('o', 'Examples on CodeSandbox'),
+  parameters: {
+    styles,
+  },
 };
 
-export const OneStory = () => <App />;
-OneStory.storyName = 'IBM Products';
-OneStory.parameters = { options: { showPanel: false } };
+export const c4pGallery = () => <App />;
+c4pGallery.storyName = 'Carbon for IBM Products';
+c4pGallery.parameters = { options: { showPanel: false } };

--- a/examples/carbon-for-ibm-products/example-gallery/src/example-gallery.stories.js
+++ b/examples/carbon-for-ibm-products/example-gallery/src/example-gallery.stories.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright IBM Corp. 2020, 2021
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { getPathForComponent } from '../../../../packages/core/story-structure';
+import App from './App';
+
+export default {
+  title: getPathForComponent('o', 'Examples on CodePen.io'),
+};
+
+export const OneStory = () => <App />;
+OneStory.storyName = 'IBM Products';
+OneStory.parameters = { options: { showPanel: false } };

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -35,7 +35,7 @@ module.exports = {
     //fastRefresh: true, -- this option would be nice, but seems to cause errors, see https://github.com/storybookjs/storybook/issues/13745
     strictMode: true,
   },
-  stories: ['../../**/+(docs|src)/**/*+(-story|.stories).*'],
+  stories: ['../../../**/+(docs|src)/**/*+(-story|.stories).*'],
   webpackFinal: async (configuration) =>
     merge(configuration, {
       cache: {

--- a/packages/core/docs/getting-started.stories.mdx
+++ b/packages/core/docs/getting-started.stories.mdx
@@ -7,6 +7,6 @@ import { Description, Meta } from '@storybook/addon-docs';
 
 import readme from '../../../README.md';
 
-<Meta title="Getting Started" />
+<Meta title="Overview/Getting started" />
 
 <Description markdown={readme} />

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -14,7 +14,21 @@
 // paths but ignored during searching.
 const s = [
   {
-    n: 'Carbon for IBM Products',
+    n: 'Overview',
+    s: [
+      {
+        n: 'Getting started',
+        s: [],
+      },
+      {
+        n: 'Usage examples',
+        s: [],
+      },
+      'o/Examples on CodePen.io',
+    ],
+  },
+  {
+    n: 'IBM Products',
     s: [
       {
         n: 'Components',
@@ -138,10 +152,6 @@ const s = [
         ],
       },
     ],
-  },
-  {
-    n: 'Getting Started',
-    s: [],
   },
 ];
 

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -24,7 +24,7 @@ const s = [
         n: 'Usage examples',
         s: [],
       },
-      'o/Examples on CodePen.io',
+      'o/Examples on CodeSandbox',
     ],
   },
   {


### PR DESCRIPTION
Create a new 'Overview' section in the storybook, and move the 'Getting Started' page into it, and also add the examples gallery into it. We can also add multi-component playgrounds etc into this section.

#### What did you change?

storybook config, and added a new story to the examples gallery

#### How did you test and verify your work?

Ran storybook.
