### PR TITLE
chore(DataSpreadsheet): use color token for active cell

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -114,6 +114,7 @@
       padding-bottom: $spacing-01;
       border: $spacing-01 solid $interactive-01;
       background-color: $ui-background;
+      color: $text-01;
       text-align: left;
 
       &[data-active-row-index='header'],


### PR DESCRIPTION
I noticed that the color for the active cell element was not set, so when I checked this component on one of the carbon dark modes, you could not see the content of the active cell.

#### What did you change?
`_data-spreadsheet.scss`
#### How did you test and verify your work?
Storybook