### PR TITLE
chore: ensure dependency updates bring peer dependencies up to latest

### DIFF
--- a/config/babel-preset-ibm-cloud-cognitive/package.json
+++ b/config/babel-preset-ibm-cloud-cognitive/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
   },
   "devDependencies": {
     "npm-check-updates": "^12.2.0"

--- a/config/cli/package.json
+++ b/config/cli/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
   },
   "devDependencies": {
     "@commitlint/parse": "^16.0.0",

--- a/config/jest-config-ibm-cloud-cognitive/package.json
+++ b/config/jest-config-ibm-cloud-cognitive/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "//upgrade-dependencies": "# don't upgrade carbon (done globally) or chalk (until v5 works in the jest config, see https://github.com/facebook/jest/issues/12119)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^chalk$)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^chalk$)/'"
   },
   "devDependencies": {
     "npm-check-updates": "^12.2.0"

--- a/config/storybook-addon-carbon-theme/package.json
+++ b/config/storybook-addon-carbon-theme/package.json
@@ -35,7 +35,7 @@
     "build:js": "babel src --out-dir dist -s",
     "prepare": "npm run build",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon)/'"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sync": "carbon-cli sync",
     "update-gallery-config": "node scripts/example-gallery-builder/index.js; yarn format:prettier:files examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js --write",
     "//upgrade:dependencies:top": "# don't upgrade carbon (done globally), react/react-dom (not tested), husky (major change in action), eslint (until eslint-config-carbon's babel-eslint supports eslint v8), stylelint (until stylelint-config-carbon supports stylelint v14)",
-    "upgrade:dependencies:top": "npm-check-updates -u --reject '/(carbon|^react$|^react-dom$|^husky$|^eslint$|^stylelint$)/'",
+    "upgrade:dependencies:top": "npm-check-updates -u --dep dev,peer,prod --reject '/(carbon|^react$|^react-dom$|^husky$|^eslint$|^stylelint$)/'",
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
     "upgrade:dependencies:yarn": "yarn set version latest",
     "upgrade:automatic": "run-s upgrade:dependencies:*",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "upgrade:dependencies:packages": "yarn run-all --no-sort --concurrency 1 upgrade-dependencies",
     "upgrade:dependencies:yarn": "yarn set version latest",
     "upgrade:automatic": "run-s upgrade:dependencies:*",
-    "upgrade:carbon": "npm-check-updates -u --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
+    "upgrade:carbon": "npm-check-updates -u --dep dev,peer,prod --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/'",
     "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh"
   },
   "devDependencies": {

--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -35,11 +35,11 @@
     "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$|^uuid$)/'"
   },
   "peerDependencies": {
-    "@carbon/elements": "^10.46.0",
-    "@carbon/grid": "^10.39.0",
-    "@carbon/icons-react": "^10.42.0",
-    "carbon-components": "^10.47.1",
-    "carbon-components-react": "^7.47.2",
+    "@carbon/elements": "^10.50.0",
+    "@carbon/grid": "^10.40.0",
+    "@carbon/icons-react": "^10.45.0",
+    "carbon-components": "^10.51.0",
+    "carbon-components-react": "^7.51.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"

--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf es lib scss",
     "test": "jest --colors",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally), react (explicit range peer dependency), uuid (not tested)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$|^uuid$)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^uuid$)/'"
   },
   "peerDependencies": {
     "@carbon/elements": "^10.50.0",

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -47,7 +47,7 @@
     "postinstall": "carbon-telemetry collect --install",
     "test": "jest --colors",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency) or chalk (until we can load it as ESM)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$|^chalk$)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^chalk$)/'"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -73,15 +73,15 @@
     "react-resize-detector": "^7.0.0"
   },
   "peerDependencies": {
-    "@carbon/colors": "^10.34.0",
-    "@carbon/icons-react": "^10.42.0",
+    "@carbon/colors": "^10.35.0",
+    "@carbon/icons-react": "^10.45.0",
     "@carbon/import-once": "^10.5.0",
-    "@carbon/layout": "^10.34.0",
-    "@carbon/motion": "^10.26.0",
-    "@carbon/themes": "^10.46.0",
-    "@carbon/type": "^10.38.0",
-    "carbon-components": "^10.47.1",
-    "carbon-components-react": "^7.47.2",
+    "@carbon/layout": "^10.35.0",
+    "@carbon/motion": "^10.27.0",
+    "@carbon/themes": "^10.49.0",
+    "@carbon/type": "^10.40.0",
+    "carbon-components": "^10.51.0",
+    "carbon-components-react": "^7.51.0",
     "carbon-icons": "^7.0.7",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "start": "run-s build:carbon start:storybook",
     "start:storybook": "start-storybook -s ./public -p 3000",
     "//upgrade-dependencies": "# don't upgrade carbon (done globally), react (not tested)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^react$|^react-dom$)/'"
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$)/'"
   },
   "devDependencies": {
     "@babel/core": "^7.16.10",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -45,8 +45,8 @@
     "sync:clone": "git clone git@github.com:carbon-design-system/ibm-security.git --depth 1",
     "sync:copy": "copyfiles 'ibm-security/src/**/*' . -u 1",
     "test": "jest --colors",
-    "//upgrade-dependencies": "# don't upgrade carbon (done globally) or faker (destructively updated)",
-    "upgrade-dependencies": "npm-check-updates -u --color --reject '/(carbon|^faker$)/'"
+    "//upgrade-dependencies": "# don't upgrade carbon (done globally), react/react-dom (explicit range peer dependency) or faker (destructively updated)",
+    "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$|^faker$)/'"
   },
   "peerDependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
Our weekly dependency updates were updating the yarn lock and offline mirror, ensuring that we were always building alongside the latest versions of carbon, but `npm-check-updates` by default does NOT update the peerDependencies field, so our peer dependencies were sometimes lagging behind, meaning that some of our users might be using our library alongside older Carbon versions -- something we don't recommend. This update ensures that our peer dependencies are pulled up to the latest versions at the same time.

#### What did you change?

package.json update scripts

#### How did you test and verify your work?

Ran the various update processes and checked the outputs.