### PR TITLE
fix(PageHeader): issue1789 a11y issues BreadcrumbWithOverflow & ActionBar

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
@@ -65,21 +65,26 @@ export let ActionBar = React.forwardRef(
           aria-hidden={true}
           ref={sizingRef}
         >
-          <ActionBarOverflowItems
-            className={`${blockClass}__hidden-sizing-item`}
-            overflowAriaLabel="hidden sizing overflow items"
-            overflowItems={[]}
-            key="hidden-overflow-menu"
-          ></ActionBarOverflowItems>
-          {actions.map(({ key, id, ...rest }) => (
-            <ActionBarItem
-              {...rest}
-              // ensure id is not duplicated
-              data-original-id={id}
-              key={`hidden-item-${key}`}
+          {/* aria-hidden false is needed to prevent accessibility failure */}
+          {/* "Element "button" should not be focusable within the subtree of an */}
+          {/* element with an 'aria-hidden' attribute with value 'true'." */}
+          <span aria-hidden={false}>
+            <ActionBarOverflowItems
               className={`${blockClass}__hidden-sizing-item`}
-            />
-          ))}
+              overflowAriaLabel="hidden sizing overflow items"
+              overflowItems={[]}
+              key="hidden-overflow-menu"
+            ></ActionBarOverflowItems>
+            {actions.map(({ key, id, ...rest }) => (
+              <ActionBarItem
+                {...rest}
+                // ensure id is not duplicated
+                data-original-id={id}
+                key={`hidden-item-${key}`}
+                className={`${blockClass}__hidden-sizing-item`}
+              />
+            ))}
+          </span>
         </div>
       );
     }, [actions]);

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
@@ -141,7 +141,9 @@ describe(ActionBar.displayName, () => {
     expect(menuItemNotSeen).toBeNull();
 
     // Click overflow button and check for last action
-    const ofBtn = screen.getByLabelText(overflowAriaLabel);
+    const ofBtn = screen.getByLabelText(overflowAriaLabel, {
+      selector: `.${blockClass}-overflow-items`,
+    });
     userEvent.click(ofBtn);
 
     // <ul role='menu' /> but default <ul> role of list used for query

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBarOverflowItems.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBarOverflowItems.js
@@ -35,9 +35,10 @@ export const ActionBarOverflowItems = ({
       className={cx(blockClass, className)}
       direction="bottom"
       flipped
+      iconDescription={overflowAriaLabel} // also needs setting to avoid a11y "Accessible name does not match or contain the visible label text"
       menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
     >
-      {React.Children.map(overflowItems, (item) => {
+      {React.Children.map(overflowItems, (item, index) => {
         // This uses a copy of a menu item option
         // NOTE: Cannot use a real Tooltip icon below as it uses a <button /> the
         // div equivalent below is based on Carbon 10.25.0
@@ -47,11 +48,11 @@ export const ActionBarOverflowItems = ({
             itemText={
               <div
                 className={`${blockClass}__item-content`}
-                aria-describedby={`${internalId}--item-label`}
+                aria-describedby={`${internalId.current}-${index}--item-label`}
               >
                 <span
                   className={`${blockClass}__item-label`}
-                  id={`${internalId}--item-label`}
+                  id={`${internalId.current}-${index}--item-label`}
                 >
                   {item.props.iconDescription}
                 </span>

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -57,6 +57,7 @@ export let BreadcrumbWithOverflow = ({
       <BreadcrumbItem key={`breadcrumb-overflow-${internalId.current}`}>
         <OverflowMenu
           ariaLabel={overflowAriaLabel}
+          iconDescription={overflowAriaLabel} // also needs setting to avoid a11y "Accessible name does not match or contain the visible label text"
           renderIcon={OverflowMenuHorizontal32}
           className={`${blockClass}__overflow-menu`}
           menuOptionsClass={`${blockClass}__overflow-menu-options`}


### PR DESCRIPTION
Contributes to #1789

Fixes A11y issues raised in #1789 that can be addressed directly. The right/left scroll buttons which can be shown by tabs needs an update to Carbon https://github.com/carbon-design-system/carbon/issues/11109

#### What did you change?

- Added `icon-description` properties to match `aria-label` when creating overflows for breadcrumb and action bar items.
- Wrapped aria-hidden buttons with an inner aria-hidden={false} as suggested by a11y checker.
- Corrected label id used by hidden action bar items

#### How did you test and verify your work?
Storybook, a11y checker and tests.