### PR TITLE
fix(AddSelect): refactor custom filter and init navigation

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { forwardRef, useState, useEffect } from 'react';
+import React, { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import {
@@ -56,25 +56,9 @@ export let AddSelect = forwardRef(
     };
 
     // hooks
-    const [filteredItems, setFilteredItems] = useState([]);
     const [singleSelection, setSingleSelection] = useState('');
     const [multiSelection, setMultiSelection] = useState([]);
     const [searchTerm, setSearchTerm] = useState('');
-
-    // filter items as a search term is entered
-    useEffect(() => {
-      const results = searchTerm
-        ? items.filter((item) => {
-            // if user provides their own filter function use that
-            if (onSearchFilter) {
-              return onSearchFilter(item, searchTerm);
-            }
-            // otherwise use the default label filter
-            return item.label.includes(searchTerm);
-          })
-        : items;
-      setFilteredItems(results);
-    }, [items, onSearchFilter, searchTerm]);
 
     // handlers
     const handleSearch = (e) => {
@@ -98,6 +82,22 @@ export let AddSelect = forwardRef(
     const onNavigateItem = () => {
       // TODO figure out navigation
     };
+
+    // item filtering
+    const getFilteredItems = () =>
+      items.filter((item) => {
+        if (!searchTerm) {
+          return item;
+        }
+        // if user provides their own filter function use that
+        if (onSearchFilter) {
+          return onSearchFilter(item, searchTerm);
+        }
+        // otherwise use the default label filter
+        return item.label.toLowerCase().includes(searchTerm);
+      });
+
+    const filteredItems = getFilteredItems();
 
     // sidebar
     const influencer = (

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -61,21 +61,18 @@ export let AddSelect = forwardRef(
     const [multiSelection, setMultiSelection] = useState([]);
     const [searchTerm, setSearchTerm] = useState('');
 
-    // save items locally
-    useEffect(() => {
-      setFilteredItems(items);
-    }, [items]);
-
     // filter items as a search term is entered
     useEffect(() => {
-      const results = items.filter((item) => {
-        // if user provides their own filter function use that
-        if (onSearchFilter) {
-          return onSearchFilter(item, searchTerm);
-        }
-        // otherwise use the default label filter
-        return item.label.includes(searchTerm);
-      });
+      const results = searchTerm
+        ? items.filter((item) => {
+            // if user provides their own filter function use that
+            if (onSearchFilter) {
+              return onSearchFilter(item, searchTerm);
+            }
+            // otherwise use the default label filter
+            return item.label.includes(searchTerm);
+          })
+        : items;
       setFilteredItems(results);
     }, [items, onSearchFilter, searchTerm]);
 

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import {
@@ -18,6 +18,7 @@ import {
   TextInput,
   Tag,
 } from 'carbon-components-react';
+import { ChevronRight16 } from '@carbon/icons-react';
 import { Tearsheet, TearsheetNarrow } from '../../components/Tearsheet';
 import { NoDataEmptyState } from '../../components/EmptyStates/NoDataEmptyState';
 import { pkg } from '../../settings';
@@ -55,17 +56,32 @@ export let AddSelect = forwardRef(
     };
 
     // hooks
+    const [filteredItems, setFilteredItems] = useState([]);
     const [singleSelection, setSingleSelection] = useState('');
     const [multiSelection, setMultiSelection] = useState([]);
     const [searchTerm, setSearchTerm] = useState('');
 
+    // save items locally
+    useEffect(() => {
+      setFilteredItems(items);
+    }, [items]);
+
+    // filter items as a search term is entered
+    useEffect(() => {
+      const results = items.filter((item) => {
+        // if user provides their own filter function use that
+        if (onSearchFilter) {
+          return onSearchFilter(item, searchTerm);
+        }
+        // otherwise use the default label filter
+        return item.label.includes(searchTerm);
+      });
+      setFilteredItems(results);
+    }, [items, onSearchFilter, searchTerm]);
+
     // handlers
-    const onSearchHandler = (e) => {
-      const { value } = e.target;
-      setSearchTerm(value);
-      if (onSearchFilter) {
-        onSearchFilter(value);
-      }
+    const handleSearch = (e) => {
+      setSearchTerm(e.target.value);
     };
 
     const handleSingleSelection = (value) => {
@@ -82,16 +98,9 @@ export let AddSelect = forwardRef(
       }
     };
 
-    // data manipulation
-    const getFilteredItems = () => {
-      // if the user uses their own filter then they provide the filtered items
-      if (onSearchFilter) {
-        return items;
-      }
-      // by default, just filter results by their label from a single search term
-      return items.filter((i) => i.label.includes(searchTerm));
+    const onNavigateItem = () => {
+      // TODO figure out navigation
     };
-    const filteredResults = getFilteredItems();
 
     // sidebar
     const influencer = (
@@ -125,46 +134,51 @@ export let AddSelect = forwardRef(
             labelText="temp label"
             placeholder={inputPlaceholder}
             value={searchTerm}
-            onChange={onSearchHandler}
+            onChange={handleSearch}
           />
           <div className={`${blockClass}__items-label-container`}>
             <p className={`${blockClass}__items-label`}>{itemsLabel}</p>
             <Tag type="gray" size="sm">
-              {filteredResults.length}
+              {filteredItems.length}
             </Tag>
           </div>
         </div>
-        {filteredResults.length > 0 ? (
+        {filteredItems.length > 0 ? (
           <div className={`${blockClass}__selections-wrapper`}>
             <StructuredListWrapper
               selection
               className={`${blockClass}__selections`}
             >
               <StructuredListBody>
-                {filteredResults.map((item) => (
+                {filteredItems.map((item) => (
                   <StructuredListRow key={item.id}>
                     <StructuredListCell>
-                      {multi ? (
-                        <Checkbox
-                          className={`${blockClass}__selections-checkbox`}
-                          onChange={(value) =>
-                            handleMultiSelection(item.value, value)
-                          }
-                          labelText={item.label}
-                          id={item.id}
-                          checked={multiSelection.includes(item.value)}
-                        />
-                      ) : (
-                        <RadioButton
-                          className={`${blockClass}__selections-radio`}
-                          name="add-select-selections"
-                          id={item.id}
-                          value={item.value}
-                          labelText={item.label}
-                          onChange={handleSingleSelection}
-                          selected={item.value === singleSelection}
-                        />
-                      )}
+                      <div className={`${blockClass}__selections-cell-wrapper`}>
+                        {multi ? (
+                          <Checkbox
+                            className={`${blockClass}__selections-checkbox`}
+                            onChange={(value) =>
+                              handleMultiSelection(item.value, value)
+                            }
+                            labelText={item.label}
+                            id={item.id}
+                            checked={multiSelection.includes(item.value)}
+                          />
+                        ) : (
+                          <RadioButton
+                            className={`${blockClass}__selections-radio`}
+                            name="add-select-selections"
+                            id={item.id}
+                            value={item.value}
+                            labelText={item.label}
+                            onChange={handleSingleSelection}
+                            selected={item.value === singleSelection}
+                          />
+                        )}
+                        {item.children && (
+                          <ChevronRight16 onClick={onNavigateItem} />
+                        )}
+                      </div>
                     </StructuredListCell>
                   </StructuredListRow>
                 ))}

--- a/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
+++ b/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
@@ -41,6 +41,12 @@
     &-wrapper {
       display: block;
     }
+
+    &-cell-wrapper {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
   }
 
   // multi select specific

--- a/packages/cloud-cognitive/src/components/SingleAddSelect/SingleAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/SingleAddSelect/SingleAddSelect.stories.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 import {
   getStoryTitle,
@@ -67,23 +67,11 @@ const Template = (args) => {
   return <SingleAddSelect {...args} />;
 };
 
-const CustomFilterTemplate = (args) => {
-  const [items, setItems] = useState(args.items);
-  const filterHandler = (searchTerm) => {
-    if (!searchTerm) {
-      setItems(args.items);
-    } else {
-      // search all attributes for value
-      const newItems = items.filter((i) =>
-        Object.keys(i).some((key) => i[key].includes(searchTerm))
-      );
-      setItems(newItems);
-    }
-  };
+const CustomFilterTemplate = () => {
   const props = {
     ...defaultProps,
-    items,
-    onSearchFilter: filterHandler,
+    onSearchFilter: (item, searchTerm) =>
+      Object.keys(item).some((key) => item[key].includes(searchTerm)),
   };
   return <SingleAddSelect {...props} />;
 };
@@ -97,5 +85,26 @@ export const Default = prepareStory(Template, {
 export const WithCustomFilter = prepareStory(CustomFilterTemplate, {
   args: {
     ...defaultProps,
+  },
+});
+
+export const WithHierarchy = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    items: [
+      ...defaultProps.items,
+      {
+        id: '4',
+        label: 'California',
+        value: 'california',
+        children: [
+          {
+            id: '1',
+            label: 'Los Angeles',
+            value: 'la',
+          },
+        ],
+      },
+    ],
   },
 });


### PR DESCRIPTION
Contributes to #1582 

* the code now checks for a `children` attribute in the items array to distinguish the hierarchy of the list and adds a chevron to indicate that you can drill down further. just the start of the implementation as this PR shifted focus while I was working on this.
* i refactored the way the search filter work and how custom filtering works. now it appropriately uses a hook to filter the data and now the user only needs to provide a filter function instead of maintaining the state. clearly the initial implementation was done hastily on my part. this should represent a more polished version.