### PR TITLE
fix: add select avatar and userprofileimage update

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -18,6 +18,7 @@ import {
 import { ChevronRight16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { UserProfileImage } from '../UserProfileImage';
 import { pkg } from '../../settings';
 const componentName = 'AddSelectList';
 
@@ -79,6 +80,16 @@ export let AddSelectList = ({
 
   const isSelected = (id) => multiSelection.includes(id);
 
+  const getAvatarProps = ({ src, alt, icon, backgroundColor }) => ({
+    className: `${blockClass}-cell-avatar`,
+    size: 'lg',
+    theme: 'light',
+    image: src,
+    imageDescription: alt,
+    icon,
+    backgroundColor,
+  });
+
   return (
     <div className={`${blockClass}-wrapper`}>
       <StructuredListWrapper selection className={`${blockClass}`}>
@@ -104,15 +115,22 @@ export let AddSelectList = ({
                           checked={isSelected(item.id)}
                           className={`${blockClass}-checkbox-wrapper`}
                         />
-                        <div className={`${blockClass}-checkbox-label-text`}>
-                          <span className={`${blockClass}-cell-title`}>
-                            {item.title}
-                          </span>
-                          {item.subtitle && (
-                            <span className={`${blockClass}-cell-subtitle`}>
-                              {item.subtitle}
-                            </span>
+                        <div className={`${blockClass}-checkbox-label-wrapper`}>
+                          {item.avatar && (
+                            <UserProfileImage
+                              {...getAvatarProps(item.avatar)}
+                            />
                           )}
+                          <div className={`${blockClass}-checkbox-label-text`}>
+                            <span className={`${blockClass}-cell-title`}>
+                              {item.title}
+                            </span>
+                            {item.subtitle && (
+                              <span className={`${blockClass}-cell-subtitle`}>
+                                {item.subtitle}
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </div>
                       {modifiers?.options?.length && (

--- a/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
+++ b/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
@@ -73,10 +73,14 @@
       align-items: center;
     }
 
+    &-checkbox-label-wrapper {
+      display: flex;
+      margin-left: $spacing-05;
+    }
+
     &-checkbox-label-text {
       display: flex;
       flex-direction: column;
-      padding-left: $spacing-05;
     }
 
     &-checkbox-wrapper.#{$carbon-prefix}--form-item {
@@ -85,6 +89,10 @@
 
     &-checkbox-wrapper .#{$carbon-prefix}--checkbox-label-text {
       display: none;
+    }
+
+    &-cell-avatar {
+      margin-right: $spacing-05;
     }
   }
 

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -14,6 +14,8 @@ import {
 import { MultiAddSelect } from '.';
 import mdx from './MultiAddSelect.mdx';
 // import { action } from '@storybook/addon-actions';
+import image from '../UserProfileImage/headshot.png'; // cspell:disable-line
+import { Group24 } from '@carbon/icons-react';
 
 export default {
   title: getStoryTitle(MultiAddSelect.displayName),
@@ -152,6 +154,45 @@ export const WithModifiers = prepareStory(Template, {
           value: '3',
           title: 'item 3',
           subtitle: 'item 3 subtitle',
+        },
+      ],
+    },
+  },
+});
+
+export const WithAvatars = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    items: {
+      entries: [
+        {
+          id: '1',
+          value: '1',
+          title: 'item 1',
+          subtitle: 'item 1 subtitle',
+          avatar: {
+            src: image,
+            alt: 'head shot',
+          },
+        },
+        {
+          id: '2',
+          value: '2',
+          title: 'item 2',
+          subtitle: 'item 2 subtitle',
+          avatar: {
+            icon: Group24,
+            backgroundColor: 'dark-green',
+          },
+        },
+        {
+          id: '3',
+          value: '3',
+          title: 'item 3',
+          subtitle: 'item 3 subtitle',
+          avatar: {
+            icon: Group24,
+          },
         },
       ],
     },

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
@@ -43,6 +43,7 @@ export let UserProfileImage = React.forwardRef(
       backgroundColor,
       className,
       kind,
+      icon,
       initials,
       image,
       imageDescription,
@@ -81,17 +82,45 @@ export let UserProfileImage = React.forwardRef(
         .toUpperCase();
     };
 
-    const FillItem = image
-      ? () => (
+    const getFillItem = () => {
+      if (image) {
+        return () => (
           <img
             alt={imageDescription}
             src={image}
             className={`${blockClass}__photo ${blockClass}__photo--${size}`}
           />
-        )
-      : initials
-      ? formatInitials
-      : kind && size && icons[kind][size];
+        );
+      }
+      if (initials) {
+        return formatInitials;
+      }
+      if (kind && size) {
+        return icons[kind][size];
+      }
+      return icon;
+    };
+
+    // if user doesn't provide a color just generate a random one
+    const getRandomColor = () => {
+      const colors = [
+        'light-cyan',
+        'dark-cyan',
+        'light-gray',
+        'dark-gray',
+        'light-green',
+        'dark-green',
+        'light-magenta',
+        'dark-magenta',
+        'light-purple',
+        'dark-purple',
+        'light-teal',
+        'dark-teal',
+      ];
+      return colors[Math.floor(Math.random() * colors.length)];
+    };
+
+    const FillItem = getFillItem();
 
     const renderUserProfileImage = () => (
       <div
@@ -105,7 +134,7 @@ export let UserProfileImage = React.forwardRef(
           className,
           `${blockClass}--${size}`,
           `${blockClass}--${theme}`,
-          `${blockClass}--${backgroundColor}`,
+          `${blockClass}--${backgroundColor || getRandomColor()}`,
         ])}
         {...getDevtoolsProps(componentName)}
       >
@@ -158,6 +187,11 @@ UserProfileImage.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Provide a custom icon to use if you need to use an icon other than the included ones
+   */
+  icon: PropTypes.object,
 
   /**
    * When passing the image prop, supply a full path to the image to be displayed.

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
@@ -13,6 +13,7 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg, carbon } from '../../settings';
 
 import { UserProfileImage } from '.';
+import { Group24 } from '@carbon/icons-react';
 
 const blockClass = `${pkg.prefix}--user-profile-image`;
 const componentName = UserProfileImage.displayName;
@@ -111,4 +112,13 @@ describe(componentName, () => {
     expectError(required('imageDescription', 'UserProfileImage'), () => {
       renderComponent({ image: 'path_to_image.jpg' });
     }));
+
+  it('should display a custom icon if one is provided', () => {
+    const { container } = renderComponent({
+      icon: Group24,
+      kind: null,
+    });
+    const renderedSVG = container.querySelector('svg');
+    expect(renderedSVG).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Contributes to #1850 and #1851

this PR accomplishes two things.

1. it allows `UserProfileImage` to accept an optional icon to display in lieu of the built in ones. i also included an additional utility to add a random background color if one is not provided.
2. adds avatar support to add select.

<img width="1343" alt="Screen Shot 2022-03-29 at 3 18 13 PM" src="https://user-images.githubusercontent.com/6370760/160699714-773fb27c-f2cc-45c9-9361-d3fa5e921f66.png">
