### PR TITLE
chore(InlineEdit): animate inline edit to edit off

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -20,12 +20,12 @@ import { pkg } from '../../settings';
 import { Button } from 'carbon-components-react';
 import {
   Close16,
-  Edit16,
-  EditOff16,
   Checkmark16,
   WarningFilled16,
   WarningAltFilled16,
 } from '@carbon/icons-react';
+
+import { EditAndEditOff } from './edit-n-edit-off-svg';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--inline-edit`;
@@ -300,7 +300,7 @@ export let InlineEdit = React.forwardRef(
               hasIconOnly
               iconDescription={editDescription}
               onClick={handleEdit}
-              renderIcon={disabled ? EditOff16 : Edit16}
+              renderIcon={EditAndEditOff}
               disabled={disabled}
               tabIndex={-1}
             />

--- a/packages/cloud-cognitive/src/components/InlineEdit/_edit-n-edit-off-svg.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_edit-n-edit-off-svg.scss
@@ -1,0 +1,32 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Standard imports.
+@import '../../global/styles/project-settings';
+@import '../../global/styles/mixins';
+
+.edit-n-edit-off-svg .underline {
+  transform: rotate(0);
+  transform-origin: 100% 60%;
+  transition: all $duration--moderate-02 motion(standard, productive);
+}
+
+[disabled] > .edit-n-edit-off-svg .underline {
+  /* 4.2px = width of line * 1.5  */
+  // stylelint-disable-next-line carbon/layout-token-use
+  transform: rotate(45deg) scaleX(1.33) translateX(4.2px);
+}
+
+.edit-n-edit-off-svg .mask-black {
+  // stylelint-disable-next-line
+  fill: #000000 !important;
+}
+
+.edit-n-edit-off-svg .mask-white {
+  // stylelint-disable-next-line
+  fill: #ffffff !important;
+}

--- a/packages/cloud-cognitive/src/components/InlineEdit/_index.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_index.scss
@@ -6,3 +6,4 @@
 //
 
 @import './inline-edit';
+@import './edit-n-edit-off-svg';

--- a/packages/cloud-cognitive/src/components/InlineEdit/edit-n-edit-off-svg.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/edit-n-edit-off-svg.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+// Other standard imports.
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+// Based on Carbon Icons Edit16 and EditOff16
+export const EditAndEditOff = ({ className }) => {
+  return (
+    <svg
+      className={cx('edit-n-edit-off-svg', className)}
+      focusable="false"
+      preserveAspectRatio="xMidYMid meet"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Edit"
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 32 32"
+      role="img"
+    >
+      <g>
+        {/* masks */}
+        <mask id="pencil-mask">
+          {/* <!-- Everything under a white pixel will be visible --> */}
+          <rect x="0" y="0" width="32" height="32" className="mask-white" />
+
+          {/* <!-- Everything under a black pixel will be invisible --> */}
+          <path
+            d="M9.6 24H6 V20.4 L18 8.4 L21.6 12z"
+            className="mask-black"
+          ></path>
+          <path
+            d="M23 10.6 L19.4 7 L22.4 4 L26 7.6z"
+            className="mask-black"
+          ></path>
+        </mask>
+        <mask id="line-mask">
+          <g id="line-mask-group" className="underline">
+            <rect
+              x="0"
+              y="0"
+              width="32"
+              height="48" // leave enough room for pencil when rotated
+              className="mask-white"
+            />
+            <path d="M2 26 H30 V28 H2z" className="mask-black" />
+          </g>
+        </mask>
+      </g>
+      <g fill="currentColor">
+        {/* image */}
+        <g mask="url(#line-mask">
+          <path
+            mask="url(#pencil-mask)"
+            d="M4 19.6 L4 26 L10.4 26 L27.3 9.1 A2 2 0 0 0 27.3 6.1 L23.7 2.5 A2 2 0 0 0 20.9 2.7 "
+          ></path>
+        </g>
+
+        <path id="line" className="underline" d="M2 28 H30 V30H2z"></path>
+      </g>
+    </svg>
+  );
+};
+
+EditAndEditOff.propTypes = {
+  /**
+   * Provide an optional class to be applied to the containing node.
+   */
+  className: PropTypes.string,
+};


### PR DESCRIPTION
Contributes to #1492 

Add a moment of delight, animate between edit and edit off icons.

#### What did you change?

Rebuilt SVG for Edit16 and used it to animate to an icon like EditOff16

#### How did you test and verify your work?
Storybook toggle `disabled` control
