### PR TITLE
fix: missing package in page header example

### DIFF
--- a/examples/carbon-for-ibm-products/PageHeader/package.json
+++ b/examples/carbon-for-ibm-products/PageHeader/package.json
@@ -7,6 +7,7 @@
     "@carbon/icons-react": "^10",
     "carbon-components": "^10",
     "carbon-components-react": "^7",
+    "carbon-icons": "latest",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-scripts": "4.0.3",

--- a/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
+++ b/examples/carbon-for-ibm-products/example-gallery/src/gallery-config/index.js
@@ -11,49 +11,49 @@ const defaultOrNot = (item) => item.default || item;
 const config = [
   {
     label: 'API Key Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/APIKeyModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/APIKeyModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./APIKeyModal--thumbnail.png')) + ')',
   },
   {
     label: 'About Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/AboutModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/AboutModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./AboutModal--thumbnail.png')) + ')',
   },
   {
     label: 'Cascade',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/Cascade',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/Cascade',
     thumbnail:
       'url( ' + defaultOrNot(require('./Cascade--thumbnail.png')) + ')',
   },
   {
     label: 'Create Full Page',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/CreateFullPage',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/CreateFullPage',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateFullPage--thumbnail.png')) + ')',
   },
   {
     label: 'Create Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/CreateModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/CreateModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateModal--thumbnail.png')) + ')',
   },
   {
     label: 'Create Side Panel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/CreateSidePanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/CreateSidePanel',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateSidePanel--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/CreateTearsheet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/CreateTearsheet',
     thumbnail:
       'url( ' + defaultOrNot(require('./CreateTearsheet--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet Narrow',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/CreateTearsheetNarrow',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/CreateTearsheetNarrow',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./CreateTearsheetNarrow--thumbnail.png')) +
@@ -61,37 +61,37 @@ const config = [
   },
   {
     label: 'Empty State',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/EmptyStates',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/EmptyStates',
     thumbnail:
       'url( ' + defaultOrNot(require('./EmptyStates--thumbnail.png')) + ')',
   },
   {
     label: 'Export Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ExportModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ExportModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./ExportModal--thumbnail.png')) + ')',
   },
   {
     label: 'Expressive Card',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ExpressiveCard',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ExpressiveCard',
     thumbnail:
       'url( ' + defaultOrNot(require('./ExpressiveCard--thumbnail.png')) + ')',
   },
   {
     label: 'HTTP Error',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/HTTPErrors',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/HTTPErrors',
     thumbnail:
       'url( ' + defaultOrNot(require('./HTTPErrors--thumbnail.png')) + ')',
   },
   {
     label: 'Import Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ImportModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ImportModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./ImportModal--thumbnail.png')) + ')',
   },
   {
     label: 'Notifications Panel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/NotificationsPanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/NotificationsPanel',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./NotificationsPanel--thumbnail.png')) +
@@ -99,73 +99,73 @@ const config = [
   },
   {
     label: 'OptionsTile',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/OptionsTile',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/OptionsTile',
     thumbnail:
       'url( ' + defaultOrNot(require('./OptionsTile--thumbnail.png')) + ')',
   },
   {
     label: 'Page Header Example',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/PageHeader',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/PageHeader',
     thumbnail:
       'url( ' + defaultOrNot(require('./PageHeader--thumbnail.png')) + ')',
   },
   {
-    label: 'Productive Card',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ProductiveCard',
+    label: 'ProductiveCard',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ProductiveCard',
     thumbnail:
       'url( ' + defaultOrNot(require('./ProductiveCard--thumbnail.png')) + ')',
   },
   {
-    label: 'Remove Modal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/RemoveModal',
+    label: 'RemoveModal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/RemoveModal',
     thumbnail:
       'url( ' + defaultOrNot(require('./RemoveModal--thumbnail.png')) + ')',
   },
   {
     label: 'Saving',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/Saving',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/Saving',
     thumbnail: 'url( ' + defaultOrNot(require('./Saving--thumbnail.png')) + ')',
   },
   {
-    label: 'Side Panel',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/SidePanel',
+    label: 'SidePanel',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/SidePanel',
     thumbnail:
       'url( ' + defaultOrNot(require('./SidePanel--thumbnail.png')) + ')',
   },
   {
-    label: 'Status icon',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/StatusIcon',
+    label: 'StatusIcon',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/StatusIcon',
     thumbnail:
       'url( ' + defaultOrNot(require('./StatusIcon--thumbnail.png')) + ')',
   },
   {
-    label: 'Tagset',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/TagSet',
+    label: 'TagSet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/TagSet',
     thumbnail: 'url( ' + defaultOrNot(require('./TagSet--thumbnail.png')) + ')',
   },
   {
     label: 'Tearsheet',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/Tearsheet',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/Tearsheet',
     thumbnail:
       'url( ' + defaultOrNot(require('./Tearsheet--thumbnail.png')) + ')',
   },
   {
-    label: 'User Profile Image',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/UserProfileImage',
+    label: 'UserProfileImage',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/UserProfileImage',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./UserProfileImage--thumbnail.png')) +
       ')',
   },
   {
-    label: 'Web Terminal',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/WebTerminal',
+    label: 'WebTerminal',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/WebTerminal',
     thumbnail:
       'url( ' + defaultOrNot(require('./WebTerminal--thumbnail.png')) + ')',
   },
   {
     label: 'React 16 usage',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ccs-base-react-16',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ccs-base-react-16',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./ccs-base-react-16--thumbnail.png')) +
@@ -173,7 +173,7 @@ const config = [
   },
   {
     label: 'React 17 usage',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/ccs-base-react-17',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/ccs-base-react-17',
     thumbnail:
       'url( ' +
       defaultOrNot(require('./ccs-base-react-17--thumbnail.png')) +
@@ -181,7 +181,7 @@ const config = [
   },
   {
     label: 'Prefix CSS/JS Example',
-    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-products/tree/main/examples/carbon-for-ibm-products/prefix-example',
+    url: 'https://codesandbox.io/s/github/carbon-design-system/ibm-cloud-cognitive/tree/main/examples/carbon-for-ibm-products/prefix-example',
     thumbnail:
       'url( ' + defaultOrNot(require('./prefix-example--thumbnail.png')) + ')',
   },


### PR DESCRIPTION
The page header example was missing 'carbon-icons' in package.json