### PR TITLE
feat(DataSpreadsheet): remove cell selection in certain case

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -427,8 +427,6 @@ export let DataSpreadsheet = React.forwardRef(
       spreadsheetRef,
       createActiveCell,
       containerHasFocus,
-      selectionAreas,
-      clickAndHoldActive,
     ]);
 
     const localRef = useRef();

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -27,6 +27,7 @@ import { getCellSize } from './getCellSize';
 import { DataSpreadsheetHeader } from './DataSpreadsheetHeader';
 import { useActiveElement } from '../../global/js/hooks';
 import { createActiveCellFn } from './createActiveCellFn';
+import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
 // cspell:words rowcount colcount
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -64,8 +65,9 @@ export let DataSpreadsheet = React.forwardRef(
     const [activeCellCoordinates, setActiveCellCoordinates] = useState(null);
     const [selectionAreas, setSelectionAreas] = useState([]);
     const [clickAndHoldActive, setClickAndHoldActive] = useState(false);
-    const [currentMatcher, setCurrentMatcher] = useState(null);
+    const [currentMatcher, setCurrentMatcher] = useState('');
     const cellSizeValue = getCellSize(cellSize);
+    const currentMatcherRef = useRef();
     const defaultColumn = useMemo(
       () => ({
         width: 150,
@@ -124,12 +126,24 @@ export let DataSpreadsheet = React.forwardRef(
     }, [spreadsheetRef]);
 
     // Removes the cell selection elements
-    const removeCellSelections = useCallback(() => {
-      const cellSelections = spreadsheetRef.current.querySelectorAll(
-        `.${blockClass}__selection-area--element`
-      );
-      Array.from(cellSelections).forEach((element) => element.remove());
-    }, [spreadsheetRef]);
+    const removeCellSelections = useCallback(
+      (matcher) => {
+        if (matcher && typeof matcher === 'string') {
+          const selectionToRemove = spreadsheetRef.current.querySelector(
+            `[data-matcher-id="${matcher}"]`
+          );
+          if (selectionToRemove) {
+            selectionToRemove.remove();
+          }
+        } else {
+          const cellSelections = spreadsheetRef.current.querySelectorAll(
+            `.${blockClass}__selection-area--element`
+          );
+          [...cellSelections].forEach((element) => element.remove());
+        }
+      },
+      [spreadsheetRef]
+    );
 
     // Click outside useEffect
     useEffect(() => {
@@ -143,11 +157,11 @@ export let DataSpreadsheet = React.forwardRef(
         ) {
           return;
         }
+        setActiveCellCoordinates(null);
         setSelectionAreas([]);
         removeActiveCell();
         removeCellSelections();
         setContainerHasFocus(false);
-        setActiveCellCoordinates(null);
       };
       document.addEventListener('click', handleOutsideClick);
       return () => {
@@ -164,6 +178,12 @@ export let DataSpreadsheet = React.forwardRef(
         const activeCellValue = activeCellFullData
           ? Object.values(activeCellFullData.row.values)[coords?.column]
           : null;
+        const handleActiveCellMouseEnter = () => {
+          handleActiveCellMouseEnterCallback(
+            selectionAreas,
+            clickAndHoldActive
+          );
+        };
         createActiveCellFn({
           placementElement,
           coords,
@@ -172,9 +192,17 @@ export let DataSpreadsheet = React.forwardRef(
           blockClass,
           onActiveCellChange,
           activeCellValue,
+          handleActiveCellMouseEnter,
         });
       },
-      [spreadsheetRef, rows, onActiveCellChange]
+      [
+        spreadsheetRef,
+        rows,
+        onActiveCellChange,
+        clickAndHoldActive,
+        handleActiveCellMouseEnterCallback,
+        selectionAreas,
+      ]
     );
 
     const handleInitialArrowPress = useCallback(() => {
@@ -329,6 +357,42 @@ export let DataSpreadsheet = React.forwardRef(
       ]
     );
 
+    // Only update if there are cell selection areas
+    // Find point object that matches currentMatcher and remove the second point
+    // because hovering over the active cell while clicking and holding should
+    // remove the previously existing selection area
+    const handleActiveCellMouseEnterCallback = useCallback(
+      (areas, clickHold) => {
+        const freshMatcherValue = currentMatcherRef.current;
+        if (!freshMatcherValue) {
+          return;
+        }
+        if (areas && areas.length && clickHold && freshMatcherValue) {
+          setSelectionAreas((prev) => {
+            const selectionAreaClone = deepCloneObject(prev);
+            const indexOfItemToUpdate = selectionAreaClone.findIndex(
+              (item) => item.matcher === freshMatcherValue
+            );
+            if (indexOfItemToUpdate === -1) {
+              return prev;
+            }
+            if (
+              typeof selectionAreaClone[indexOfItemToUpdate].point2 ===
+                'object' &&
+              selectionAreaClone[indexOfItemToUpdate].areaCreated
+            ) {
+              selectionAreaClone[indexOfItemToUpdate].point2 = null;
+              selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
+              removeCellSelections(freshMatcherValue);
+              return selectionAreaClone;
+            }
+            return prev;
+          });
+        }
+      },
+      [removeCellSelections]
+    );
+
     // Adds active cell highlight to correct cell onKeyDown
     useEffect(() => {
       const activeCellPlacementElement = spreadsheetRef?.current.querySelector(
@@ -340,12 +404,19 @@ export let DataSpreadsheet = React.forwardRef(
         `[data-row-index="header"][data-column-index="header"]`
       );
       if (containerHasFocus) {
+        const handleActiveCellMouseEnter = () => {
+          handleActiveCellMouseEnterCallback(
+            selectionAreas,
+            clickAndHoldActive
+          );
+        };
         createActiveCell({
           placementElement: activeCellCoordinates
             ? activeCellPlacementElement
             : selectAllElement,
           coords: activeCellCoordinates,
           addToHeader: shouldPlaceActiveCellInHeader,
+          handleActiveCellMouseEnter,
         });
       }
     }, [
@@ -353,6 +424,9 @@ export let DataSpreadsheet = React.forwardRef(
       spreadsheetRef,
       createActiveCell,
       containerHasFocus,
+      selectionAreas,
+      handleActiveCellMouseEnterCallback,
+      clickAndHoldActive,
     ]);
 
     const localRef = useRef();
@@ -382,6 +456,7 @@ export let DataSpreadsheet = React.forwardRef(
 
         {/* BODY */}
         <DataSpreadsheetBody
+          ref={currentMatcherRef}
           clickAndHoldActive={clickAndHoldActive}
           setClickAndHoldActive={setClickAndHoldActive}
           currentMatcher={currentMatcher}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { FixedSizeList } from 'react-window';
 import cx from 'classnames';
@@ -16,276 +16,286 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 import { createCellSelectionArea } from './createCellSelectionArea';
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
-export const DataSpreadsheetBody = ({
-  defaultColumn,
-  getTableBodyProps,
-  id,
-  prepareRow,
-  rows,
-  setActiveCellCoordinates,
-  selectionAreas,
-  setContainerHasFocus,
-  setSelectionAreas,
-  scrollBarSize,
-  totalColumnsWidth,
-  clickAndHoldActive,
-  setClickAndHoldActive,
-  currentMatcher,
-  setCurrentMatcher,
-}) => {
-  // Create cell selection areas based on selectionAreas array
-  useEffect(() => {
-    if (selectionAreas && selectionAreas.length) {
-      selectionAreas.map((area) => {
-        if (!area.areaCreated && area.point1 && area.point2 && area.matcher) {
-          // Do not create a cell selection area if point1 and point2 have the same values
-          // Cell selections must have two distinctly different points for an area to be created
-          if (
-            area.point1.row === area.point2.row &&
-            area.point1.column === area.point2.column
-          ) {
-            const selectionAreasClone = deepCloneObject(selectionAreas);
-            const indexOfCurrentArea = selectionAreasClone.findIndex(
-              (item) => item.matcher === area.matcher
-            );
-            selectionAreasClone[indexOfCurrentArea].areaCreated = false;
-            selectionAreasClone[indexOfCurrentArea].point2 = null;
-            return setSelectionAreas(selectionAreasClone);
+export const DataSpreadsheetBody = forwardRef(
+  (
+    {
+      defaultColumn,
+      getTableBodyProps,
+      id,
+      prepareRow,
+      rows,
+      setActiveCellCoordinates,
+      selectionAreas,
+      setContainerHasFocus,
+      setSelectionAreas,
+      scrollBarSize,
+      totalColumnsWidth,
+      clickAndHoldActive,
+      setClickAndHoldActive,
+      currentMatcher,
+      setCurrentMatcher,
+    },
+    ref
+  ) => {
+    // Create cell selection areas based on selectionAreas array
+    useEffect(() => {
+      if (selectionAreas && selectionAreas.length) {
+        selectionAreas.map((area) => {
+          if (!area.areaCreated && area.point1 && area.point2 && area.matcher) {
+            // Do not create a cell selection area if point1 and point2 have the same values
+            // Cell selections must have two distinctly different points for an area to be created
+            if (
+              area.point1.row === area.point2.row &&
+              area.point1.column === area.point2.column
+            ) {
+              const selectionAreasClone = deepCloneObject(selectionAreas);
+              const indexOfCurrentArea = selectionAreasClone.findIndex(
+                (item) => item.matcher === area.matcher
+              );
+              selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+              selectionAreasClone[indexOfCurrentArea].point2 = null;
+              return setSelectionAreas(selectionAreasClone);
+            }
+            createCellSelectionArea({
+              area,
+              blockClass,
+              selectionAreas,
+              setSelectionAreas,
+            });
           }
-          createCellSelectionArea({
-            area,
-            blockClass,
-            selectionAreas,
-            setSelectionAreas,
-          });
-        }
-        return;
-      });
-    }
-  }, [selectionAreas, setSelectionAreas]);
+          return;
+        });
+      }
+    }, [selectionAreas, setSelectionAreas]);
 
-  // Mouse up
-  useEffect(() => {
-    const handleMouseUp = (event) => {
-      setClickAndHoldActive(false);
-      const cellButton = event.target.closest(`.${blockClass}__body--td`);
-      if (cellButton) {
-        const endCellCoordinates = {
-          row: Number(cellButton.getAttribute('data-row-index')),
-          column: Number(cellButton.getAttribute('data-column-index')),
-        };
-        setCurrentMatcher(null);
-        setSelectionAreas((prev) => {
-          const selectionAreaClone = deepCloneObject(prev);
+    // Mouse up
+    useEffect(() => {
+      const handleMouseUp = (event) => {
+        setClickAndHoldActive(false);
+        const cellButton = event.target.closest(`.${blockClass}__body--td`);
+        if (cellButton) {
+          const endCellCoordinates = {
+            row: Number(cellButton.getAttribute('data-row-index')),
+            column: Number(cellButton.getAttribute('data-column-index')),
+          };
+          ref.current = null;
+          setCurrentMatcher(null);
+          setSelectionAreas((prev) => {
+            const selectionAreaClone = deepCloneObject(prev);
+            const indexOfItemToUpdate = selectionAreaClone.findIndex(
+              (item) => item.matcher === currentMatcher
+            );
+            // No items in the array have an object that matches the value of currentMatcher
+            if (indexOfItemToUpdate === -1) {
+              return prev;
+            }
+            selectionAreaClone[indexOfItemToUpdate].point2 = endCellCoordinates;
+            selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
+            return selectionAreaClone;
+          });
+        } else {
+          const selectionAreaClone = deepCloneObject(selectionAreas);
           const indexOfItemToUpdate = selectionAreaClone.findIndex(
             (item) => item.matcher === currentMatcher
           );
-          // No items in the array have an object that matches the value of currentMatcher
           if (indexOfItemToUpdate === -1) {
-            return prev;
+            return;
           }
-          selectionAreaClone[indexOfItemToUpdate].point2 = endCellCoordinates;
-          selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
-          return selectionAreaClone;
-        });
-      } else {
-        const selectionAreaClone = deepCloneObject(selectionAreas);
-        const indexOfItemToUpdate = selectionAreaClone.findIndex(
-          (item) => item.matcher === currentMatcher
-        );
-        if (indexOfItemToUpdate === -1) {
-          return;
+          const newArray = selectionAreaClone.filter(
+            (item) => item.matcher !== currentMatcher
+          );
+          ref.current = null;
+          setCurrentMatcher(null);
+          setSelectionAreas(newArray);
         }
-        const newArray = selectionAreaClone.filter(
-          (item) => item.matcher !== currentMatcher
-        );
-        setCurrentMatcher(null);
-        setSelectionAreas(newArray);
-      }
-    };
-    document.addEventListener('mouseup', handleMouseUp);
-    return () => {
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, [
-    selectionAreas,
-    currentMatcher,
-    setSelectionAreas,
-    setClickAndHoldActive,
-    setCurrentMatcher,
-  ]);
-
-  // Make sure that if the cellSize prop changes, the active
-  // cell also gets updated with the new size
-  useEffect(() => {
-    const listContainer = spreadsheetBodyRef?.current;
-    const activeCellButton = listContainer.querySelector(
-      `.${blockClass}__active-cell--highlight`
-    );
-    if (activeCellButton) {
-      activeCellButton.style.height = `${defaultColumn?.rowHeight}px`;
-    }
-  }, [defaultColumn?.rowHeight]);
-
-  // onClick fn for each cell in the data spreadsheet body,
-  // adds the active cell highlight
-  const handleBodyCellClick = useCallback(
-    (event, cell, columnIndex) => {
-      const isHoldingCommandKey = event.metaKey || event.ctrlKey;
-      setContainerHasFocus(true);
-      const activeCoordinates = {
-        row: cell.row.index,
-        column: columnIndex,
       };
-      const tempMatcher = uuidv4();
-
-      setActiveCellCoordinates(activeCoordinates);
-      // prevent multiple selections unless cmd key is held
-      // meaning that selectionAreas should only have one item by default
-      if (isHoldingCommandKey) {
-        setSelectionAreas((prev) => [
-          ...prev,
-          { point1: activeCoordinates, matcher: tempMatcher },
-        ]);
-      } else {
-        // remove all previous cell selections
-        const cellSelections = spreadsheetBodyRef.current.querySelectorAll(
-          `.${blockClass}__selection-area--element`
-        );
-        Array.from(cellSelections).forEach((element) => element.remove());
-        setSelectionAreas([
-          { point1: activeCoordinates, matcher: tempMatcher },
-        ]);
-      }
-      setCurrentMatcher(tempMatcher);
-      setClickAndHoldActive(true);
-    },
-    [
-      setActiveCellCoordinates,
+      document.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+    }, [
+      selectionAreas,
+      currentMatcher,
       setSelectionAreas,
-      setContainerHasFocus,
       setClickAndHoldActive,
       setCurrentMatcher,
-    ]
-  );
+      ref,
+    ]);
 
-  const handleBodyCellHover = useCallback(
-    (event, cell, columnIndex) => {
-      if (clickAndHoldActive) {
-        const cellCoordinates = {
+    // Make sure that if the cellSize prop changes, the active
+    // cell also gets updated with the new size
+    useEffect(() => {
+      const listContainer = spreadsheetBodyRef?.current;
+      const activeCellButton = listContainer.querySelector(
+        `.${blockClass}__active-cell--highlight`
+      );
+      if (activeCellButton) {
+        activeCellButton.style.height = `${defaultColumn?.rowHeight}px`;
+      }
+    }, [defaultColumn?.rowHeight]);
+
+    // onClick fn for each cell in the data spreadsheet body,
+    // adds the active cell highlight
+    const handleBodyCellClick = useCallback(
+      (event, cell, columnIndex) => {
+        const isHoldingCommandKey = event.metaKey || event.ctrlKey;
+        setContainerHasFocus(true);
+        const activeCoordinates = {
           row: cell.row.index,
           column: columnIndex,
         };
-        setSelectionAreas((prev) => {
-          const selectionAreaClone = deepCloneObject(prev);
-          const indexOfItemToUpdate = selectionAreaClone.findIndex(
-            (item) => item.matcher === currentMatcher
-          );
-          // No items in the array match up with the currentMatcher value
-          if (indexOfItemToUpdate === -1) {
-            return prev;
-          }
-          // Do not update state if you're still hovering on the same cell
-          if (
-            selectionAreaClone[indexOfItemToUpdate].point2?.row ===
-              cellCoordinates.row &&
-            selectionAreaClone[indexOfItemToUpdate].point2?.column ===
-              cellCoordinates.column
-          ) {
-            return prev;
-          }
-          selectionAreaClone[indexOfItemToUpdate].point2 = cellCoordinates;
-          selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
-          return selectionAreaClone;
-        });
-      }
-    },
-    [clickAndHoldActive, currentMatcher, setSelectionAreas]
-  );
+        const tempMatcher = uuidv4();
 
-  // Renders each cell in the spreadsheet body
-  const RenderRow = useCallback(
-    ({ index, style }) => {
-      const row = rows[index];
-      prepareRow(row);
-      return (
-        <div
-          {...row.getRowProps({ style })}
-          className={cx(`${blockClass}__tr`)}
-          data-row-index={index}
-        >
-          {/* ROW HEADER BUTTON */}
-          <button
-            tabIndex={-1}
+        setActiveCellCoordinates(activeCoordinates);
+        // prevent multiple selections unless cmd key is held
+        // meaning that selectionAreas should only have one item by default
+        if (isHoldingCommandKey) {
+          setSelectionAreas((prev) => [
+            ...prev,
+            { point1: activeCoordinates, matcher: tempMatcher },
+          ]);
+        } else {
+          // remove all previous cell selections
+          const cellSelections = spreadsheetBodyRef.current.querySelectorAll(
+            `.${blockClass}__selection-area--element`
+          );
+          Array.from(cellSelections).forEach((element) => element.remove());
+          setSelectionAreas([
+            { point1: activeCoordinates, matcher: tempMatcher },
+          ]);
+        }
+        ref.current = tempMatcher;
+        setCurrentMatcher(tempMatcher);
+        setClickAndHoldActive(true);
+      },
+      [
+        setActiveCellCoordinates,
+        setSelectionAreas,
+        setContainerHasFocus,
+        setClickAndHoldActive,
+        setCurrentMatcher,
+        ref,
+      ]
+    );
+
+    const handleBodyCellHover = useCallback(
+      (event, cell, columnIndex) => {
+        if (clickAndHoldActive) {
+          const cellCoordinates = {
+            row: cell.row.index,
+            column: columnIndex,
+          };
+          setSelectionAreas((prev) => {
+            const selectionAreaClone = deepCloneObject(prev);
+            const indexOfItemToUpdate = selectionAreaClone.findIndex(
+              (item) => item.matcher === currentMatcher
+            );
+            // No items in the array match up with the currentMatcher value
+            if (indexOfItemToUpdate === -1) {
+              return prev;
+            }
+            // Do not update state if you're still hovering on the same cell
+            if (
+              selectionAreaClone[indexOfItemToUpdate].point2?.row ===
+                cellCoordinates.row &&
+              selectionAreaClone[indexOfItemToUpdate].point2?.column ===
+                cellCoordinates.column
+            ) {
+              return prev;
+            }
+            selectionAreaClone[indexOfItemToUpdate].point2 = cellCoordinates;
+            selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
+            return selectionAreaClone;
+          });
+        }
+      },
+      [clickAndHoldActive, currentMatcher, setSelectionAreas]
+    );
+
+    // Renders each cell in the spreadsheet body
+    const RenderRow = useCallback(
+      ({ index, style }) => {
+        const row = rows[index];
+        prepareRow(row);
+        return (
+          <div
+            {...row.getRowProps({ style })}
+            className={cx(`${blockClass}__tr`)}
             data-row-index={index}
-            data-column-index="header"
-            type="button"
-            className={cx(
-              `${blockClass}__td`,
-              `${blockClass}__td-th`,
-              `${blockClass}--interactive-cell-element`
-            )}
-            style={{
-              width: defaultColumn?.rowHeaderWidth,
-            }}
           >
-            {index + 1}
-          </button>
-          {/* CELL BUTTONS */}
-          {row.cells.map((cell, index) => (
+            {/* ROW HEADER BUTTON */}
             <button
               tabIndex={-1}
-              data-row-index={cell.row.index}
-              data-column-index={index}
-              {...cell.getCellProps()}
+              data-row-index={index}
+              data-column-index="header"
+              type="button"
               className={cx(
                 `${blockClass}__td`,
-                `${blockClass}__body--td`,
+                `${blockClass}__td-th`,
                 `${blockClass}--interactive-cell-element`
               )}
-              key={`cell_${index}`}
-              onMouseDown={(event) => handleBodyCellClick(event, cell, index)}
-              onMouseOver={(event) => handleBodyCellHover(event, cell, index)}
-              onFocus={() => {}}
-              type="button"
+              style={{
+                width: defaultColumn?.rowHeaderWidth,
+              }}
             >
-              {cell.render('Cell')}
+              {index + 1}
             </button>
-          ))}
-        </div>
-      );
-    },
-    [
-      prepareRow,
-      rows,
-      defaultColumn.rowHeaderWidth,
-      handleBodyCellClick,
-      handleBodyCellHover,
-    ]
-  );
+            {/* CELL BUTTONS */}
+            {row.cells.map((cell, index) => (
+              <button
+                tabIndex={-1}
+                data-row-index={cell.row.index}
+                data-column-index={index}
+                {...cell.getCellProps()}
+                className={cx(
+                  `${blockClass}__td`,
+                  `${blockClass}__body--td`,
+                  `${blockClass}--interactive-cell-element`
+                )}
+                key={`cell_${index}`}
+                onMouseDown={(event) => handleBodyCellClick(event, cell, index)}
+                onMouseOver={(event) => handleBodyCellHover(event, cell, index)}
+                onFocus={() => {}}
+                type="button"
+              >
+                {cell.render('Cell')}
+              </button>
+            ))}
+          </div>
+        );
+      },
+      [
+        prepareRow,
+        rows,
+        defaultColumn.rowHeaderWidth,
+        handleBodyCellClick,
+        handleBodyCellHover,
+      ]
+    );
 
-  const spreadsheetBodyRef = useRef();
-  return (
-    <div
-      ref={spreadsheetBodyRef}
-      className={cx(`${blockClass}__body--container`)}
-      {...getTableBodyProps()}
-    >
-      <FixedSizeList
-        className={cx(
-          `${blockClass}__list--container`,
-          `${blockClass}__list--container--${id}`
-        )}
-        height={400}
-        itemCount={rows.length}
-        itemSize={defaultColumn?.rowHeight}
-        width={totalColumnsWidth + scrollBarSize}
+    const spreadsheetBodyRef = useRef();
+    return (
+      <div
+        ref={spreadsheetBodyRef}
+        className={cx(`${blockClass}__body--container`)}
+        {...getTableBodyProps()}
       >
-        {RenderRow}
-      </FixedSizeList>
-    </div>
-  );
-};
+        <FixedSizeList
+          className={cx(
+            `${blockClass}__list--container`,
+            `${blockClass}__list--container--${id}`
+          )}
+          height={400}
+          itemCount={rows.length}
+          itemSize={defaultColumn?.rowHeight}
+          width={totalColumnsWidth + scrollBarSize}
+        >
+          {RenderRow}
+        </FixedSizeList>
+      </div>
+    );
+  }
+);
 
 DataSpreadsheetBody.propTypes = {
   /**

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -87,7 +87,7 @@
     }
     .#{$block-class}__active-cell--highlight {
       position: absolute;
-      z-index: 2;
+      z-index: 3;
       border: $spacing-01 solid $interactive-01;
       background-color: transparent;
       &:focus {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/createActiveCellFn.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/createActiveCellFn.js
@@ -16,6 +16,7 @@ export const createActiveCellFn = ({
   blockClass = `${pkg.prefix}--data-spreadsheet`,
   onActiveCellChange,
   activeCellValue,
+  handleActiveCellMouseEnter,
 }) => {
   if (!coords) {
     return;
@@ -42,6 +43,7 @@ export const createActiveCellFn = ({
     `${blockClass}__active-cell--highlight`,
     `${blockClass}--interactive-cell-element`
   );
+  activeCellButton.addEventListener('mouseenter', handleActiveCellMouseEnter);
   activeCellButton.style.width = px(placementElement?.offsetWidth);
   activeCellButton.style.height = px(placementElement?.offsetHeight);
   activeCellButton.style.left = px(relativePosition.left);


### PR DESCRIPTION
Contributes to #1701 

This PR addresses #1701, where if a cell selection is created then the second point of the selection is moved back to the active cell, the cell selection should be removed.

See attached screen recording for updated behavior:

https://user-images.githubusercontent.com/10215203/156089049-21a93c18-3897-43d6-8dcb-8362bcf3af99.mov

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
packages/cloud-cognitive/src/components/DataSpreadsheet/createActiveCellFn.js
```
#### How did you test and verify your work?
