### PR TITLE
fix: productive card button size and props spread

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6413,9 +6413,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   justify-content: space-between;
   border-top: 1px solid var(--cds-ui-03, #e0e0e0);
 }
-.c4p--card__productive .c4p--card__footer .bx--btn svg {
-  margin-left: var(--cds-spacing-03, 0.5rem);
-}
 .c4p--card__productive .c4p--card__footer-no-button {
   justify-content: flex-end;
 }

--- a/packages/cloud-cognitive/src/components/Card/Card.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.js
@@ -79,10 +79,19 @@ export let Card = forwardRef(
       }
 
       const icons = actionIcons.map(
-        ({ id, icon: Icon, onClick, iconDescription, onKeyDown, href }) => {
+        ({
+          id,
+          icon: Icon,
+          onClick,
+          iconDescription,
+          onKeyDown,
+          href,
+          ...rest
+        }) => {
           if (productive) {
             return (
               <Button
+                {...rest}
                 key={id}
                 renderIcon={Icon}
                 hasIconOnly

--- a/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/_productive-card.scss
@@ -36,10 +36,6 @@
       align-items: center;
       justify-content: space-between;
       border-top: 1px solid $ui-03;
-
-      .#{$carbon-prefix}--btn svg {
-        margin-left: $spacing-03;
-      }
     }
 
     .#{$block-class}__footer-no-button {


### PR DESCRIPTION
Contributes to #1580 and #1571

* removes unnecessary margin from productive card icon buttons that were causing an incorrect size
* adds `{...rest}` to the action icons in productive cards so that users can pass additional props like `disabled` to the buttons