### PR TITLE
fix: Using padding instead of margin to prevent border to being cut

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2636,8 +2636,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   margin: 0;
 }
 .c4p--tearsheet.c4p--tearsheet--wide .c4p--tearsheet__header--with-close-icon {
-  padding-right: var(--cds-spacing-05, 1rem);
-  margin-right: var(--cds-spacing-09, 3rem);
+  padding-right: var(--cds-spacing-10, 4rem);
 }
 .c4p--tearsheet .c4p--tearsheet__header-content {
   display: flex;

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -152,8 +152,7 @@
     }
 
     &.#{$block-class}--wide .#{$block-class}__header--with-close-icon {
-      padding-right: $spacing-05;
-      margin-right: $spacing-09;
+      padding-right: $spacing-10;
     }
 
     .#{$block-class}__header-content {


### PR DESCRIPTION
Contributes to #1682 

Fix Tearsheet heading border being cut by margin-right by replace margin with padding

#### What did you change?

Replaced margin right by adding same space to padding right

#### How did you test and verify your work?

Loaded storybook up locally to test

BEFORE
![BEFORE](https://user-images.githubusercontent.com/98974352/155153739-fdb6ed20-5218-4e1f-a5b3-258773b79572.png)

AFTER
![after](https://user-images.githubusercontent.com/98974352/155153768-53a4daf4-9b97-40e3-b51e-698352204522.png)

