### PR TITLE
chore: update yarn version as part of dependencies upgrade

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -4,4 +4,4 @@
 
 yarn-offline-mirror "./.yarn/offline-mirror"
 yarn-offline-mirror-pruning true
-yarn-path ".yarn/releases/yarn-1.22.10.cjs"
+yarn-path ".yarn/releases/yarn-1.22.17.cjs"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested), husky (major change in action), eslint (until eslint-config-carbon's babel-eslint supports eslint v8), stylelint (until stylelint-config-carbon supports stylelint v14)",
     "upgrade:dependencies:top": "npm-check-updates -u --reject '/(carbon|^react$|^react-dom$|^husky$|^eslint$|^stylelint$)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
+    "upgrade:dependencies:yarn": "yarn policies set-version",
     "upgrade:automatic": "run-s upgrade:dependencies:*",
     "upgrade:carbon": "npm-check-updates -u --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
     "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested), husky (major change in action), eslint (until eslint-config-carbon's babel-eslint supports eslint v8), stylelint (until stylelint-config-carbon supports stylelint v14)",
     "upgrade:dependencies:top": "npm-check-updates -u --reject '/(carbon|^react$|^react-dom$|^husky$|^eslint$|^stylelint$)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
-    "upgrade:dependencies:yarn": "yarn policies set-version",
+    "upgrade:dependencies:yarn": "yarn set version latest",
     "upgrade:automatic": "run-s upgrade:dependencies:*",
     "upgrade:carbon": "npm-check-updates -u --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
     "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh"


### PR DESCRIPTION
Our `yarn` version is locked in to our repo, but hasn't been updated recently. Update to the latest `yarn` as part of the regular dependencies upgrades.

#### What did you change?

package.json, plus yarn config

#### How did you test and verify your work?

Ran `yarn` and builds.