### PR TITLE
feat(DataSpreadsheet): add `onSelectionAreaChange` prop

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -51,6 +51,8 @@ const defaults = {
   columns: Object.freeze([]),
   data: Object.freeze([]),
   onDataUpdate: Object.freeze(() => {}),
+  onActiveCellChange: Object.freeze(() => {}),
+  onSelectionAreaChange: Object.freeze(() => {}),
 };
 
 /**
@@ -66,7 +68,8 @@ export let DataSpreadsheet = React.forwardRef(
       data = defaults.data,
       onDataUpdate = defaults.onDataUpdate,
       id,
-      onActiveCellChange,
+      onActiveCellChange = defaults.onActiveCellChange,
+      onSelectionAreaChange = defaults.onSelectionAreaChange,
 
       // Collect any other property values passed in.
       ...rest
@@ -79,6 +82,7 @@ export let DataSpreadsheet = React.forwardRef(
     const [containerHasFocus, setContainerHasFocus] = useState(false);
     const [activeCellCoordinates, setActiveCellCoordinates] = useState(null);
     const [selectionAreas, setSelectionAreas] = useState([]);
+    const [selectionAreaData, setSelectionAreaData] = useState([]);
     const [clickAndHoldActive, setClickAndHoldActive] = useState(false);
     const [currentMatcher, setCurrentMatcher] = useState('');
     const [isEditing, setIsEditing] = useState(false);
@@ -334,6 +338,7 @@ export let DataSpreadsheet = React.forwardRef(
             !activeKeys.current.includes('Shift')
           ) {
             setSelectionAreas([]);
+            setSelectionAreaData([]);
             removeCellSelections({ spreadsheetRef });
           }
         }
@@ -682,6 +687,7 @@ export let DataSpreadsheet = React.forwardRef(
           setActiveCellCoordinates={setActiveCellCoordinates}
           setSelectionAreas={setSelectionAreas}
           setCurrentMatcher={setCurrentMatcher}
+          setSelectionAreaData={setSelectionAreaData}
         />
 
         {/* BODY */}
@@ -699,8 +705,11 @@ export let DataSpreadsheet = React.forwardRef(
           defaultColumn={defaultColumn}
           getTableBodyProps={getTableBodyProps}
           onActiveCellChange={onActiveCellChange}
+          onSelectionAreaChange={onSelectionAreaChange}
           prepareRow={prepareRow}
           rows={rows}
+          selectionAreaData={selectionAreaData}
+          setSelectionAreaData={setSelectionAreaData}
           setActiveCellCoordinates={setActiveCellCoordinates}
           scrollBarSize={scrollBarSize}
           totalColumnsWidth={totalColumnsWidth}
@@ -794,6 +803,11 @@ DataSpreadsheet.propTypes = {
    * The setter fn for the data prop
    */
   onDataUpdate: PropTypes.func,
+
+  /**
+   * The event handler that is called when the selection area values change
+   */
+  onSelectionAreaChange: PropTypes.func,
 
   /* TODO: add types and DocGen for all props. */
 };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -25,6 +25,9 @@ export default {
     onActiveCellChange: {
       action: 'active cell change',
     },
+    onSelectionAreaChange: {
+      action: 'selection area change',
+    },
   },
   parameters: {
     styles,
@@ -98,7 +101,7 @@ const Template = ({ ...args }) => {
 };
 
 const LargeTemplate = ({ ...args }) => {
-  const [data, setData] = useState(() => generateData(16));
+  const [data, setData] = useState(() => generateData(1000));
   const columns = useMemo(() => columnData, []);
 
   return (

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
@@ -137,11 +137,13 @@ describe(componentName, () => {
     const ref = React.createRef();
     const { click } = userEvent;
     const activeCellChangeFn = jest.fn();
+    const onSelectionAreaChangeFn = jest.fn();
     render(
       <DataSpreadsheet
         {...defaultProps}
         ref={ref}
         onActiveCellChange={activeCellChangeFn}
+        onSelectionAreaChange={onSelectionAreaChangeFn}
       />
     );
     const allCells = ref?.current.querySelectorAll(`.${blockClass}__th`);
@@ -152,5 +154,6 @@ describe(componentName, () => {
       `.${blockClass}__selection-area--element`
     );
     expect(selectionArea).toBeInTheDocument();
+    expect(onSelectionAreaChangeFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -13,6 +13,7 @@ import cx from 'classnames';
 import { pkg } from '../../settings';
 import { deepCloneObject } from '../../global/js/utils/deepCloneObject';
 import uuidv4 from '../../global/js/utils/uuidv4';
+import { usePreviousValue } from '../../global/js/hooks';
 
 import { removeCellSelections } from './utils/removeCellSelections';
 import { createCellSelectionArea } from './utils/createCellSelectionArea';
@@ -31,6 +32,8 @@ export const DataSpreadsheetBody = forwardRef(
       id,
       prepareRow,
       rows,
+      selectionAreaData,
+      setSelectionAreaData,
       setActiveCellCoordinates,
       selectionAreas,
       setContainerHasFocus,
@@ -41,13 +44,72 @@ export const DataSpreadsheetBody = forwardRef(
       setClickAndHoldActive,
       currentMatcher,
       setCurrentMatcher,
+      onSelectionAreaChange,
     },
     ref
   ) => {
+    const previousState = usePreviousValue({
+      selectionAreaData,
+      clickAndHoldActive,
+    });
+
+    // Call the `onSelectionAreaChange` handler to send selection area data
+    // back to the consumer
+    useEffect(() => {
+      if (selectionAreaData.length) {
+        if (
+          (!clickAndHoldActive && previousState?.clickAndHoldActive) ||
+          previousState?.selectionAreaData?.length !== selectionAreaData?.length
+        ) {
+          onSelectionAreaChange(selectionAreaData);
+        }
+      }
+    }, [
+      previousState?.selectionAreaData,
+      selectionAreaData,
+      onSelectionAreaChange,
+      clickAndHoldActive,
+      previousState?.clickAndHoldActive,
+    ]);
+
     // Create cell selection areas based on selectionAreas array
     useEffect(() => {
       if (selectionAreas && selectionAreas.length) {
         selectionAreas.map((area) => {
+          // Setup selection area data that will be sent back to consumer via onSelectionAreaChange prop
+          if (area.areaCreated) {
+            const rowStart = Math.min(area.point1.row, area.point2.row);
+            const rowEnd = Math.max(area.point1.row, area.point2.row);
+            const columnStart = Math.min(
+              area.point1.column,
+              area.point2.column
+            );
+            const columnEnd = Math.max(area.point1.column, area.point2.column);
+            const selectionData = {
+              rows: {
+                start: rowStart,
+                end: rowEnd,
+              },
+              columns: {
+                start: columnStart,
+                end: columnEnd,
+              },
+              cells: populateSelectionAreaCellData({
+                rowStart,
+                rowEnd,
+                columnStart,
+                columnEnd,
+              }),
+              selectionId: area.matcher,
+            };
+            setSelectionAreaData((prev) => {
+              const prevValues = deepCloneObject(prev);
+              const newAreaData = prevValues.filter(
+                (item) => item.selectionId !== area.matcher
+              );
+              return [...newAreaData, selectionData];
+            });
+          }
           if (!area.areaCreated && area.point1 && area.point2 && area.matcher) {
             // Do not create a cell selection area if point1 and point2 have the same values
             // Cell selections must have two distinctly different points for an area to be created
@@ -74,7 +136,32 @@ export const DataSpreadsheetBody = forwardRef(
           return;
         });
       }
-    }, [selectionAreas, setSelectionAreas, defaultColumn]);
+    }, [
+      selectionAreas,
+      setSelectionAreas,
+      defaultColumn,
+      onSelectionAreaChange,
+      setSelectionAreaData,
+    ]);
+
+    const populateSelectionAreaCellData = ({
+      rowStart,
+      rowEnd,
+      columnStart,
+      columnEnd,
+    }) => {
+      const cellContainer = [];
+      for (let rowIndex = rowStart; rowIndex <= rowEnd; rowIndex++) {
+        for (
+          let columnIndex = columnStart;
+          columnIndex <= columnEnd;
+          columnIndex++
+        ) {
+          cellContainer.push([rowIndex, columnIndex]);
+        }
+      }
+      return cellContainer;
+    };
 
     // Mouse up
     useEffect(() => {
@@ -182,6 +269,7 @@ export const DataSpreadsheetBody = forwardRef(
               { point1: activeCoordinates, matcher: tempMatcher },
             ]);
             setCurrentMatcher(tempMatcher);
+            setSelectionAreaData([]);
           }
         };
       },
@@ -195,6 +283,7 @@ export const DataSpreadsheetBody = forwardRef(
         setClickAndHoldActive,
         setCurrentMatcher,
         ref,
+        setSelectionAreaData,
       ]
     );
 
@@ -247,6 +336,7 @@ export const DataSpreadsheetBody = forwardRef(
             setSelectionAreas,
             spreadsheetRef: ref,
             index,
+            setSelectionAreaData,
           });
         };
       },
@@ -258,6 +348,7 @@ export const DataSpreadsheetBody = forwardRef(
         setActiveCellCoordinates,
         activeCellCoordinates,
         rows,
+        setSelectionAreaData,
       ]
     );
 
@@ -404,6 +495,11 @@ DataSpreadsheetBody.propTypes = {
   onActiveCellChange: PropTypes.func,
 
   /**
+   * The event handler that is called when the selection areas change
+   */
+  onSelectionAreaChange: PropTypes.func,
+
+  /**
    * Prepare row function from react-table
    */
   prepareRow: PropTypes.func,
@@ -417,6 +513,11 @@ DataSpreadsheetBody.propTypes = {
    * The scrollbar width
    */
   scrollBarSize: PropTypes.number,
+
+  /**
+   * Array of selection area data
+   */
+  selectionAreaData: PropTypes.array,
 
   /**
    * Array of selection areas
@@ -442,6 +543,11 @@ DataSpreadsheetBody.propTypes = {
    * Setter fn for currentMatcher state value
    */
   setCurrentMatcher: PropTypes.func,
+
+  /**
+   * Setter fn for selectionAreaData state value
+   */
+  setSelectionAreaData: PropTypes.func,
 
   /**
    * Setter fn for selectionAreas state value

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -25,6 +25,7 @@ export const DataSpreadsheetHeader = forwardRef(
       setActiveCellCoordinates,
       setCurrentMatcher,
       setSelectionAreas,
+      setSelectionAreaData,
       rows,
     },
     ref
@@ -41,6 +42,7 @@ export const DataSpreadsheetHeader = forwardRef(
           setSelectionAreas,
           spreadsheetRef: ref,
           index,
+          setSelectionAreaData,
         });
       };
     };
@@ -155,6 +157,11 @@ DataSpreadsheetHeader.propTypes = {
    * Setter fn for currentMatcher value
    */
   setCurrentMatcher: PropTypes.func,
+
+  /**
+   * Setter fn for selectionAreaData state value
+   */
+  setSelectionAreaData: PropTypes.func,
 
   /**
    * Setter fn for selectionAreas value

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
@@ -19,7 +19,9 @@ export const handleHeaderCellSelection = ({
   spreadsheetRef,
   index,
   isKeyboard,
+  setSelectionAreaData,
 }) => {
+  setSelectionAreaData([]);
   const rowValue = isKeyboard ? activeCellCoordinates?.row : index;
   const columnValue = isKeyboard ? activeCellCoordinates?.column : index;
   const point1 = {


### PR DESCRIPTION
Contributes to #1757 

Adds a new prop, `onSelectionAreaChange`, that sends data back to the consumer detailing each selection area. This function prop is called whenever new selection areas are created either from the spreadsheet body or from selecting a row or column header.

The structure of the data sent back is as follows:
```js
[
  {
    rows: {
      start: 0,
      end: 0
    },
    columns: {
      start: 0,
      end: 2
    },
    cells: [
      [0, 0],
      [0, 1],
      [0, 2],
    ]
  }
]
```

You can also see the return value of this prop by looking at the actions tab in storybook after selecting an area.
![Screen Shot 2022-03-24 at 10 02 54 AM](https://user-images.githubusercontent.com/10215203/159933403-738f53e2-a9f1-447d-8d01-e96c90f44a54.png)


#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
```
#### How did you test and verify your work?
Storybook and added to tests