### PR TITLE
fix(DataSpreadsheet): browser fix, update selectionArea on cell updates

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetOutsideClick.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetOutsideClick.js
@@ -7,6 +7,7 @@
 
 import { useEffect } from 'react';
 import { pkg } from '../../../settings';
+import { removeCellSelections } from '../utils/removeCellSelections';
 
 // Click outside useEffect for spreadsheet
 export const useSpreadsheetOutsideClick = ({
@@ -15,7 +16,6 @@ export const useSpreadsheetOutsideClick = ({
   setActiveCellCoordinates,
   setSelectionAreas,
   removeActiveCell,
-  removeCellSelections,
   setContainerHasFocus,
   activeKeys,
   removeCellEditor,
@@ -37,7 +37,7 @@ export const useSpreadsheetOutsideClick = ({
       setActiveCellCoordinates(null);
       setSelectionAreas([]);
       removeActiveCell();
-      removeCellSelections();
+      removeCellSelections({ spreadsheetRef });
       setContainerHasFocus(false);
       removeCellEditor();
       activeKeys.current = [];
@@ -49,7 +49,6 @@ export const useSpreadsheetOutsideClick = ({
   }, [
     spreadsheetRef,
     removeActiveCell,
-    removeCellSelections,
     activeKeys,
     blockClass,
     setActiveCellCoordinates,


### PR DESCRIPTION
Contributes to #1858 

This fixes the issues preventing cell edits in Safari and Firefox. Also removes a duplicate `removeCellSelections` function. Lastly, after submitting cell edits the selection area was not being updated, that was fixed as well.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetOutsideClick.js
```
#### How did you test and verify your work?
Storybook