### PR TITLE
fix(options-tile): fix summary behaviour

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -201,6 +201,10 @@ export let OptionsTile = React.forwardRef(
       } else if (locked) {
         Icon = Locked16;
         summaryClasses.push(`${blockClass}__summary--locked`);
+
+        if (!text) {
+          text = lockedText;
+        }
       }
 
       const summaryHidden = enabled === false;

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -207,7 +207,12 @@ export let OptionsTile = React.forwardRef(
         }
       }
 
-      const summaryHidden = enabled === false;
+      const hasValidationState = invalid || warn || locked;
+      const summaryHidden = !hasValidationState && enabled === false;
+
+      if (summaryHidden) {
+        summaryClasses.push(`${blockClass}__summary--hidden`);
+      }
 
       return (
         <div className={`${blockClass}__title`}>

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -134,6 +134,16 @@ describe(componentName, () => {
     expect(summary).toHaveClass(`${blockClass}__summary--locked`);
   });
 
+  it('renders lockedText when locked and no summary is set', () => {
+    const lockedText = 'locked explanation';
+
+    render(<OptionsTile {...props} locked lockedText={lockedText} />);
+
+    const summary = screen.getByRole('heading').nextSibling;
+
+    expect(summary.textContent).toBe(lockedText);
+  });
+
   it('renders open state when passed', () => {
     const { container } = render(<OptionsTile {...props} open={true} />);
 


### PR DESCRIPTION
Contributes to #1722, #1725

#### What did you change?
- `props.lockedText` is shown as fallback if no summary is set but tile is locked
- summary is hidden when not in validation state and disabled (as per design)

#### How did you test and verify your work?

Automated testing, Storybook
