### PR TITLE
fix(ICA): Make edit icon button inline with ICA label and total

### DIFF
--- a/packages/security/src/components/ICA/ICA.js
+++ b/packages/security/src/components/ICA/ICA.js
@@ -136,7 +136,7 @@ const ICA = ({
             <span>/{truncatedTotal}</span>
           </span>
         ) : null}
-        {iconButton}
+         <span className={`${namespace}__icon`}>{iconButton}</span>
       </span>
     </div>
   );

--- a/packages/security/src/components/ICA/_index.scss
+++ b/packages/security/src/components/ICA/_index.scss
@@ -26,6 +26,12 @@
 
     margin-bottom: 0;
   }
+  
+  &__icon {
+    width: carbon--mini-units($count: 2);
+    height: carbon--mini-units($count: 2);
+  }
+
 
   &__total {
     @include carbon--type-style($name: body-short-01);


### PR DESCRIPTION
I had the change in https://github.com/carbon-design-system/ibm-security/pull/1135 but said i'd add it to this repo.

#### What did you change?

Before(button was pushing total label down):
![image](https://user-images.githubusercontent.com/55839633/150991874-0930dc78-9573-40d7-b7fe-84697d4467cf.png)

After:
![image](https://user-images.githubusercontent.com/55839633/150991943-0f5a28dd-8e09-45ba-8554-653e1cb836fd.png)


#### How did you test and verify your work?
Loaded storybook up locally to test
