### PR TITLE
fix(ComponentPlayground): fix carbon settings import

### DIFF
--- a/packages/core/src/component-playground/ComponentPlayground.js
+++ b/packages/core/src/component-playground/ComponentPlayground.js
@@ -17,7 +17,7 @@ import {
   TearsheetNarrow,
   TearsheetWide,
 } from './components';
-import { carbon } from '../../../../../cloud-cognitive/src/settings';
+import { carbon } from '../../../cloud-cognitive/src/settings';
 //import { CardData } from './data';
 
 const App = () => {


### PR DESCRIPTION
In one of the previous carbon prefix PRs, the settings import was incorrect which caused the netlify build to fail.