### PR TITLE
refactor(options-tile): implement release review feedback

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -48,8 +48,6 @@ export let OptionsTile = React.forwardRef(
       children,
       className,
       enabled,
-      heading,
-      headingId: userDefinedHeadingId,
       invalid,
       invalidText,
       locked,
@@ -58,6 +56,8 @@ export let OptionsTile = React.forwardRef(
       open,
       size = defaults.size,
       summary,
+      title,
+      titleId: userDefinedTitleId,
       warn,
       warnText,
 
@@ -74,7 +74,7 @@ export let OptionsTile = React.forwardRef(
     const contentRef = useRef(null);
 
     const id = uuidv4();
-    const headingId = userDefinedHeadingId ?? `${id}-heading`;
+    const titleId = userDefinedTitleId ?? `${id}-title`;
 
     const isExpandable = children !== undefined;
 
@@ -215,9 +215,9 @@ export let OptionsTile = React.forwardRef(
       }
 
       return (
-        <div className={`${blockClass}__title`}>
-          <h6 id={headingId} className={`${blockClass}__heading`}>
-            {heading}
+        <div className={`${blockClass}__heading`}>
+          <h6 id={titleId} className={`${blockClass}__title`}>
+            {title}
           </h6>
           {text && (
             <span className={cx(summaryClasses)} aria-hidden={summaryHidden}>
@@ -255,7 +255,7 @@ export let OptionsTile = React.forwardRef(
               toggled={enabled}
               labelA=""
               labelB=""
-              aria-labelledby={headingId}
+              aria-labelledby={titleId}
               onToggle={onToggle}
               size="sm"
               disabled={isLocked}
@@ -316,16 +316,6 @@ OptionsTile.propTypes = {
   enabled: PropTypes.bool,
 
   /**
-   * Provide the heading for this OptionsTile.
-   */
-  heading: PropTypes.string.isRequired,
-
-  /**
-   * Optionally provide an id which should be used for the heading.
-   */
-  headingId: PropTypes.string,
-
-  /**
    * Whether the OptionsTile is in invalid validation state.
    */
   invalid: PropTypes.bool,
@@ -365,6 +355,16 @@ OptionsTile.propTypes = {
    * Optionally provide a text summarizing the current state of the content.
    */
   summary: PropTypes.string,
+
+  /**
+   * Provide the title for this OptionsTile.
+   */
+  title: PropTypes.string.isRequired,
+
+  /**
+   * Optionally provide an id which should be used for the title.
+   */
+  titleId: PropTypes.string,
 
   /**
    * Whether the OptionsTile is in warning validation state.

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.mdx
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.mdx
@@ -20,7 +20,8 @@ likely not interested in all available options, but only a subset.
 An options tile can also be paired with a toggle to enable or disable an entire
 set of features with ease.
 
-[CD&AI Options Tile guidelines](https://pages.github.ibm.com/cdai-design/pal/components/options-tile/usage)
+[Options Tile guidelines](https://pages.github.ibm.com/cdai-design/pal/components/options-tile/usage)
+(IBM internal)
 
 ## Example usage
 

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
@@ -77,7 +77,7 @@ const Template = (args) => {
   // spell-checker:enable
 
   const id = uuidv4();
-  const headingId = args.headingId ?? `${id}-heading`;
+  const titleId = args.titleId ?? `${id}-title`;
 
   const isInvalid = args.invalid;
   const isWarn = !isInvalid && args.warn;
@@ -86,7 +86,7 @@ const Template = (args) => {
 
   return (
     <OptionsTile onToggle={action('onToggle')} {...args}>
-      <FormGroup aria-labelledby={headingId} legendText="" hasMargin={false}>
+      <FormGroup aria-labelledby={titleId} legendText="" hasMargin={false}>
         <p>
           User interface defines the language the application is displayed in.
           Locale sets the regional display formats for information like time,
@@ -133,7 +133,7 @@ const TemplateStatic = ({ enabled, ...rest }) => {
 
 export const optionsTile = prepareStory(Template, {
   args: {
-    heading: 'Language',
+    title: 'Language',
     summary: 'English | Locale: English',
     invalidText: 'Your system does not support this configuration',
     warnText: 'A restart is required to apply these settings',
@@ -143,7 +143,7 @@ export const optionsTile = prepareStory(Template, {
 
 export const staticOptionsTile = prepareStory(TemplateStatic, {
   args: {
-    heading: 'Hardware acceleration',
+    title: 'Hardware acceleration',
     enabled: true,
   },
 });

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -35,7 +35,11 @@ describe(componentName, () => {
   });
 
   it('has no accessibility violations', async () => {
-    const { container } = render(<OptionsTile {...props} />);
+    const { container } = render(
+      <main>
+        <OptionsTile {...props} />
+      </main>
+    );
     await expect(container).toBeAccessible(componentName);
     await expect(container).toHaveNoAxeViolations();
   });

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -23,7 +23,7 @@ const dataTestId = uuidv4();
 
 // common props
 const props = {
-  heading: `heading-${uuidv4()}`,
+  title: `title-${uuidv4()}`,
   'data-testid': dataTestId,
   children,
 };
@@ -84,7 +84,7 @@ describe(componentName, () => {
   });
 
   it('renders as static variant if no children are provided', () => {
-    const { container } = render(<OptionsTile heading="Static variant" />);
+    const { container } = render(<OptionsTile title="Static variant" />);
 
     expect(container.querySelector('details')).toBeFalsy();
   });
@@ -155,14 +155,14 @@ describe(componentName, () => {
     expect(screen.getByTestId(dataTestId)).toHaveClass(`${blockClass}--lg`);
   });
 
-  it('uses props.headingId as the heading id and as the aria-labelledby attribute of the toggle', () => {
-    const headingId = uuidv4();
+  it('uses props.titleId as the title id and as the aria-labelledby attribute of the toggle', () => {
+    const titleId = uuidv4();
 
-    render(<OptionsTile {...props} headingId={headingId} enabled />);
+    render(<OptionsTile {...props} titleId={titleId} enabled />);
 
-    expect(screen.getByRole('heading').id).toBe(headingId);
+    expect(screen.getByRole('heading').id).toBe(titleId);
     // TODO: update to role "switch" for Carbon v11
-    expect(screen.getByRole('checkbox')).toHaveAccessibleName(props.heading);
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName(props.title);
   });
 
   it('expands and collapses on click', () => {

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/_index.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_index.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -57,6 +57,10 @@
     transition: background-color $duration--fast-01 motion(entrance, productive);
   }
 
+  .#{$block-class}__header::-webkit-details-marker {
+    display: none;
+  }
+
   .#{$block-class}__header:hover {
     background-color: $hover-ui;
   }
@@ -119,6 +123,7 @@
   }
 
   .#{$block-class}__chevron {
+    display: block;
     justify-self: center;
     transition: transform $duration--fast-02 motion(standard, productive);
   }

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -12,6 +12,10 @@
 // Other Carbon settings.
 @import 'carbon-components/scss/globals/scss/helper-mixins';
 
+// PageHeader uses the following Carbon components:
+// Toggle
+@import 'carbon-components/scss/components/toggle/toggle';
+
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin options-tile {

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -61,11 +61,11 @@
     @include focus-outline('outline');
   }
 
-  .#{$block-class}__title {
+  .#{$block-class}__heading {
     grid-column: 2;
   }
 
-  .#{$block-class}__heading {
+  .#{$block-class}__title {
     @include carbon--type-style('productive-heading-01');
 
     color: $text-01;

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -48,7 +48,7 @@
     box-sizing: border-box;
     align-items: center;
     padding-right: $spacing-05;
-    grid-template-columns: 3rem 1fr 1rem;
+    grid-template-columns: 3rem 1fr 2rem; // chevron container, heading, toggle width
   }
 
   .#{$block-class}__header {
@@ -96,7 +96,7 @@
   .#{$block-class}__summary--warn,
   .#{$block-class}__summary--locked {
     column-gap: $spacing-02;
-    grid-template-columns: 1rem 1fr;
+    grid-template-columns: 1rem 1fr; // icon, text
   }
 
   .#{$block-class}__summary--invalid {
@@ -118,6 +118,9 @@
   .#{$block-class}__summary-text {
     overflow: hidden;
     height: max-content;
+    // spacing-05 + toggle width
+    // stylelint-disable-next-line carbon/layout-token-use
+    padding-right: calc(#{$spacing-05} + 2rem);
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -202,18 +205,6 @@
 
   .#{$block-class}--lg .#{$block-class}__summary {
     margin-top: $spacing-01;
-  }
-
-  .#{$block-class}--lg .#{$block-class}__summary-text {
-    // spacing-05 + toggle width
-    // stylelint-disable-next-line carbon/layout-token-use
-    padding-right: calc(#{$spacing-05} + 1rem);
-  }
-
-  .#{$block-class}--xl .#{$block-class}__summary-text {
-    // spacing-05 + toggle width
-    // stylelint-disable-next-line carbon/layout-token-use
-    padding-right: calc(#{$spacing-05} + 2rem);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
@@ -10,7 +10,7 @@
 $block-class: #{$pkg-prefix}--options-tile;
 
 .#{$block-class} {
-  width: 100%;
+  width: 80vw;
   min-width: 16rem;
   max-width: 48rem;
 }

--- a/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_storybook-styles.scss
@@ -10,9 +10,9 @@
 $block-class: #{$pkg-prefix}--options-tile;
 
 .#{$block-class} {
-  width: 70vw;
-  min-width: 32rem;
-  max-width: 64rem;
+  width: 100%;
+  min-width: 16rem;
+  max-width: 48rem;
 }
 
 .#{$block-class}__content p {

--- a/packages/cloud-cognitive/src/components/OptionsTile/index.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2021
+ * Copyright IBM Corp. 2021, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Contributes to #1656

#### What did you change?

- Updated copyright year in all file headers to include 2022
- Import Carbon toggle component scss
- Renamed props
  - `props.heading` -> `props.title`
  - `props.headingId` -> `props.titleId`
- Render component as child of `<main>` element for automated a11y test
- Improve responsive behaviour in storybook
- Annotated why certain spacings don't use tokens but `rem`
- Fix chevron rendering on iOS Safari

#### How did you test and verify your work?
- Storybook
- Tests
