### PR TITLE
ci: add concurrency option to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi there! 👋 This PR adds a setting to the CI workflow to cancel existing jobs for a given PR when a new commit is added. This option helps to reduce the number of runners used across repos as the org is limited to only 20 runners.

#### What did you change?

I updated the `.github/workflows/ci.yml` workflow with the `concurrency` option from: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

#### How did you test and verify your work?

We are currently using this config over on the Design System monorepo to reduce the number of runners being used by actions.