### PR TITLE
fix(DataSpreadsheet): correct cursor placement

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -89,7 +89,10 @@ export let DataSpreadsheet = React.forwardRef(
     const [currentMatcher, setCurrentMatcher] = useState('');
     const [isEditing, setIsEditing] = useState(false);
     const [cellEditorValue, setCellEditorValue] = useState('');
-    const previousState = usePreviousValue({ activeCellCoordinates });
+    const previousState = usePreviousValue({
+      activeCellCoordinates,
+      isEditing,
+    });
     const cellSizeValue = getCellSize(cellSize);
     const cellEditorRef = useRef();
     const [activeCellContent, setActiveCellContent] = useState();
@@ -504,6 +507,18 @@ export let DataSpreadsheet = React.forwardRef(
       setCellEditorValue(activeCellValue);
       cellEditorRulerRef.current.textContent = activeCellValue;
     };
+
+    // Sets the initial placement of the cell editor cursor at the end of the text area
+    // this is not done for us by default in Safari
+    useEffect(() => {
+      if (isEditing && !previousState?.isEditing) {
+        cellEditorRef.current.setSelectionRange(
+          cellEditorRulerRef.current.textContent.length,
+          cellEditorRulerRef.current.textContent.length
+        );
+        cellEditorRef.current.focus();
+      }
+    }, [isEditing, previousState?.isEditing]);
 
     const handleActiveCellClick = () => {
       if (

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -104,6 +104,7 @@
       overflow: hidden;
       /* stylelint-disable-next-line carbon/layout-token-use */
       padding: 0 calc(#{$spacing-03} + 1px) 0 $spacing-03;
+      margin: 0;
       background-color: $body-cell-background;
       resize: none;
       &.#{$carbon-prefix}--text-area {
@@ -143,6 +144,8 @@
       /* stylelint-disable-next-line carbon/layout-token-use */
       padding-right: calc(#{$spacing-03} - 1px);
       padding-bottom: $spacing-01;
+      /* stylelint-disable-next-line carbon/layout-token-use */
+      padding-left: calc(#{$spacing-03} - #{$spacing-01});
       border: $spacing-01 solid $interactive-01;
       background-color: $body-cell-background;
       color: $text-01;


### PR DESCRIPTION
Contributes to #1882 

This PR fixes the placement of the text area cursor in Safari. Previously, the cursor was placed at the beginning of the content in the text area, now it is placed at the end of the content of the cell being edited.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
```
#### How did you test and verify your work?
Storybook