### PR TITLE
fix: avoid relying on defaultProps in carbon components (issue #1643)

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -75,7 +75,7 @@ ActionSetButton.propTypes = {
   loading: PropTypes.bool,
 };
 
-const defaultKind = Button.defaultProps.kind;
+const defaultKind = 'primary';
 
 const willStack = (size, numberOfActions) =>
   size === 'xs' || size === 'sm' || (size === 'md' && numberOfActions > 2);

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -13,8 +13,6 @@ import { expectMultipleError } from '../../global/js/utils/test-helper';
 
 import { pkg } from '../../settings';
 
-import { Loading } from 'carbon-components-react';
-
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { ActionSet } from '.';
@@ -128,7 +126,7 @@ describe(componentName, () => {
 
   it('renders a loading button', () => {
     render(<ActionSet actions={[{ ...actionS, loading: true }]} />);
-    const loader = Loading.defaultProps.description;
+    const loader = 'Active loading indicator';
     expect(screen.getByRole('button').textContent).toEqual(
       `${labelS}${loader}${loader}`
     );

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
@@ -133,5 +133,5 @@ ButtonMenu.propTypes = {
 };
 
 ButtonMenu.defaultProps = {
-  size: Button.defaultProps.size,
+  size: 'default',
 };


### PR DESCRIPTION
Closes #1643 

A number of Carbon functional components have recently switched from using `defaultProps` to using ES6 default values for prop parameters on the component function. This causes a number of test failures where we are accessing those default prop values for use in our components. This is now the recommended way to provide default prop values, so this PR removes all dependency on `defaultProps` in carbon components.

#### What did you change?

ActionSet and ButtonMenu

#### How did you test and verify your work?

Ran tests