### PR TITLE
chore(InlineEdit): move into edit and update section of storybook

### DIFF
--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -59,6 +59,10 @@ const s = [
             ],
           },
           {
+            n: 'Edit and update',
+            s: ['c/InlineEdit', 'c/EditSidePanel'],
+          },
+          {
             n: 'Empty state',
             s: [
               'c/EmptyState',
@@ -71,10 +75,6 @@ const s = [
             ],
           },
           { n: 'Export', s: ['c/ExportModal'] },
-          {
-            n: 'Edit and update flows',
-            s: ['c/EditSidePanel'],
-          },
           { n: 'Generating an API key', s: ['c/APIKeyModal'] },
           {
             n: 'HTTP errors',
@@ -102,7 +102,6 @@ const s = [
           'c/CancelableTextEdit',
           'c/ComboButton',
           'c/ExampleComponent',
-          'c/InlineEdit',
           'c/TearsheetShell',
         ],
       },


### PR DESCRIPTION
InlineEdit is not an internal component, but is one of the edit and update flows. We already have that section in the storybook, so move InlineEdit into that section (also drop the word "flows" to align with PAL site).

#### What did you change?

storybook structure config

#### How did you test and verify your work?

ran storybook
