### PR TITLE
fix(DataSpreadsheet): use type token for cells/cell editor/active cell

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -627,7 +627,7 @@ export let DataSpreadsheet = React.forwardRef(
         cellEditorRef.current.style.height =
           activeCellRef?.current.style.height;
         cellEditorRef.current.style.paddingTop = `${
-          (parseInt(activeCellRef?.current.style.height) - 16) / 2
+          (parseInt(activeCellRef?.current.style.height) - 16) / 2 - 1
         }px`; // calculate paddingTop based on cellHeight which could be variable depending on the cellSize prop
         cellEditorRef.current.style.textAlign =
           cellProps?.column?.placement === 'right' ? 'right' : 'left';

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -45,7 +45,8 @@
 
     .#{$block-class}__th,
     .#{$block-class}__td {
-      // height: 2.25rem; // update to be controlled by cellSize prop later
+      @include carbon--type-style('body-short-01');
+
       padding: 0 $spacing-03;
       border: 0;
       margin: 0;
@@ -85,6 +86,8 @@
       text-align: left;
     }
     .#{$block-class}__cell-editor {
+      @include carbon--type-style('body-short-01');
+
       position: absolute;
       z-index: 4;
       display: none;
@@ -97,6 +100,8 @@
       }
     }
     .#{$block-class}__active-cell--highlight {
+      @include carbon--type-style('body-short-01');
+
       position: absolute;
       z-index: 3;
       display: none;


### PR DESCRIPTION
Contributes to #1759 

This PR adds the `body-short-01` type token to all spreadsheet cells, the active cell, and the cell editor (text area). Previously, the text area font size was slightly larger than the font size of the body cells.

I also updated the calculation of the paddingTop value of the cellEditor, it was off by 1px. Now, going into edit mode, the contents of the cell being edited does not move or jump anymore.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
```
#### How did you test and verify your work?
Storybook