### PR TITLE
Page header title edit transition

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6127,6 +6127,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.c4p--page-header .c4p--page-header__title--editable {
+  margin-top: calc(-1 * var(--cds-spacing-01, 0.125rem));
+  margin-left: calc(-1 * var(--cds-spacing-05, 1rem));
+}
 .c4p--page-header .c4p--page-header__title .c4p--inline-edit__value {
   transform: translateY(-2px);
 }

--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -130,9 +130,32 @@
       }
     }
 
-    .#{$block-class}__placeholder {
+    .#{$block-class}__input::after {
+      display: block;
+      opacity: 0;
+      content: attr(data-placeholder);
+      color: $text-05;
+    }
+
+    .#{$block-class}__disabled-cover {
       position: absolute;
-      left: $spacing-03;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none; // act as if not there
+    }
+
+    &.#{$block-class}--disabled .#{$block-class}__disabled-cover {
+      // when disabled prevent pointer events going through to the input
+      cursor: not-allowed;
+      pointer-events: all;
+    }
+
+    .#{$block-class}__input--empty::after {
+      opacity: 1;
+      // only transition fade in
+      transition: opacity $duration--moderate-02 motion(standard, productive);
     }
 
     .#{$block-class}__controls {

--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -112,12 +112,15 @@
     }
 
     .#{$block-class}__input {
-      display: flex;
-      overflow: hidden;
+      display: inline-block;
+      // positions text and placeholder including when showing placeholder
+      // NOTE: Using flex does strange things to a caret in content editable
+      line-height: var(--#{$block-class}--size);
+      min-height: var(--#{$block-class}--size);
+      // min-width: $spacing-05; // space for caret when empty
+      min-width: calc(100% - 2 * var(--#{$block-class}--size) - $spacing-05);
       max-width: calc(100% - 2 * var(--#{$block-class}--size) - $spacing-05);
-      height: 100%;
-      flex: 1 1 100%;
-      align-items: center;
+
       // stylelint-disable-next-line carbon/layout-token-use
       margin-right: calc(2 * var(--#{$block-class}--size)); // room for controls
       margin-left: $spacing-05;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -1041,7 +1041,7 @@ PageHeader.propTypes = {
    *    - onChange: function to process the live value (React change === HTML Input)
    *    - onSave: function to process a confirmed change
    *    - editableLabel: label for edit required if onChange supplied
-   *    - revertDescription: label for edit revert button
+   *    - cancelDescription: label for edit cancel button
    *    - saveDescription: label for edit save button
    * - Object containing user defined contents. These must fit within the area defined for the title in both main part of the header and the breadcrumb.
    *    - content: title or name of current location shown in main part of page header
@@ -1060,7 +1060,7 @@ PageHeader.propTypes = {
       id: PropTypes.string, // .isRequired.if(inlineEditRequired),
       onChange: PropTypes.func,
       onSave: PropTypes.func,
-      revertDescription: PropTypes.string, //.isRequired.if(inlineEditRequired),
+      cancelDescription: PropTypes.string, //.isRequired.if(inlineEditRequired),
       saveDescription: PropTypes.string, //.isRequired.if(inlineEditRequired),
       // Update docgen if changed
     }),

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -359,7 +359,7 @@ const title = {
     onSave: () => {
       // gets replaced in template
     },
-    revertDescription: 'Revert',
+    cancelDescription: 'Cancel',
     saveDescription: 'Save',
     text: 'An editable title',
   },

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -425,6 +425,12 @@ $right-section-alt-width: 100% - $left-section-alt-width;
       white-space: nowrap;
     }
 
+    .#{$block-class}__title--editable {
+      // move to match non-editable version position
+      margin-top: calc(-1 * #{$spacing-01});
+      margin-left: calc(-1 * #{$spacing-05});
+    }
+
     .#{$block-class}__title .#{$pkg-prefix}--inline-edit__value {
       // The heading text sits 2px pixels lower in the inline edit which is aligned center
       // stylelint-disable-next-line carbon/layout-token-use


### PR DESCRIPTION
Contributes to #1492 

Some design review fixes.

#### What did you change?
- Changed the input layout to use line-height/height instead of flex as when empty the cursor did something weird (sat top left instead of central).
https://user-images.githubusercontent.com/15086604/153023611-16792b00-5d74-4388-83ce-1f7a9f659569.mp4
- Also fixed placeholder issue shown in same clip
- Fixed disabled behaviour which required placing an element over the contenteditable to prevent it gaining focus.

#### How did you test and verify your work?
Storybook