### PR TITLE
test(options-tile): extend automated test coverage

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -157,7 +157,7 @@ describe(componentName, () => {
     expect(summary.getAttribute('aria-hidden')).toBe('true');
   });
 
-  it('it can be controlled by setting props.open', () => {
+  it('can be controlled by setting props.open', () => {
     const { container, rerender } = render(<OptionsTile {...props} />);
     expect(container.querySelector('details').open).toBe(false);
 

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -148,10 +148,24 @@ describe(componentName, () => {
     expect(summary.textContent).toBe(lockedText);
   });
 
-  it('renders open state when passed', () => {
-    const { container } = render(<OptionsTile {...props} open={true} />);
+  it('hides the summary when props.enabled = false', () => {
+    const summaryText = 'hidden summary';
+    render(<OptionsTile {...props} summary={summaryText} enabled={false} />);
 
+    const summary = screen.getByRole('heading').nextSibling;
+    expect(summary.textContent).toBe(summaryText);
+    expect(summary.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('it can be controlled by setting props.open', () => {
+    const { container, rerender } = render(<OptionsTile {...props} />);
+    expect(container.querySelector('details').open).toBe(false);
+
+    rerender(<OptionsTile {...props} open={true} />);
     expect(container.querySelector('details').open).toBe(true);
+
+    rerender(<OptionsTile {...props} open={false} />);
+    expect(container.querySelector('details').open).toBe(false);
   });
 
   it('supports "lg" size', () => {
@@ -175,6 +189,8 @@ describe(componentName, () => {
     expect(container.querySelector('details').open).toBe(false);
     fireEvent.click(container.querySelector('summary'));
     expect(container.querySelector('details').open).toBe(true);
+    fireEvent.click(container.querySelector('summary'));
+    expect(container.querySelector('details').open).toBe(false);
   });
 
   it('emits onToggle', () => {


### PR DESCRIPTION
Contributes to #1656

#### What did you change?
- Add new test: "it hides the summary when props.enabled = false"
- Enhance existing tests
  - "it renders open state when passed"
    - renamed to "it can be controlled by setting props.open"
    - test both cases: set to expanded when collapsed and set to collapsed when expanded
  - "it expands and collapses on click"
    - also test collapsing on click again

#### How did you test and verify your work?
Automated tests


#### Additional notes
@matthewgallo The remaining "untested" parts are solely for the animation. I would assume we don't necessarily want test this to avoid additional delays in the testing suite when waiting for animations to be complete. What do you think?