### PR TITLE
chore: remove cdai bx in testss

### DIFF
--- a/packages/cdai/src/components/IdeButton/IdeButton.spec.js
+++ b/packages/cdai/src/components/IdeButton/IdeButton.spec.js
@@ -9,6 +9,8 @@ import React from 'react';
 import { Add16 } from '@carbon/icons-react';
 import { IdeButton } from '../IdeButton';
 import { shallow, mount } from 'enzyme';
+import { settings } from 'carbon-components';
+const { prefix } = settings;
 
 describe('IdeButton', () => {
   describe('Renders common props as expected', () => {
@@ -103,7 +105,7 @@ describe('IdeButton', () => {
     const icon = iconButton.find('svg');
 
     it('should have the appropriate icon', () => {
-      expect(icon.hasClass('bx--btn__icon')).toBe(true);
+      expect(icon.hasClass(`${prefix}--btn__icon`)).toBe(true);
     });
   });
 
@@ -118,7 +120,7 @@ describe('IdeButton', () => {
     const icon = iconButton.find('svg');
 
     it('should have the appropriate icon', () => {
-      expect(icon.hasClass('bx--btn__icon')).toBe(true);
+      expect(icon.hasClass(`${prefix}--btn__icon`)).toBe(true);
       expect(icon.find(':not(svg):not(title)').html()).toBe(
         originalIcon.children().html()
       );
@@ -144,7 +146,7 @@ describe('Primary Button', () => {
     const wrapper = shallow(<IdeButton className="extra-class" />);
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn`)).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -160,7 +162,9 @@ describe('Secondary Button', () => {
     );
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn--secondary')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn--secondary`)).toEqual(
+        true
+      );
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -174,7 +178,7 @@ describe('Ghost Button', () => {
     const wrapper = shallow(<IdeButton kind="ghost" className="extra-class" />);
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn--ghost')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn--ghost`)).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -190,7 +194,7 @@ describe('Small Button', () => {
     );
 
     it('Has the expected classes for small', () => {
-      expect(wrapper.dive().hasClass('bx--btn--sm')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn--sm`)).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -206,7 +210,7 @@ describe('DangerButton', () => {
     );
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn--danger')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn--danger`)).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -222,7 +226,9 @@ describe('danger--primaryButton', () => {
     );
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn--danger--primary')).toEqual(true);
+      expect(
+        wrapper.dive().hasClass(`${prefix}--btn--danger--primary`)
+      ).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {
@@ -238,7 +244,7 @@ describe('TertiaryButton', () => {
     );
 
     it('Has the expected classes', () => {
-      expect(wrapper.dive().hasClass('bx--btn--tertiary')).toEqual(true);
+      expect(wrapper.dive().hasClass(`${prefix}--btn--tertiary`)).toEqual(true);
     });
 
     it('Should add extra classes that are passed via className', () => {

--- a/packages/cdai/src/components/IdeCreate/ide-create.test.js
+++ b/packages/cdai/src/components/IdeCreate/ide-create.test.js
@@ -11,6 +11,8 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import IdeCreate from './ide-create';
 import IdeCreateStep from './ide-create-step';
+import { settings } from 'carbon-components';
+const { prefix } = settings;
 
 configure({ adapter: new Adapter() });
 
@@ -45,7 +47,7 @@ const propsNoCancel = {
 it('should render correct contents', () => {
   const wrapper = mount(<IdeCreate {...props} />);
   expect(wrapper.find('.ide-create-container')).toHaveLength(1);
-  const secondaryButton = wrapper.find('.bx--btn--secondary');
+  const secondaryButton = wrapper.find(`.${prefix}--btn--secondary`);
   expect(secondaryButton).toHaveLength(1);
   const secondaryNode = secondaryButton.getDOMNode();
   expect(secondaryNode).toBeDefined();
@@ -57,7 +59,7 @@ it('should render correct contents with a launch out link', () => {
   props.externalLink = true;
   const wrapper = mount(<IdeCreate {...props} />);
   expect(wrapper.find('.ide-create-container')).toHaveLength(1);
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton.props().renderIcon).not.toEqual(null);
   wrapper.unmount();
 });
@@ -65,7 +67,7 @@ it('should render correct contents with a launch out link', () => {
 it('should render correct contents with no cancel step', () => {
   const wrapper = mount(<IdeCreate {...propsNoCancel} />);
   expect(wrapper.find('.ide-create-container')).toHaveLength(1);
-  const secondaryButton = wrapper.find('.bx--btn--secondary');
+  const secondaryButton = wrapper.find(`.${prefix}--btn--secondary`);
   expect(secondaryButton).toHaveLength(0);
   props.buttonTextStepNext = 'Next';
   wrapper.unmount();
@@ -80,7 +82,7 @@ it('should render correct contents with hidden next button', () => {
     </IdeCreate>
   );
   expect(wrapper.find('.ide-create-container')).toHaveLength(1);
-  const secondaryButton = wrapper.find('.bx--btn--secondary');
+  const secondaryButton = wrapper.find(`.${prefix}--btn--secondary`);
   expect(secondaryButton).toHaveLength(1);
   const secondaryNode = secondaryButton.getDOMNode();
   expect(secondaryNode).toBeDefined();
@@ -99,7 +101,7 @@ it('should move to the next panel', () => {
   const instance = wrapper.instance();
   instance.setNextPage();
   expect(instance.state.step).toBe(1);
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   const primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
@@ -114,7 +116,7 @@ it('should disable the next button when stepNextDisabled is true', () => {
       <IdeCreateStep />
     </IdeCreate>
   );
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton.props().disabled).toBe(true);
   const instance = wrapper.instance();
   instance.setNextPage();
@@ -132,7 +134,7 @@ it('should move to the next panel using internal function', () => {
   const instance = wrapper.instance();
   instance._handleNextButton();
   expect(instance.state.step).toBe(1);
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   const primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
@@ -155,7 +157,7 @@ it('should move to the previous panel', () => {
   expect(instance.state.step).toBe(1);
   instance._handleBackButton();
   expect(instance.state.step).toBe(0);
-  const secondaryButton = wrapper.find('.bx--btn--secondary');
+  const secondaryButton = wrapper.find(`.${prefix}--btn--secondary`);
   expect(secondaryButton).toHaveLength(1);
   const secondaryNode = secondaryButton.getDOMNode();
   expect(secondaryNode).toBeDefined();
@@ -170,7 +172,7 @@ it('should render single panel for form only', () => {
       <IdeCreateStep />
     </IdeCreate>
   );
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   const primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
@@ -189,7 +191,7 @@ it('should set action button disabled', () => {
   const instance = wrapper.instance();
   instance.setNextPage();
   instance.setActionButtonDisabled(true);
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   const primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
@@ -206,14 +208,14 @@ it('should set action button disabled when formActionDisabled is true', () => {
   );
   const instance = wrapper.instance();
   instance.setNextPage();
-  let primaryButton = wrapper.find('.bx--btn--primary');
+  let primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   let primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
   expect(primaryNode.disabled).toBeTruthy();
   wrapper.setProps({ formActionDisabled: false });
   wrapper.update();
-  primaryButton = wrapper.find('.bx--btn--primary');
+  primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   primaryNode = primaryButton.getDOMNode();
   expect(primaryNode).toBeDefined();
@@ -242,15 +244,15 @@ it('should call the callback functions', () => {
       <IdeCreateStep />
     </IdeCreate>
   );
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   primaryButton.simulate('click');
   expect(onFormAction).toHaveBeenCalled();
-  const secondaryButton = wrapper.find('.bx--btn--secondary');
+  const secondaryButton = wrapper.find(`.${prefix}--btn--secondary`);
   expect(secondaryButton).toHaveLength(1);
   secondaryButton.simulate('click');
   expect(onCancel).toHaveBeenCalledTimes(1);
-  const breadcrumb = wrapper.find('.ide-create-breadcrumb .bx--link');
+  const breadcrumb = wrapper.find(`.${prefix}--link`);
   expect(breadcrumb).toHaveLength(1);
   breadcrumb.simulate('click');
   expect(onCancel).toHaveBeenCalledTimes(1);
@@ -267,7 +269,7 @@ it('should call consumers callback on breadcrumb is no breadCrumbURL, but define
       <IdeCreateStep />
     </IdeCreate>
   );
-  const breadcrumb = wrapper.find('.ide-create-breadcrumb .bx--link');
+  const breadcrumb = wrapper.find(`.${prefix}--link`);
   expect(breadcrumb).toHaveLength(1);
   breadcrumb.simulate('click');
   expect(propsWithCallback.breadCrumbCallback).toHaveBeenCalledTimes(1);
@@ -387,7 +389,7 @@ it('should show progress indicator when there are multiple steps', () => {
   const progress = wrapper.find('.ide-create-progress-container');
   expect(progress).toHaveLength(1);
 
-  const steps = progress.find('.bx--progress-step');
+  const steps = progress.find(`.${prefix}--progress-step`);
   expect(steps.length).toEqual(2);
 
   // click on second step
@@ -406,14 +408,14 @@ it('should show progress indicator when there are multiple steps and a pre-check
       <IdeCreateStep label="two" />
     </IdeCreate>
   );
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   primaryButton.simulate('click');
 
   const progress = wrapper.find('.ide-create-progress-container');
   expect(progress).toHaveLength(1);
 
-  const steps = progress.find('.bx--progress-step');
+  const steps = progress.find(`.${prefix}--progress-step`);
   expect(steps.length).toEqual(2);
 
   // click on second step
@@ -451,14 +453,14 @@ it('should not click on a disabled step when usePreCheck is set', () => {
     </IdeCreate>
   );
 
-  const primaryButton = wrapper.find('.bx--btn--primary');
+  const primaryButton = wrapper.find(`.${prefix}--btn--primary`);
   expect(primaryButton).toHaveLength(1);
   primaryButton.simulate('click');
 
   const progress = wrapper.find('.ide-create-progress-container');
   expect(progress).toHaveLength(1);
 
-  const steps = progress.find('.bx--progress-step');
+  const steps = progress.find(`.${prefix}--progress-step`);
   expect(steps.length).toEqual(2);
 
   // click on second step - disabled

--- a/packages/cdai/src/components/IdeDataTable/IdeDataTable.spec.js
+++ b/packages/cdai/src/components/IdeDataTable/IdeDataTable.spec.js
@@ -20,6 +20,7 @@ import { rows, headers } from './fixtures/table.data.js';
 const baseComponent = (props = {}) =>
   jth.getJSXForComponent(IdeDataTable, { rows: [], headers: [] }, props);
 const prefix = (value) => `test-prefix-${value}`;
+import { settings } from 'carbon-components';
 
 describe('<IdeDataTable>', () => {
   beforeAll(() => {
@@ -475,7 +476,7 @@ describe('<IdeDataTable>', () => {
       component
         .find(idAttributeSelector('table-row-0'))
         .at(1)
-        .hasClass('bx--data-table--selected')
+        .hasClass(`${settings.prefix}--data-table--selected`)
     ).toEqual(false);
 
     component
@@ -487,7 +488,7 @@ describe('<IdeDataTable>', () => {
       component
         .find(idAttributeSelector('table-row-0'))
         .at(1)
-        .hasClass('bx--data-table--selected')
+        .hasClass(`${settings.prefix}--data-table--selected`)
     ).toEqual(true);
   });
 

--- a/packages/cdai/src/components/IdeHome/IdeHome.spec.js
+++ b/packages/cdai/src/components/IdeHome/IdeHome.spec.js
@@ -16,6 +16,8 @@ import {
 } from './test_assets/testProps.js';
 import { idAttributeSelector } from '../../component_helpers/IDHelper';
 import * as jth from '../../component_helpers/jest_test_helper_functions.js';
+import { settings } from 'carbon-components';
+const { prefix } = settings;
 
 describe('IdeHome unit tests', () => {
   let component, unmount;
@@ -38,19 +40,19 @@ describe('IdeHome unit tests', () => {
     const testClassNames = {
       'IdeHome-Header-Text': [
         'ide-home-heading-container',
-        'bx--col-sm-1',
-        'bx--col-md-2',
-        'bx--col-lg-6',
-        'bx--col-xlg-6',
-        'bx--col-max-6',
+        `${prefix}--col-sm-1`,
+        `${prefix}--col-md-2`,
+        `${prefix}--col-lg-6`,
+        `${prefix}--col-xlg-6`,
+        `${prefix}--col-max-6`,
       ],
       'IdeHome-Header-Image': [
         'ide-home-image-container',
-        'bx--col-sm-3',
-        'bx--col-md-6',
-        'bx--col-lg-10',
-        'bx--col-xlg-10',
-        'bx--col-max-10',
+        `${prefix}--col-sm-3`,
+        `${prefix}--col-md-6`,
+        `${prefix}--col-lg-10`,
+        `${prefix}--col-xlg-10`,
+        `${prefix}--col-max-10`,
       ],
     };
     mountTestComponent();
@@ -101,27 +103,27 @@ describe('IdeHome unit tests', () => {
     const testClassNames = {
       'IdeHome-Header-Text': [
         'ide-home-heading-container',
-        'bx--col-sm-2',
-        'bx--col-md-3',
-        'bx--col-lg-6',
-        'bx--col-xlg-6',
-        'bx--col-max-6',
+        `${prefix}--col-sm-2`,
+        `${prefix}--col-md-3`,
+        `${prefix}--col-lg-6`,
+        `${prefix}--col-xlg-6`,
+        `${prefix}--col-max-6`,
       ],
       'IdeHome-Header-Image': [
         'ide-home-image-container',
-        'bx--col-sm-2',
-        'bx--col-md-3',
-        'bx--col-lg-8',
-        'bx--col-xlg-8',
-        'bx--col-max-8',
+        `${prefix}--col-sm-2`,
+        `${prefix}--col-md-3`,
+        `${prefix}--col-lg-8`,
+        `${prefix}--col-xlg-8`,
+        `${prefix}--col-max-8`,
       ],
       'IdeHome-header-toggle-container': [
         'ide-home-header-toggle-container',
-        'bx--col-sm-1',
-        'bx--col-md-2',
-        'bx--col-lg-2',
-        'bx--col-xlg-2',
-        'bx--col-max-2',
+        `${prefix}--col-sm-1`,
+        `${prefix}--col-md-2`,
+        `${prefix}--col-lg-2`,
+        `${prefix}--col-xlg-2`,
+        `${prefix}--col-max-2`,
       ],
     };
     const props = withCollapsibleAbility();
@@ -140,19 +142,19 @@ describe('IdeHome unit tests', () => {
     const testClassNames = {
       'IdeHome-Header-Text': [
         'ide-home-heading-container',
-        'bx--col-sm-3',
-        'bx--col-md-6',
-        'bx--col-lg-14',
-        'bx--col-xlg-14',
-        'bx--col-max-14',
+        `${prefix}--col-sm-3`,
+        `${prefix}--col-md-6`,
+        `${prefix}--col-lg-14`,
+        `${prefix}--col-xlg-14`,
+        `${prefix}--col-max-14`,
       ],
       'IdeHome-header-toggle-container': [
         'ide-home-header-toggle-container',
-        'bx--col-sm-1',
-        'bx--col-md-2',
-        'bx--col-lg-2',
-        'bx--col-xlg-2',
-        'bx--col-max-2',
+        `${prefix}--col-sm-1`,
+        `${prefix}--col-md-2`,
+        `${prefix}--col-lg-2`,
+        `${prefix}--col-xlg-2`,
+        `${prefix}--col-max-2`,
       ],
     };
     let props = withCollapsibleAbility();
@@ -160,7 +162,7 @@ describe('IdeHome unit tests', () => {
     mountTestComponent(null, props);
     expect(
       component.find(idAttributeSelector('IdeHome-Header')).prop('className')
-    ).toEqual('collapsed ide-home-header bx--row');
+    ).toEqual(`collapsed ide-home-header ${prefix}--row`);
     for (let [id, classNames] of Object.entries(testClassNames)) {
       classNames.map((className) => {
         expect(

--- a/packages/cdai/src/components/IdeTableToolbarSearch/IdeTableToolbarSearch.spec.js
+++ b/packages/cdai/src/components/IdeTableToolbarSearch/IdeTableToolbarSearch.spec.js
@@ -8,6 +8,8 @@
 import React from 'react';
 import { IdeTableToolbarSearch } from '../IdeTableToolbarSearch';
 import { shallow } from 'enzyme';
+import { settings } from 'carbon-components';
+const { prefix } = settings;
 
 describe('IdeTableToolbarSearch', () => {
   describe('Renders as expected by default', () => {
@@ -23,7 +25,9 @@ describe('IdeTableToolbarSearch', () => {
     it('Should have the correct classes', () => {
       expect(wrapper.dive().hasClass('ide-table-toolbar-search')).toBe(true);
       expect(
-        wrapper.dive().hasClass('bx--toolbar-search-container-expandable')
+        wrapper
+          .dive()
+          .hasClass(`${prefix}--toolbar-search-container-expandable`)
       ).toBe(true);
     });
   });
@@ -37,7 +41,9 @@ describe('IdeTableToolbarSearch', () => {
     it('Should have the correct classes', () => {
       expect(wrapper.dive().hasClass('ide-table-toolbar-search')).toBe(true);
       expect(
-        wrapper.dive().hasClass('bx--toolbar-search-container-expandable')
+        wrapper
+          .dive()
+          .hasClass(`${prefix}--toolbar-search-container-expandable`)
       ).toBe(true);
     });
 


### PR DESCRIPTION
Contributes to #1387

#### What did you change?

Changed some tests to use settings.prefix from carbon-components.  This is in preparation for Carbon 11 which will move away from the 'bx' prefix.

#### How did you test and verify your work?

Ran the tests.
