### PR TITLE
feat(DataSpreadsheet): #1731 add active highlight to column/row headers

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -593,6 +593,7 @@ export let DataSpreadsheet = React.forwardRef(
           cellSizeValue={cellSizeValue}
           defaultColumn={defaultColumn}
           headerGroups={headerGroups}
+          selectionAreas={selectionAreas}
         />
 
         {/* BODY */}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -14,6 +14,7 @@ import { pkg } from '../../settings';
 import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { createCellSelectionArea } from './createCellSelectionArea';
+import { checkActiveHeaderCell } from './checkActiveHeaderCell';
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
 export const DataSpreadsheetBody = forwardRef(
@@ -253,32 +254,6 @@ export const DataSpreadsheetBody = forwardRef(
       [clickAndHoldActive, currentMatcher, setSelectionAreas]
     );
 
-    const checkSelectionAreaForActiveHeader = useCallback(
-      (headerIndex) => {
-        // Determines if a row header cell should receive a highlight/active background color
-        // Check each object in selectionAreas and see if the headerIndex is between
-        // point1.row and point2.row, inclusive
-        const areasCloned = deepCloneObject(selectionAreas);
-        const activeRowIndexes = [];
-        areasCloned.forEach((area) => {
-          const greatestRowIndex = Math.max(area.point1?.row, area.point2?.row);
-          const lowestRowIndex = Math.min(area.point1?.row, area.point2?.row);
-          for (let i = lowestRowIndex; i <= greatestRowIndex; i++) {
-            activeRowIndexes.push(i);
-          }
-        });
-        const activeRowIndexesNoDuplicates = [...new Set(activeRowIndexes)];
-        if (
-          areasCloned?.length &&
-          activeRowIndexesNoDuplicates.includes(headerIndex)
-        ) {
-          return true;
-        }
-        return false;
-      },
-      [selectionAreas]
-    );
-
     // Renders each cell in the spreadsheet body
     const RenderRow = useCallback(
       ({ index, style }) => {
@@ -303,7 +278,7 @@ export const DataSpreadsheetBody = forwardRef(
                 {
                   [`${blockClass}__td-th--active-header`]:
                     activeCellCoordinates?.row === index ||
-                    checkSelectionAreaForActiveHeader(index),
+                    checkActiveHeaderCell(index, selectionAreas, 'row'),
                 }
               )}
               style={{
@@ -343,7 +318,7 @@ export const DataSpreadsheetBody = forwardRef(
         handleBodyCellClick,
         handleBodyCellHover,
         activeCellCoordinates?.row,
-        checkSelectionAreaForActiveHeader,
+        selectionAreas,
       ]
     );
 

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
-import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
+import { checkActiveHeaderCell } from './checkActiveHeaderCell';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -19,39 +19,6 @@ export const DataSpreadsheetHeader = ({
   headerGroups,
   selectionAreas,
 }) => {
-  const checkSelectionAreaForActiveHeader = useCallback(
-    (headerIndex) => {
-      // Determines if a column header cell should receive a highlight/active background color
-      // Check each object in selectionAreas and see if the headerIndex is between
-      // point1.column and point2.column, inclusive
-
-      const areasCloned = deepCloneObject(selectionAreas);
-      const activeColumnIndexes = [];
-      areasCloned.forEach((area) => {
-        const greatestColumnIndex = Math.max(
-          area.point1?.column,
-          area.point2?.column
-        );
-        const lowestColumnIndex = Math.min(
-          area.point1?.column,
-          area.point2?.column
-        );
-        for (let i = lowestColumnIndex; i <= greatestColumnIndex; i++) {
-          activeColumnIndexes.push(i);
-        }
-      });
-      const activeColumnIndexesNoDuplicates = [...new Set(activeColumnIndexes)];
-      if (
-        areasCloned?.length &&
-        activeColumnIndexesNoDuplicates.includes(headerIndex)
-      ) {
-        return true;
-      }
-      return false;
-    },
-    [selectionAreas]
-  );
-
   return (
     <div className={cx(`${blockClass}__header--container`)}>
       {headerGroups.map((headerGroup, index) => (
@@ -99,7 +66,7 @@ export const DataSpreadsheetHeader = ({
                 {
                   [`${blockClass}__th--active-header`]:
                     activeCellCoordinates?.column === index ||
-                    checkSelectionAreaForActiveHeader(index),
+                    checkActiveHeaderCell(index, selectionAreas, 'column'),
                 }
               )}
               type="button"

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/checkActiveHeaderCell.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/checkActiveHeaderCell.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
+
+// Determines if a row or column header cell should receive a highlight/active background color
+// Check each object in selectionAreas and see if the headerIndex is between
+// point1.row and point2.row, inclusive
+export const checkActiveHeaderCell = (
+  headerIndex,
+  selectionAreas,
+  headerType
+) => {
+  const areasCloned = deepCloneObject(selectionAreas);
+  const activeRowIndexes = [];
+  areasCloned.forEach((area) => {
+    const greatestRowIndex = Math.max(
+      area.point1?.[headerType],
+      area.point2?.[headerType]
+    );
+    const lowestRowIndex = Math.min(
+      area.point1?.[headerType],
+      area.point2?.[headerType]
+    );
+    for (let i = lowestRowIndex; i <= greatestRowIndex; i++) {
+      activeRowIndexes.push(i);
+    }
+  });
+  const activeRowIndexesNoDuplicates = [...new Set(activeRowIndexes)];
+  if (
+    areasCloned?.length &&
+    activeRowIndexesNoDuplicates.includes(headerIndex)
+  ) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
Contributes to #1731 

Part 2 of #1731: whenever the cell selection areas change the row/column headers will receive the active highlight background color at the appropriate time.

See example below:

https://user-images.githubusercontent.com/10215203/156810371-e6518963-42ef-4558-bc07-5477f4912e11.mov



#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
```
#### How did you test and verify your work?
Storybook