### PR TITLE
chore(DataSpreadsheet): add curried functions for event handlers

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -29,6 +29,7 @@ import { useActiveElement } from '../../global/js/hooks';
 import { createActiveCellFn } from './createActiveCellFn';
 import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
 import { usePreviousValue } from '../../global/js/hooks';
+import uuidv4 from '../../global/js/utils/uuidv4';
 // cspell:words rowcount colcount
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -70,6 +71,7 @@ export let DataSpreadsheet = React.forwardRef(
     const previousState = usePreviousValue({ activeCellCoordinates });
     const cellSizeValue = getCellSize(cellSize);
     const currentMatcherRef = useRef();
+    const activeKeys = useRef([]);
     const defaultColumn = useMemo(
       () => ({
         width: 150,
@@ -106,6 +108,7 @@ export let DataSpreadsheet = React.forwardRef(
       ) {
         setContainerHasFocus(false);
         removeActiveCell();
+        activeKeys.current = [];
       }
       if (
         focusedElement.classList.contains(blockClass) ||
@@ -164,6 +167,7 @@ export let DataSpreadsheet = React.forwardRef(
         removeActiveCell();
         removeCellSelections();
         setContainerHasFocus(false);
+        activeKeys.current = [];
       };
       document.addEventListener('click', handleOutsideClick);
       return () => {
@@ -227,12 +231,90 @@ export let DataSpreadsheet = React.forwardRef(
       return;
     }, [activeCellCoordinates]);
 
-    const updateActiveCellCoordinates = ({ coords, updatedValue }) => {
-      setActiveCellCoordinates({
-        ...coords,
-        ...updatedValue,
-      });
-    };
+    const updateActiveCellCoordinates = useCallback(
+      ({ coords, updatedValue }) => {
+        const newActiveCell = {
+          ...coords,
+          ...updatedValue,
+        };
+        setActiveCellCoordinates(newActiveCell);
+        // Only run if the active cell is _not_ a header cell. This will add a point1 object
+        // to selectionAreas every time the active cell changes, allowing us to create cell
+        // selections using keyboard
+        if (
+          newActiveCell.row !== 'header' &&
+          newActiveCell.column !== 'header'
+        ) {
+          const tempMatcher = uuidv4();
+          setSelectionAreas([{ point1: newActiveCell, matcher: tempMatcher }]);
+          setCurrentMatcher(tempMatcher);
+        }
+      },
+      []
+    );
+
+    const handleMultipleKeys = useCallback(() => {
+      const activeKeyValues = activeKeys.current;
+      const selectionAreasClone = deepCloneObject(selectionAreas);
+      const indexOfCurrentArea = selectionAreasClone.findIndex(
+        (item) => item.matcher === currentMatcher
+      );
+      const pointToUpdate = selectionAreasClone[indexOfCurrentArea]?.point2
+        ? selectionAreasClone[indexOfCurrentArea].point2
+        : selectionAreasClone[indexOfCurrentArea].point1;
+      // Down + Shift
+      if (activeKeyValues.includes(16) && activeKeyValues.includes(40)) {
+        if (rows.length - 1 === pointToUpdate.row) {
+          return;
+        }
+        const newPoint = {
+          row: pointToUpdate.row + 1,
+          column: pointToUpdate.column,
+        };
+        selectionAreasClone[indexOfCurrentArea].point2 = newPoint;
+        selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+        setSelectionAreas(selectionAreasClone);
+      }
+      // Right + Shift
+      if (activeKeyValues.includes(16) && activeKeyValues.includes(39)) {
+        if (columns.length - 1 === pointToUpdate.column) {
+          return;
+        }
+        const newPoint = {
+          row: pointToUpdate.row,
+          column: pointToUpdate.column + 1,
+        };
+        selectionAreasClone[indexOfCurrentArea].point2 = newPoint;
+        selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+        setSelectionAreas(selectionAreasClone);
+      }
+      // Up + Shift
+      if (activeKeyValues.includes(16) && activeKeyValues.includes(38)) {
+        if (pointToUpdate.row === 0) {
+          return;
+        }
+        const newPoint = {
+          row: pointToUpdate.row - 1,
+          column: pointToUpdate.column,
+        };
+        selectionAreasClone[indexOfCurrentArea].point2 = newPoint;
+        selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+        setSelectionAreas(selectionAreasClone);
+      }
+      // Left + Shift
+      if (activeKeyValues.includes(16) && activeKeyValues.includes(37)) {
+        if (pointToUpdate.column === 0) {
+          return;
+        }
+        const newPoint = {
+          row: pointToUpdate.row,
+          column: pointToUpdate.column - 1,
+        };
+        selectionAreasClone[indexOfCurrentArea].point2 = newPoint;
+        selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+        setSelectionAreas(selectionAreasClone);
+      }
+    }, [selectionAreas, currentMatcher, columns, rows]);
 
     const handleKeyPress = useCallback(
       (event) => {
@@ -245,119 +327,141 @@ export let DataSpreadsheet = React.forwardRef(
         if ([35, 36, 37, 38, 39, 40].indexOf(keyCode) > -1) {
           event.preventDefault();
         }
-        // Clear out all cell selection areas if user uses any arrow key
+        // Clear out all cell selection areas if user uses any arrow key, except if the shift key is being held
         if ([37, 38, 39, 40].indexOf(keyCode) > -1) {
-          if (selectionAreas?.length) {
+          if (
+            selectionAreas?.length &&
+            keyCode !== 16 &&
+            !activeKeys.current.includes(16)
+          ) {
             setSelectionAreas([]);
             removeCellSelections();
           }
         }
-        switch (keyCode) {
-          // Tab
-          case 9: {
-            setSelectionAreas([]);
-            removeActiveCell();
-            setContainerHasFocus(false);
-            setActiveCellCoordinates(null);
-            break;
-          }
-          // Left
-          case 37: {
-            handleInitialArrowPress();
-            const coordinatesClone = { ...activeCellCoordinates };
-            if (coordinatesClone.column === 'header') {
-              return;
+        // Update list of activeKeys
+        if (!activeKeys.current?.includes(keyCode)) {
+          const activeClone = [...activeKeys.current];
+          activeKeys.current = [...activeClone, keyCode];
+        }
+        if (activeKeys.current?.length > 1) {
+          handleMultipleKeys();
+        }
+        // Allow arrow key navigation if there are less than two activeKeys OR
+        // if one of the activeCellCoordinates is in a header position
+        if (
+          !activeKeys.current.includes(16) ||
+          activeCellCoordinates.row === 'header' ||
+          activeCellCoordinates.column === 'header'
+        ) {
+          switch (keyCode) {
+            // Tab
+            case 9: {
+              setSelectionAreas([]);
+              removeActiveCell();
+              setContainerHasFocus(false);
+              setActiveCellCoordinates(null);
+              break;
             }
-            if (typeof coordinatesClone.column === 'number') {
-              if (coordinatesClone.column === 0) {
+            // Left
+            case 37: {
+              handleInitialArrowPress();
+              const coordinatesClone = { ...activeCellCoordinates };
+              if (coordinatesClone.column === 'header') {
+                return;
+              }
+              if (typeof coordinatesClone.column === 'number') {
+                if (coordinatesClone.column === 0) {
+                  updateActiveCellCoordinates({
+                    coords: coordinatesClone,
+                    updatedValue: { column: 'header' },
+                  });
+                  return;
+                }
                 updateActiveCellCoordinates({
                   coords: coordinatesClone,
-                  updatedValue: { column: 'header' },
+                  updatedValue: { column: coordinatesClone.column - 1 },
                 });
+              }
+              break;
+            }
+            // Up
+            case 38: {
+              handleInitialArrowPress();
+              const coordinatesClone = { ...activeCellCoordinates };
+              if (coordinatesClone.row === 'header') {
                 return;
               }
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { column: coordinatesClone.column - 1 },
-              });
-            }
-            break;
-          }
-          // Up
-          case 38: {
-            handleInitialArrowPress();
-            const coordinatesClone = { ...activeCellCoordinates };
-            if (coordinatesClone.row === 'header') {
-              return;
-            }
-            if (typeof coordinatesClone.row === 'number') {
-              // set row back to header if we are at index 0
-              if (coordinatesClone.row === 0) {
+              if (typeof coordinatesClone.row === 'number') {
+                // set row back to header if we are at index 0
+                if (coordinatesClone.row === 0) {
+                  updateActiveCellCoordinates({
+                    coords: coordinatesClone,
+                    updatedValue: { row: 'header' },
+                  });
+                  return;
+                }
+                // if we are at any other index than 0, subtract 1 from current row index
                 updateActiveCellCoordinates({
                   coords: coordinatesClone,
-                  updatedValue: { row: 'header' },
+                  updatedValue: { row: coordinatesClone.row - 1 },
                 });
-                return;
               }
-              // if we are at any other index than 0, subtract 1 from current row index
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { row: coordinatesClone.row - 1 },
-              });
+              break;
             }
-            break;
-          }
-          // Right
-          case 39: {
-            handleInitialArrowPress();
-            const coordinatesClone = { ...activeCellCoordinates };
-            if (coordinatesClone.column === 'header') {
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { column: 0 },
-              });
-            }
-            if (typeof coordinatesClone.column === 'number') {
-              // Prevent active cell coordinates from updating if the active
-              // cell is in the last column, ie we can't go any further to the right
-              if (columns.length - 1 === coordinatesClone.column) {
-                return;
+            // Right
+            case 39: {
+              handleInitialArrowPress();
+              const coordinatesClone = { ...activeCellCoordinates };
+              if (coordinatesClone.column === 'header') {
+                updateActiveCellCoordinates({
+                  coords: coordinatesClone,
+                  updatedValue: { column: 0 },
+                });
               }
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { column: coordinatesClone.column + 1 },
-              });
-            }
-            break;
-          }
-          // Down
-          case 40: {
-            handleInitialArrowPress();
-            const coordinatesClone = { ...activeCellCoordinates };
-            if (coordinatesClone.row === 'header') {
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { row: 0 },
-              });
-            }
-            if (typeof coordinatesClone.row === 'number') {
-              // Prevent active cell coordinates from updating if the active
-              // cell is in the last row, ie we can't go any further down since
-              // we are in the last row
-              if (rows.length - 1 === coordinatesClone.row) {
-                return;
+              if (typeof coordinatesClone.column === 'number') {
+                // Prevent active cell coordinates from updating if the active
+                // cell is in the last column, ie we can't go any further to the right
+                if (columns.length - 1 === coordinatesClone.column) {
+                  return;
+                }
+                updateActiveCellCoordinates({
+                  coords: coordinatesClone,
+                  updatedValue: { column: coordinatesClone.column + 1 },
+                });
               }
-              updateActiveCellCoordinates({
-                coords: coordinatesClone,
-                updatedValue: { row: coordinatesClone.row + 1 },
-              });
+              break;
             }
-            break;
+            // Down
+            case 40: {
+              handleInitialArrowPress();
+              const coordinatesClone = { ...activeCellCoordinates };
+              if (coordinatesClone.row === 'header') {
+                updateActiveCellCoordinates({
+                  coords: coordinatesClone,
+                  updatedValue: { row: 0 },
+                });
+              }
+              if (typeof coordinatesClone.row === 'number') {
+                // Prevent active cell coordinates from updating if the active
+                // cell is in the last row, ie we can't go any further down since
+                // we are in the last row
+                if (rows.length - 1 === coordinatesClone.row) {
+                  return;
+                }
+                updateActiveCellCoordinates({
+                  coords: coordinatesClone,
+                  updatedValue: { row: coordinatesClone.row + 1 },
+                });
+              }
+              break;
+            }
           }
         }
       },
       [
+        updateActiveCellCoordinates,
         handleInitialArrowPress,
+        handleMultipleKeys,
         activeCellCoordinates,
         selectionAreas?.length,
         removeCellSelections,
@@ -429,6 +533,18 @@ export let DataSpreadsheet = React.forwardRef(
       containerHasFocus,
     ]);
 
+    const handleKeyUp = (event) => {
+      const { keyCode } = event;
+      // Remove key from active keys array on key up
+      if (activeKeys.current?.includes(keyCode)) {
+        const activeKeysClone = [...activeKeys.current];
+        const filteredKeysClone = activeKeysClone.filter(
+          (item) => item !== keyCode
+        );
+        activeKeys.current = filteredKeysClone;
+      }
+    };
+
     const localRef = useRef();
     const spreadsheetRef = ref || localRef;
     return (
@@ -445,6 +561,7 @@ export let DataSpreadsheet = React.forwardRef(
         aria-rowcount={rows?.length || 0}
         aria-colcount={columns?.length || 0}
         onKeyDown={handleKeyPress}
+        onKeyUp={handleKeyUp}
         onFocus={() => setContainerHasFocus(true)}
       >
         {/* HEADER */}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -137,36 +137,38 @@ export const DataSpreadsheetBody = forwardRef(
     // onClick fn for each cell in the data spreadsheet body,
     // adds the active cell highlight
     const handleBodyCellClick = useCallback(
-      (event, cell, columnIndex) => {
-        const isHoldingCommandKey = event.metaKey || event.ctrlKey;
-        setContainerHasFocus(true);
-        const activeCoordinates = {
-          row: cell.row.index,
-          column: columnIndex,
-        };
-        const tempMatcher = uuidv4();
+      (cell, columnIndex) => {
+        return (event) => {
+          const isHoldingCommandKey = event.metaKey || event.ctrlKey;
+          setContainerHasFocus(true);
+          const activeCoordinates = {
+            row: cell.row.index,
+            column: columnIndex,
+          };
+          const tempMatcher = uuidv4();
 
-        setActiveCellCoordinates(activeCoordinates);
-        // prevent multiple selections unless cmd key is held
-        // meaning that selectionAreas should only have one item by default
-        if (isHoldingCommandKey) {
-          setSelectionAreas((prev) => [
-            ...prev,
-            { point1: activeCoordinates, matcher: tempMatcher },
-          ]);
-        } else {
-          // remove all previous cell selections
-          const cellSelections = spreadsheetBodyRef.current.querySelectorAll(
-            `.${blockClass}__selection-area--element`
-          );
-          Array.from(cellSelections).forEach((element) => element.remove());
-          setSelectionAreas([
-            { point1: activeCoordinates, matcher: tempMatcher },
-          ]);
-        }
-        ref.current = tempMatcher;
-        setCurrentMatcher(tempMatcher);
-        setClickAndHoldActive(true);
+          setActiveCellCoordinates(activeCoordinates);
+          // prevent multiple selections unless cmd key is held
+          // meaning that selectionAreas should only have one item by default
+          if (isHoldingCommandKey) {
+            setSelectionAreas((prev) => [
+              ...prev,
+              { point1: activeCoordinates, matcher: tempMatcher },
+            ]);
+          } else {
+            // remove all previous cell selections
+            const cellSelections = spreadsheetBodyRef.current.querySelectorAll(
+              `.${blockClass}__selection-area--element`
+            );
+            Array.from(cellSelections).forEach((element) => element.remove());
+            setSelectionAreas([
+              { point1: activeCoordinates, matcher: tempMatcher },
+            ]);
+          }
+          ref.current = tempMatcher;
+          setCurrentMatcher(tempMatcher);
+          setClickAndHoldActive(true);
+        };
       },
       [
         setActiveCellCoordinates,
@@ -179,35 +181,37 @@ export const DataSpreadsheetBody = forwardRef(
     );
 
     const handleBodyCellHover = useCallback(
-      (event, cell, columnIndex) => {
-        if (clickAndHoldActive) {
-          const cellCoordinates = {
-            row: cell.row.index,
-            column: columnIndex,
-          };
-          setSelectionAreas((prev) => {
-            const selectionAreaClone = deepCloneObject(prev);
-            const indexOfItemToUpdate = selectionAreaClone.findIndex(
-              (item) => item.matcher === currentMatcher
-            );
-            // No items in the array match up with the currentMatcher value
-            if (indexOfItemToUpdate === -1) {
-              return prev;
-            }
-            // Do not update state if you're still hovering on the same cell
-            if (
-              selectionAreaClone[indexOfItemToUpdate].point2?.row ===
-                cellCoordinates.row &&
-              selectionAreaClone[indexOfItemToUpdate].point2?.column ===
-                cellCoordinates.column
-            ) {
-              return prev;
-            }
-            selectionAreaClone[indexOfItemToUpdate].point2 = cellCoordinates;
-            selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
-            return selectionAreaClone;
-          });
-        }
+      (cell, columnIndex) => {
+        return () => {
+          if (clickAndHoldActive) {
+            const cellCoordinates = {
+              row: cell.row.index,
+              column: columnIndex,
+            };
+            setSelectionAreas((prev) => {
+              const selectionAreaClone = deepCloneObject(prev);
+              const indexOfItemToUpdate = selectionAreaClone.findIndex(
+                (item) => item.matcher === currentMatcher
+              );
+              // No items in the array match up with the currentMatcher value
+              if (indexOfItemToUpdate === -1) {
+                return prev;
+              }
+              // Do not update state if you're still hovering on the same cell
+              if (
+                selectionAreaClone[indexOfItemToUpdate].point2?.row ===
+                  cellCoordinates.row &&
+                selectionAreaClone[indexOfItemToUpdate].point2?.column ===
+                  cellCoordinates.column
+              ) {
+                return prev;
+              }
+              selectionAreaClone[indexOfItemToUpdate].point2 = cellCoordinates;
+              selectionAreaClone[indexOfItemToUpdate].areaCreated = false;
+              return selectionAreaClone;
+            });
+          }
+        };
       },
       [clickAndHoldActive, currentMatcher, setSelectionAreas]
     );
@@ -253,8 +257,8 @@ export const DataSpreadsheetBody = forwardRef(
                   `${blockClass}--interactive-cell-element`
                 )}
                 key={`cell_${index}`}
-                onMouseDown={(event) => handleBodyCellClick(event, cell, index)}
-                onMouseOver={(event) => handleBodyCellHover(event, cell, index)}
+                onMouseDown={handleBodyCellClick(cell, index)}
+                onMouseOver={handleBodyCellHover(cell, index)}
                 onFocus={() => {}}
                 type="button"
               >


### PR DESCRIPTION
Cleans up some of the event handlers based on video shared by @davidmenendez yesterday 😄 

Old
```jsx
onMouseDown={event => handler(event, arg1, arg2)}
```
New
```jsx
onMouseDown={handler(arg1, arg2)}
```
Then the handler function contents are wrapped in a function that returns the event itself, ie:
```jsx
const handler = (arg1, arg2) => {
  return event => {
    // handler logic here
  }
}
```


#### What did you change?
`DataSpreadsheetBody.js`
#### How did you test and verify your work?
Storybook