### PR TITLE
feat(DataSpreadsheet): highlight row/column header on active cell change

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -566,6 +566,7 @@ export let DataSpreadsheet = React.forwardRef(
       >
         {/* HEADER */}
         <DataSpreadsheetHeader
+          activeCellCoordinates={activeCellCoordinates}
           cellSizeValue={cellSizeValue}
           defaultColumn={defaultColumn}
           headerGroups={headerGroups}
@@ -573,6 +574,7 @@ export let DataSpreadsheet = React.forwardRef(
 
         {/* BODY */}
         <DataSpreadsheetBody
+          activeCellCoordinates={activeCellCoordinates}
           ref={currentMatcherRef}
           clickAndHoldActive={clickAndHoldActive}
           setClickAndHoldActive={setClickAndHoldActive}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
@@ -102,5 +102,13 @@ describe(componentName, () => {
     );
     expect(activeCellElement).toHaveAttribute('data-active-row-index', '0'); // active row index is 0 because it's the first cell
     expect(activeCellElement).toHaveAttribute('data-active-column-index', '0'); // active column index is 0 because it's the first cell
+    const firstColumnHeader = ref?.current.querySelector(
+      `[data-row-index="header"][data-column-index="0"]`
+    );
+    const firstRowHeader = ref?.current.querySelector(
+      `[data-row-index="0"][data-column-index="header"]`
+    );
+    expect(firstColumnHeader).toHaveClass(`${blockClass}__th--active-header`);
+    expect(firstRowHeader).toHaveClass(`${blockClass}__td-th--active-header`);
   });
 });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -19,6 +19,7 @@ const blockClass = `${pkg.prefix}--data-spreadsheet`;
 export const DataSpreadsheetBody = forwardRef(
   (
     {
+      activeCellCoordinates,
       defaultColumn,
       getTableBodyProps,
       id,
@@ -232,7 +233,11 @@ export const DataSpreadsheetBody = forwardRef(
               className={cx(
                 `${blockClass}__td`,
                 `${blockClass}__td-th`,
-                `${blockClass}--interactive-cell-element`
+                `${blockClass}--interactive-cell-element`,
+                {
+                  [`${blockClass}__td-th--active-header`]:
+                    activeCellCoordinates?.row === index,
+                }
               )}
               style={{
                 width: defaultColumn?.rowHeaderWidth,
@@ -270,6 +275,7 @@ export const DataSpreadsheetBody = forwardRef(
         defaultColumn.rowHeaderWidth,
         handleBodyCellClick,
         handleBodyCellHover,
+        activeCellCoordinates?.row,
       ]
     );
 
@@ -298,6 +304,14 @@ export const DataSpreadsheetBody = forwardRef(
 );
 
 DataSpreadsheetBody.propTypes = {
+  /**
+   * Default spreadsheet sizing values
+   */
+  activeCellCoordinates: PropTypes.shape({
+    row: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    column: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
+
   /**
    * Is the user clicking and holding in the data spreadsheet body
    */

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -12,7 +12,11 @@ import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
-export const DataSpreadsheetHeader = ({ defaultColumn, headerGroups }) => {
+export const DataSpreadsheetHeader = ({
+  activeCellCoordinates,
+  defaultColumn,
+  headerGroups,
+}) => {
   return (
     <div className={cx(`${blockClass}__header--container`)}>
       {headerGroups.map((headerGroup, index) => (
@@ -51,7 +55,11 @@ export const DataSpreadsheetHeader = ({ defaultColumn, headerGroups }) => {
               {...column.getHeaderProps()}
               className={cx(
                 `${blockClass}__th`,
-                `${blockClass}--interactive-cell-element`
+                `${blockClass}--interactive-cell-element`,
+                {
+                  [`${blockClass}__th--active-header`]:
+                    activeCellCoordinates?.column === index,
+                }
               )}
               type="button"
             >
@@ -65,6 +73,14 @@ export const DataSpreadsheetHeader = ({ defaultColumn, headerGroups }) => {
 };
 
 DataSpreadsheetHeader.propTypes = {
+  /**
+   * Default spreadsheet sizing values
+   */
+  activeCellCoordinates: PropTypes.shape({
+    row: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    column: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  }),
+
   /**
    * Default spreadsheet sizing values
    */

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -35,10 +35,6 @@
       position: relative;
     }
 
-    button.#{$block-class}__td {
-      margin: 0;
-      background-color: transparent;
-    }
     .#{$block-class}__tr {
       :last-child {
         .#{$block-class}__td {
@@ -60,22 +56,25 @@
       border-right: 1px solid $text-03;
     }
     .#{$block-class}__th,
-    button.#{$block-class}__td-th {
+    .#{$block-class}__td-th.#{$block-class}__td {
       @include set-header-borders();
 
       background-color: $ui-01;
       cursor: pointer;
     }
-    .#{$block-class}__td-th {
+    .#{$block-class}__td-th.#{$block-class}__td {
       @include carbon--font-weight('semibold');
 
       display: flex;
       align-items: center;
       justify-content: flex-end;
     }
+
     .#{$block-class}__td {
       @include set-body-borders();
 
+      margin: 0;
+      background-color: transparent;
       cursor: cell;
       text-align: left;
     }
@@ -111,6 +110,10 @@
         content: '';
         opacity: 0.25;
       }
+    }
+    .#{$block-class}__th--active-header,
+    .#{$block-class}__td-th--active-header.#{$block-class}__td {
+      background-color: $ui-03;
     }
   }
 }


### PR DESCRIPTION
Contributes to #1731 

With these changes, whenever the active cell changes the row and column header cells that match the coordinates of the active cell receive a different `background-color`.

See example below:

https://user-images.githubusercontent.com/10215203/156691417-02d82e38-47fd-404c-b235-48d8b0560cc6.mov



#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
```
#### How did you test and verify your work?
Storybook, added to tests