### PR TITLE
feat(SidePanel): add prefers-reduced-motion support for SidePanel animations

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1967,6 +1967,11 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   content: \\"\\";
   opacity: var(--c4p--side-panel--divider-opacity);
 }
+.c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__title-container--reduced-motion {
+  z-index: 5;
+  border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
+  margin-bottom: var(--cds-spacing-05, 1rem);
+}
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__on-detail-step .c4p--side-panel__collapsed-title-text {
   top: var(--cds-spacing-09, 3rem);
 }

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1972,6 +1972,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
   margin-bottom: var(--cds-spacing-05, 1rem);
 }
+.c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__title-container--reduced-motion.c4p--side-panel__title-container--no-title-animation {
+  border-bottom: 0;
+  margin-bottom: 0;
+}
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__on-detail-step .c4p--side-panel__collapsed-title-text {
   top: var(--cds-spacing-09, 3rem);
 }

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -75,7 +75,7 @@ export let SidePanel = React.forwardRef(
     const endTrapRef = useRef();
     const sidePanelInnerRef = useRef();
     const sidePanelCloseRef = useRef();
-    const previousState = usePreviousValue({ size });
+    const previousState = usePreviousValue({ size, open });
 
     const reducedMotion =
       window && window.matchMedia
@@ -406,10 +406,6 @@ export let SidePanel = React.forwardRef(
           onRequestClose
         ) {
           onRequestClose();
-          if (open && reducedMotion.matches) {
-            setRender(false);
-            onUnmount?.();
-          }
         }
       };
       const bodyElement = document.body;
@@ -444,7 +440,7 @@ export let SidePanel = React.forwardRef(
     // initializes the side panel to close
     const onAnimationEnd = () => {
       if (!open) {
-        onUnmount && onUnmount();
+        onUnmount?.();
         setRender(false);
       }
       setAnimationComplete(true);
@@ -479,21 +475,39 @@ export let SidePanel = React.forwardRef(
       }
     }, [open, placement, selectorPageContent, slideIn]);
 
+    useEffect(() => {
+      if (!open && previousState?.open && reducedMotion.matches) {
+        setRender(false);
+        onUnmount?.();
+      }
+    }, [open, onUnmount, reducedMotion.matches, previousState?.open]);
+
     // used to set margins of content for slide in panel version
     useEffect(() => {
       if (shouldRender && slideIn) {
         const pageContentElement = document.querySelector(selectorPageContent);
         if (placement && placement === 'right' && pageContentElement) {
           pageContentElement.style.marginRight = 0;
-          pageContentElement.style.transition = `margin-right ${moderate02}`;
+          pageContentElement.style.transition = !reducedMotion.matches
+            ? `margin-right ${moderate02}`
+            : null;
           pageContentElement.style.marginRight = SIDE_PANEL_SIZES[size];
         } else if (pageContentElement) {
           pageContentElement.style.marginLeft = 0;
-          pageContentElement.style.transition = `margin-left ${moderate02}`;
+          pageContentElement.style.transition = !reducedMotion.matches
+            ? `margin-left ${moderate02}`
+            : null;
           pageContentElement.style.marginLeft = SIDE_PANEL_SIZES[size];
         }
       }
-    }, [slideIn, selectorPageContent, placement, shouldRender, size]);
+    }, [
+      slideIn,
+      selectorPageContent,
+      placement,
+      shouldRender,
+      size,
+      reducedMotion.matches,
+    ]);
 
     // adds focus trap functionality
     /* istanbul ignore next */

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -561,6 +561,8 @@ export let SidePanel = React.forwardRef(
             [`${blockClass}__title-container-is-animating`]:
               !animationComplete || !open,
             [`${blockClass}__title-container-without-title`]: !title,
+            [`${blockClass}__title-container--reduced-motion`]:
+              reducedMotion.matches,
           })}
         >
           {currentStep > 0 && (

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -427,7 +427,6 @@ export let SidePanel = React.forwardRef(
       preventCloseOnClickOutside,
       ref,
       onUnmount,
-      reducedMotion.matches,
     ]);
 
     // initialize the side panel to open

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -191,6 +191,10 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
         border-bottom: 1px solid $decorative-01;
         margin-bottom: $spacing-05;
       }
+      &.#{$block-class}__title-container--reduced-motion.#{$block-class}__title-container--no-title-animation {
+        border-bottom: 0;
+        margin-bottom: 0;
+      }
       &.#{$block-class}__on-detail-step .#{$block-class}__collapsed-title-text {
         top: $spacing-09;
       }

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -186,6 +186,11 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       &::before {
         @include setDividerStyles();
       }
+      &.#{$block-class}__title-container--reduced-motion {
+        z-index: 5;
+        border-bottom: 1px solid $decorative-01;
+        margin-bottom: $spacing-05;
+      }
       &.#{$block-class}__on-detail-step .#{$block-class}__collapsed-title-text {
         top: $spacing-09;
       }


### PR DESCRIPTION
Contributes to #1117 

Allows for the side panel to incorporate usage with `prefers-reduced-motion`. This update consists of not animating the entrance and exit animations, as well as preventing the scrolling title animation.

#### What did you change?
`SidePanel.js`
#### How did you test and verify your work?
Storybook (turning prefers reduced motion on and off)
![image](https://user-images.githubusercontent.com/10215203/152230950-ff7432b4-0a8a-4afa-bc25-01d403f5c830.png)
