### PR TITLE
fix: add publishConfig to component usage package.json

### DIFF
--- a/packages/component-usage-report/package.json
+++ b/packages/component-usage-report/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.0",
   "description": "Creates a @carbon/cloud-cognitive component usage report.",
   "bin": "bin/component-usage-report",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
It appears that the release from yesterday evening failed because the `@carbon/component-usage-report` was never published, I think the publish step was possibly skipped because the `publishConfig` key in the package.json was missing. I re-ran the release workflow, if it fails again with the same message, I'm hoping this will fix it.

#### What did you change?
`packages/component-usage-report/package.json`