### PR TITLE
feat(TagSet): add allTagsModalTarget prop

### DIFF
--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -28,6 +28,7 @@ const allTagsModalSearchThreshold = 10;
 // Default values for props
 const defaults = {
   align: 'start',
+  allTagsModalTarget: document.body,
   overflowAlign: 'center',
   overflowDirection: 'bottom',
 };
@@ -38,6 +39,7 @@ export let TagSet = React.forwardRef(
       // The component props, in alphabetical order (for consistency).
 
       align = defaults.align,
+      allTagsModalTarget = defaults.allTagsModalTarget,
       className,
       maxVisible,
       overflowAlign = defaults.overflowAlign,
@@ -239,7 +241,7 @@ export let TagSet = React.forwardRef(
           </div>
         </div>
 
-        {tags && displayCount < tags.length
+        {allTagsModalTarget && tags && displayCount < tags.length
           ? createPortal(
               <TagSetModal
                 allTags={tags}
@@ -249,7 +251,7 @@ export let TagSet = React.forwardRef(
                 searchLabel={allTagsModalSearchLabel}
                 searchPlaceholder={allTagsModalSearchPlaceholderText}
               />,
-              document.body
+              allTagsModalTarget
             )
           : null}
       </div>
@@ -300,6 +302,10 @@ TagSet.propTypes = {
    * placeholder text for the show all search. **Note: Required if more than 10 tags**
    */
   allTagsModalSearchPlaceholderText: string_required_if_more_than_10_tags,
+  /**
+   * portal target for the all tags modal
+   */
+  allTagsModalTarget: PropTypes.node,
   /**
    * title for the show all modal. **Note: Required if more than 10 tags**
    */

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { types as tagTypes } from 'carbon-components-react/es/components/Tag/Tag';
 import { pkg } from '../../settings';
@@ -142,6 +142,10 @@ export default {
     containerWidth: {
       control: { type: 'range', min: 20, max: 800, step: 10 },
     },
+    allTagsModalTarget_CustomDomNode: {
+      control: { type: 'boolean' },
+      description: 'Optional DOM node: Modal target defaults to document.body',
+    },
   },
   decorators: [
     (story) => (
@@ -157,10 +161,18 @@ export default {
 };
 
 const Template = (argsIn) => {
-  const { containerWidth, ...args } = { ...argsIn };
+  const { containerWidth, allTagsModalTarget_ContainerNode, ...args } = {
+    ...argsIn,
+  };
+  const ref = useRef();
   return (
-    <div style={{ width: containerWidth }}>
-      <TagSet {...args} />
+    <div style={{ width: containerWidth }} ref={ref}>
+      <TagSet
+        {...args}
+        allTagsModalTarget={
+          allTagsModalTarget_ContainerNode ? ref.current : undefined
+        }
+      />
     </div>
   );
 };


### PR DESCRIPTION
Contributes to #1307 

#### What did you change?

Adds allTagsModelTarget to allow users to specify an alternative to the default document body.

#### How did you test and verify your work?
Storybook.