### PR TITLE
chore: design review remove warn state

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -24,7 +24,6 @@ import {
   EditOff16,
   Checkmark16,
   WarningFilled16,
-  WarningAltFilled16,
 } from '@carbon/icons-react';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
@@ -62,10 +61,6 @@ export let InlineEdit = React.forwardRef(
       saveDescription,
       size = defaults.size,
       value,
-      warn,
-      warnText,
-      // validator,
-      // validatorAsync,
 
       // Collect any other property values passed in.
       ...rest
@@ -77,15 +72,9 @@ export let InlineEdit = React.forwardRef(
     const ref = refIn || localRef;
     const [editing, setEditing] = useState(false);
     const [internalValue, setInternalValue] = useState(value);
-    const showValidation = invalid || warn;
-    const validationText = invalidText || warnText;
-    const validationIcon = showValidation ? (
-      invalid ? (
-        <WarningFilled16 />
-      ) : (
-        <WarningAltFilled16 />
-      )
-    ) : null;
+    const showValidation = invalid; // || warn;
+    const validationText = invalidText; // || warnText;
+    const validationIcon = showValidation ? <WarningFilled16 /> : null;
 
     const doSetEditing = (value) => {
       if (value === false) {
@@ -251,7 +240,6 @@ export let InlineEdit = React.forwardRef(
             [`${blockClass}--disabled`]: disabled,
             [`${blockClass}--editing`]: editing,
             [`${blockClass}--invalid`]: invalid,
-            [`${blockClass}--warn`]: warn,
             [`${blockClass}--light`]: light,
             [`${blockClass}--overflows`]:
               refInput.current &&
@@ -413,13 +401,13 @@ InlineEdit.propTypes = {
   /**
    * method called on input event (it's a React thing onChange behaves like on input).
    *
-   * NOTE: caller to handle invalid/warn states and associated text
+   * NOTE: caller to handle invalid states and associated text
    */
   onChange: PropTypes.func,
   /**
    * method called on change event
    *
-   * NOTE: caller to handle invalid/warn states and associated text
+   * NOTE: caller to handle invalid states and associated text
    */
   onSave: PropTypes.func,
   /**
@@ -438,12 +426,4 @@ InlineEdit.propTypes = {
    * initial/unedited value
    */
   value: PropTypes.string,
-  /**
-   * set warn state for input
-   */
-  warn: PropTypes.bool,
-  /**
-   * text shown when warn true
-   */
-  warnText: PropTypes.string,
 };

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.stories.js
@@ -23,13 +23,9 @@ const storyClass = 'inline-edit-stories';
 
 const validationOptions = {
   'Default, no validation change': {},
-  'On change or save warn if empty': { onChangeWarnIfEmpty: true },
   'On change or save invalid if empty': { onChangeInvalidIfEmpty: true },
-  'On change or save includes ABC warn': { onChangeWanWithABC: true },
   'On change or save includes ABC invalid': { onChangeInvalidWithABC: true },
-  'On save warn if empty': { onSaveWarnIfEmpty: true },
   'On save invalid if empty': { onSaveInvalidIfEmpty: true },
-  'On save includes ABC warn': { onSaveWanWithABC: true },
   'On save includes ABC invalid': { onSaveInvalidWithABC: true },
 };
 
@@ -89,31 +85,21 @@ const Template = ({
   cancelDescription,
   saveDescription,
   validation,
-  warn,
-  warnText,
   value: initialValue,
   ...rest
 }) => {
   const [value, setValue] = useState(initialValue);
   const [liveInvalid, setLiveInvalid] = useState(invalid);
-  const [liveWarn, setLiveWarn] = useState(warn);
   const [liveInvalidText, setLiveInvalidText] = useState(invalidText);
-  const [liveWarnText, setLiveWarnText] = useState(warnText);
 
   useEffect(() => {
     setLiveInvalid(invalid);
   }, [invalid]);
 
-  useEffect(() => {
-    setLiveWarn(warn);
-  }, [warn]);
-
   const handleValidation = (val, change, save) => {
     let newInvalid = false;
-    let newWarn = false;
-    let updateValidation = false;
     let invalidText = '';
-    let warnText = '';
+    let updateValidation = false;
 
     const zeroLength = val.length === 0;
     const hasABC = /ABC/.test(val);
@@ -126,35 +112,19 @@ const Template = ({
       invalidText = newInvalid ? 'This field cannot be empty' : '';
       updateValidation = true;
     } else if (
-      (change && validation?.onChangeWarnIfEmpty) ||
-      (save && validation?.onSaveWarnIfEmpty)
-    ) {
-      newWarn = zeroLength;
-      warnText = newWarn ? 'Empty fields are not good practice' : '';
-      updateValidation = true;
-    } else if (
       (change && validation?.onChangeInvalidWithABC) ||
       (save && validation?.onSaveInvalidWithABC)
     ) {
       newInvalid = hasABC;
       invalidText = newInvalid ? 'Cannot contain ABC in the entry' : '';
       updateValidation = true;
-    } else if (
-      (change && validation?.onChangeWanWithABC) ||
-      (save && validation?.onSaveWanWithABC)
-    ) {
-      newWarn = hasABC;
-      warnText = newWarn ? 'ABC should not be used in the entry' : '';
-      updateValidation = true;
     }
 
     if (updateValidation) {
       setLiveInvalid(newInvalid);
       setLiveInvalidText(invalidText);
-      setLiveWarn(newWarn);
-      setLiveWarnText(warnText);
     }
-    return updateValidation && (newWarn || newInvalid);
+    return updateValidation && newInvalid;
   };
 
   const onSave = (val) => {
@@ -198,8 +168,6 @@ const Template = ({
           onCancel,
           cancelDescription,
           saveDescription,
-          warn: liveWarn,
-          warnText: liveWarnText,
           value,
         }}
       />

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.test.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.test.js
@@ -333,44 +333,11 @@ describe(componentName, () => {
     expect(input).toHaveTextContent(startingValue + clipboardString + 'b');
   });
 
-  it('Can show warn state', () => {
-    const warnText = 'Do not forget this';
-
-    const { container } = render(
-      <InlineEdit {...requiredProps} warn={true} warnText={warnText} />
-    );
-    const component = container.querySelector(`.${blockClass}`);
-
-    screen.getByText(warnText);
-    const svg = component.querySelector(`.${blockClass}__validation-icon svg`);
-    expect(svg).not.toBeNull();
-  });
-
   it('Can show invalid state', () => {
     const invalidText = 'That is not valid';
 
     const { container } = render(
       <InlineEdit {...requiredProps} invalid={true} invalidText={invalidText} />
-    );
-    const component = container.querySelector(`.${blockClass}`);
-
-    screen.getByText(invalidText);
-    const svg = component.querySelector(`.${blockClass}__validation-icon svg`);
-    expect(svg).not.toBeNull();
-  });
-
-  it('Can show invalid state in preference to warn', () => {
-    const warnText = 'Do not forget this';
-    const invalidText = 'That is not valid';
-
-    const { container } = render(
-      <InlineEdit
-        {...requiredProps}
-        invalid={true}
-        invalidText={invalidText}
-        warn={true}
-        warnText={warnText}
-      />
     );
     const component = container.querySelector(`.${blockClass}`);
 

--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -324,10 +324,6 @@
       @include input-button-defaults($block-class);
     }
 
-    &.#{$block-class}--warn .#{$block-class}__validation-icon {
-      color: $support-warning;
-    }
-
     &.#{$block-class}--invalid .#{$block-class}__validation-icon {
       color: $support-error;
     }


### PR DESCRIPTION
Contributes to #1649 

Removes "warn" state following design review.
Validation now only supports the 'invalid' state.

#### What did you change?

InlineEdit component, styles, story and tests.

#### How did you test and verify your work?
Storybook and test