### PR TITLE
feat: password input option for export modal

### DIFF
--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
@@ -17,6 +17,7 @@ import {
   RadioButtonGroup,
   FormGroup,
   Loading,
+  PasswordInput,
 } from 'carbon-components-react';
 import cx from 'classnames';
 import { ErrorFilled16, CheckmarkFilled16 } from '@carbon/icons-react';
@@ -36,7 +37,9 @@ export let ExportModal = forwardRef(
       error,
       errorMessage,
       filename,
+      hidePasswordLabel,
       inputLabel,
+      inputType,
       invalidInputText,
       loading,
       loadingMessage,
@@ -47,6 +50,7 @@ export let ExportModal = forwardRef(
       preformattedExtensionsLabel,
       primaryButtonText,
       secondaryButtonText,
+      showPasswordLabel,
       successMessage,
       successful,
       title,
@@ -100,6 +104,17 @@ export let ExportModal = forwardRef(
     const primaryButtonDisabled = loading || !name || hasInvalidExtension();
     const submitted = loading || error || successful;
 
+    const commonInputProps = {
+      id: `text-input--${internalId.current}`,
+      value: name,
+      onChange: onNameChangeHandler,
+      labelText: inputLabel,
+      invalid: hasInvalidExtension(),
+      invalidText: invalidInputText,
+      onBlur: onBlurHandler,
+      ['data-modal-primary-focus']: true,
+    };
+
     return (
       <ComposedModal
         {...rest}
@@ -134,16 +149,18 @@ export let ExportModal = forwardRef(
                   </RadioButtonGroup>
                 </FormGroup>
               ) : (
-                <TextInput
-                  id={`text-input--${internalId.current}`}
-                  value={name}
-                  onChange={onNameChangeHandler}
-                  labelText={inputLabel}
-                  invalid={hasInvalidExtension()}
-                  invalidText={invalidInputText}
-                  onBlur={onBlurHandler}
-                  data-modal-primary-focus
-                />
+                <div className={`${blockClass}__input-container`}>
+                  {inputType === 'text' ? (
+                    <TextInput {...commonInputProps} />
+                  ) : (
+                    <PasswordInput
+                      {...commonInputProps}
+                      showPasswordLabel={showPasswordLabel}
+                      hidePasswordLabel={hidePasswordLabel}
+                      tooltipPosition="left"
+                    />
+                  )}
+                </div>
               )}
             </>
           )}
@@ -215,9 +232,17 @@ ExportModal.propTypes = {
    */
   filename: PropTypes.string.isRequired,
   /**
+   * label text that's displayed when hovering over visibility toggler to hide key
+   */
+  hidePasswordLabel: PropTypes.string,
+  /**
    * label for the text input
    */
   inputLabel: PropTypes.string,
+  /**
+   * specify the type of text input
+   */
+  inputType: PropTypes.oneOf(['text', 'password']),
   /**
    * text for an invalid input
    */
@@ -264,6 +289,10 @@ ExportModal.propTypes = {
    */
   secondaryButtonText: PropTypes.string.isRequired,
   /**
+   * label text that's displayed when hovering over visibility toggler to show key
+   */
+  showPasswordLabel: PropTypes.string,
+  /**
    * messaging to display if the export was successful
    */
   successMessage: PropTypes.string,
@@ -282,6 +311,7 @@ ExportModal.propTypes = {
 };
 
 ExportModal.defaultProps = {
+  inputType: 'text',
   preformattedExtensions: [],
   validExtensions: [],
 };

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.stories.js
@@ -36,6 +36,7 @@ const defaultProps = {
   primaryButtonText: 'Export',
   secondaryButtonText: 'Cancel',
   title: 'Export',
+  inputType: 'text',
 };
 
 const Template = (args) => {

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
@@ -26,6 +26,7 @@ const defaultProps = {
   secondaryButtonText: 'secondary button',
   successMessage: 'success',
   title: 'header content',
+  inputType: 'text',
 };
 
 describe(componentName, () => {
@@ -153,6 +154,16 @@ describe(componentName, () => {
 
     click(screen.getByText(props.secondaryButtonText));
     expect(onClose).toBeCalled();
+  });
+
+  it('renders with password field', () => {
+    const { container } = render(
+      <ExportModal {...defaultProps} inputType="password" />
+    );
+    expect(container.querySelector('.bx--text-input')).toHaveAttribute(
+      'type',
+      'password'
+    );
   });
 
   //@TODO: reinstate this test as soon as https://github.com/carbon-design-system/carbon/issues/10107 is fixed


### PR DESCRIPTION
Contributes to #1573 

adds the option to use a password field instead of a text field in the `ExportModal` component.