### PR TITLE
chore: this prettier setting fails VSCode commits

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,13 +7,15 @@
 
 'use strict';
 
-const prettierConfig = require('prettier-config-carbon');
+const {
+  jsxBracketSameLine,
+  ...prettierConfig
+} = require('prettier-config-carbon');
 
 // This setting is deprecated, undo Carbon usage as this appears to cause a conflict between
 // `yarn format` and the current version of the VS Code plugin.
 //
 // https://prettier.io/docs/en/options.html#deprecated-jsx-brackets
 //
-prettierConfig.jsxBracketSameLine = false;
 
 module.exports = prettierConfig;


### PR DESCRIPTION
Removes prettier config now deprecated, but still specified by Carbon from our usage.

#### What did you change?

Just the prettier config.

#### How did you test and verify your work?

Committing code from within VSCode. No problems were encountered, other than the report, at the command line.