### PR TITLE
fix: text alignment in tagset overflow

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3081,6 +3081,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 
 .c4p--tag-set-overflow__tooltip.c4p--tag-set-overflow__tooltip {
   min-width: initial;
+  text-align: left;
 }
 .c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__show-all-tags-link {
   display: inline-block;

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -114,6 +114,7 @@ $block-class-modal: #{$block-class}-modal;
     &.#{$block-class-overflow}__tooltip {
       // removes the min width in Carbon
       min-width: initial;
+      text-align: left;
     }
 
     .#{$block-class-overflow}__show-all-tags-link {


### PR DESCRIPTION
The text alignment of the TagSet overflow was based on the alignment of the popup. Changed to always align the text to the left.

#### What did you change?

CSS targeting the text in the overflow and related snapshot.

#### How did you test and verify your work?
Storybook.
