### PR TITLE
chore: tidy up storybook styles files

### DIFF
--- a/packages/cloud-cognitive/scripts/generate/templates/_storybook-styles.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_storybook-styles.scss
@@ -5,11 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
+@import '../../global/styles/project-settings';
 
 // TODO: add any additional styles used by DISPLAY_NAME.stories.js
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/CancelableTextEdit/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/CancelableTextEdit/_storybook-styles.scss
@@ -5,11 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-
 // TODO: add any additional styles used by CancelableTextEdit.stories.js
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/_storybook-styles.scss
@@ -5,13 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
 @import '../../global/styles/project-settings';
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';
 
 $story-class: #{$pkg-prefix}--create-tearsheet-narrow--story;
 

--- a/packages/cloud-cognitive/src/components/EditSidePanel/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/EditSidePanel/_storybook-styles.scss
@@ -5,9 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-
-// TODO: add any additional styles used by EditSidePanel.stories.js
 @import '../../global/styles/project-settings';
 
 $block-class: #{$pkg-prefix}--edit-side-panel;
@@ -28,8 +25,3 @@ $story-prefix: edit-side-panel-stories__;
 .#{$block-class} .#{$carbon-prefix}--number__control-btn::after {
   background-color: $field-02;
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/InlineEdit/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_storybook-styles.scss
@@ -5,15 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-
-// TODO: add any additional styles used by InlineEdit.stories.js
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';
-
 .inline-edit-stories__viewport {
   // width: 300px; // larger than standard size needed by text input at standard font size (html input attribute size)
   // stylelint-disable-next-line carbon/layout-token-use

--- a/packages/cloud-cognitive/src/components/InlineEdit/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_storybook-styles.scss
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@import '../../global/styles/project-settings';
+
 .inline-edit-stories__viewport {
   // width: 300px; // larger than standard size needed by text input at standard font size (html input attribute size)
   // stylelint-disable-next-line carbon/layout-token-use

--- a/packages/cloud-cognitive/src/components/LoadingBar/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/LoadingBar/_storybook-styles.scss
@@ -12,8 +12,3 @@
   width: 24rem;
   margin: $spacing-07 $spacing-05 $spacing-05 $spacing-05;
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-// @import 'carbon-components/css/carbon-components.min';

--- a/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
@@ -5,8 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@import './index';
-
 @import '../../global/styles/project-settings';
 
 $block-class: #{$pkg-prefix}--options-tile;
@@ -26,8 +24,3 @@ $block-class: #{$pkg-prefix}--options-tile;
 .#{$block-class}__content .#{$carbon-prefix}--dropdown__wrapper:first-of-type {
   margin-bottom: $spacing-06;
 }
-
-// Uncomment next line (which must appear last) to test in storybook
-// that the SCSS styles for this component are sufficiently specific
-// to override Carbon whichever order the styles get loaded in.
-//@import 'carbon-components/css/carbon-components.min';


### PR DESCRIPTION
Remove a few instances of storybook styles files importing `./index`, as this causes duplicated styles in the storybook pack -- harmless but pointless. Also remove redundant comments with an old approach to checking specificity (not needed now the CSS import order has been set in the storybook) or prompting to add code that is now there. Also update the template generator page which wrongly includes the import of `./index`.

PS this will conflict with #1622 but it seemed better not to leave it incomplete -- we'll resolve the conflict after whichever one merges first.

#### What did you change?

several _storybook-styles.scss

#### How did you test and verify your work?

Ran storybook