### PR TITLE
fix: add select cleanup

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
@@ -29,17 +29,8 @@ export let AddSelectSidebar = ({
     setMultiSelection(newSelections);
   };
 
-  // utility to flatten the list of items and their children into a single searchable array
-  const flattenItems = (arr) =>
-    arr.reduce((prev, cur) => {
-      const { children, ...item } = cur;
-      return prev
-        .concat(item)
-        .concat(children ? flattenItems(children.entries) : []);
-    }, []);
-  const flattenedItems = flattenItems(items);
   const sidebarItems = multiSelection.map((selectedId) =>
-    flattenedItems.find((item) => item.id === selectedId)
+    items.find((item) => item.id === selectedId)
   );
 
   const getTitle = ({ title, subtitle, id }) => (

--- a/packages/cloud-cognitive/src/components/AddSelect/add-select-utils.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/add-select-utils.js
@@ -1,0 +1,38 @@
+/**
+ * used to normalize nested data into a single object
+ * @param {Array} items - list of entries
+ * @returns an object of normalized item data
+ */
+export const normalize = (items) => {
+  const { entries, parentId, sortBy, filterBy } = items;
+  return entries.reduce((acc, cur) => {
+    const { children, ...entry } = cur;
+    acc[cur.id] = { ...entry };
+    if (parentId) {
+      acc[cur.id].parent = parentId;
+    }
+    if (sortBy?.length) {
+      acc[cur.id].sortBy = sortBy;
+    }
+    if (filterBy) {
+      acc[cur.id].filterBy = filterBy;
+    }
+    if (children) {
+      acc[cur.id].children = children.entries.map((child) => child.id);
+      const child = normalize({ ...children, parentId: cur.id });
+      return { ...acc, ...child };
+    }
+    return acc;
+  }, {});
+};
+
+/**
+ * used to create a single searchable array of nested items
+ * @param {Array} entries - list of entries
+ * @returns an array of items
+ */
+export const flatten = (entries) =>
+  entries.reduce((prev, cur) => {
+    const { children, ...item } = cur;
+    return prev.concat(item).concat(children ? flatten(children.entries) : []);
+  }, []);

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -64,6 +64,7 @@ const defaultProps = {
   removeIconDescription: 'Remove',
   textInputLabel: 'test input label',
   columnInputPlaceholder: 'Find',
+  onSubmit: (selections) => console.log(selections),
 };
 
 const Template = (args) => {

--- a/packages/cloud-cognitive/src/components/SingleAddSelect/SingleAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/SingleAddSelect/SingleAddSelect.stories.js
@@ -56,6 +56,7 @@ const defaultProps = {
   onCloseButtonText: 'Cancel',
   onSubmitButtonText: 'Select',
   textInputLabel: 'test input title',
+  onSubmit: (selection) => console.log(selection),
 };
 
 const Template = (args) => {


### PR DESCRIPTION
just some cleanup for add select

* moves some functions to a new utils file to reduce file bloat
* adds a submit handler
* adds some additional comments to help readability
* moves the flattened sidebar items to `AddSelect` and inside the `useEffect` so that that function only needs to run once
