### PR TITLE
fix(DataSpreadsheet): prevent check on coords that do not exist

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -189,8 +189,8 @@ export let DataSpreadsheet = React.forwardRef(
         const prevCoords = previousState?.activeCellCoordinates;
         // Only create an active cell if the activeCellCoordinates have changed
         if (
-          prevCoords?.row !== coords.row ||
-          prevCoords?.column !== coords.column
+          prevCoords?.row !== coords?.row ||
+          prevCoords?.column !== coords?.column
         ) {
           createActiveCellFn({
             placementElement,


### PR DESCRIPTION
Fixed outside click functionality, `coords.row` need a check to make sure it exists before look at it's value.

#### What did you change?
`DataSpreadsheet.js`
#### How did you test and verify your work?
Storybook