### PR TITLE
fix(EmptyState): make subtitle optional

### DIFF
--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyState.js
@@ -128,7 +128,7 @@ EmptyState.propTypes = {
   /**
    * Empty state subtext
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state heading

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStateContent.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStateContent.js
@@ -30,13 +30,15 @@ export const EmptyStateContent = ({ action, link, size, subtitle, title }) => {
       >
         {title}
       </h3>
-      <p
-        className={cx(`${blockClass}__subtitle`, {
-          [`${blockClass}__subtitle--small`]: size === 'sm',
-        })}
-      >
-        {subtitle}
-      </p>
+      {subtitle && (
+        <p
+          className={cx(`${blockClass}__subtitle`, {
+            [`${blockClass}__subtitle--small`]: size === 'sm',
+          })}
+        >
+          {subtitle}
+        </p>
+      )}
       {action?.text && action?.onClick && (
         <Button
           {...action}
@@ -91,7 +93,7 @@ EmptyStateContent.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
    * Empty state title
    */

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
@@ -113,7 +113,7 @@ ErrorEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
@@ -113,7 +113,7 @@ NoDataEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
@@ -113,7 +113,7 @@ NoTagsEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
@@ -116,7 +116,7 @@ NotFoundEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
@@ -116,7 +116,7 @@ NotificationsEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
@@ -116,7 +116,7 @@ UnauthorizedEmptyState.propTypes = {
   /**
    * Empty state subtitle
    */
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 
   /**
    * Empty state title


### PR DESCRIPTION
Contributes to #1605 

This PR makes the subtitle prop on **EmptyStates** optional instead of required to follow the [pattern guidelines](https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage/). 

#### What did you change?
- Removed `isRequired` on propTypes for all EmptyState variations.
- Added check for `subtitle` prop in EmptyStateContent

#### How did you test and verify your work?
Storybook and ran `test` on EmptyState