### PR TITLE
chore: ensure yarn stylelint config can be loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-dom": "^16.14.0",
     "rimraf": "^3.0.2",
     "stylelint": "^14.3.0",
-    "stylelint-config-ibm-products": "^0.0.1",
+    "stylelint-config-ibm-products": "*",
     "webpack": "^5.68.0"
   },
   "//resolutions": "package 'request' deprecated but still used, asks for http-signature ~1.2.0 which indirectly has vulnerabilities",


### PR DESCRIPTION
The package.json version used in the root was out of date and would never get updated by lerna.

#### What did you change?
Changed to asterisk, which should install any version found.

#### How did you test and verify your work?
Ran yarn.