### PR TITLE
fix: add outline tag type and test

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -781,6 +781,7 @@ const TYPES = {
   'cool-gray': 'Cool-Gray',
   'warm-gray': 'Warm-Gray',
   'high-contrast': 'High-Contrast',
+  outline: 'Outline',
 };
 const tagTypes = Object.keys(TYPES);
 
@@ -800,6 +801,8 @@ export const deprecatedProps = {
     'Property replaced by `withoutBackground`'
   ),
 };
+
+PageHeader.tagTypes = tagTypes;
 
 PageHeader.propTypes = {
   /**

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -23,6 +23,8 @@ import {
   required,
 } from '../../global/js/utils/test-helper';
 
+import { types as tagTypes } from 'carbon-components-react/lib/components/Tag/Tag.js';
+
 const { prefix } = pkg;
 
 const blockClass = `${prefix}--page-header`;
@@ -705,5 +707,15 @@ describe('PageHeader', () => {
     render(<PageHeader {...testProps} pageActions={pageActionsCustom} />);
 
     screen.getAllByText('Custom page action');
+  });
+
+  test('Has the same tag types as Carbon Tag', () => {
+    // Same number of tags
+    expect(PageHeader.tagTypes.length).toEqual(tagTypes.length);
+
+    // Same value for each tag
+    for (let i = 0; i < tagTypes.length; i++) {
+      expect(PageHeader.tagTypes).toContain(tagTypes[i]);
+    }
   });
 });

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -289,6 +289,7 @@ const TYPES = {
   'cool-gray': 'Cool-Gray',
   'warm-gray': 'Warm-Gray',
   'high-contrast': 'High-Contrast',
+  outline: 'Outline',
 };
 const tagTypes = Object.keys(TYPES);
 

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
@@ -12,6 +12,8 @@ import { pkg, carbon } from '../../settings';
 import { TagSet } from '.';
 import { TagSetModal } from './TagSetModal';
 
+import { types as tagTypes } from 'carbon-components-react/lib/components/Tag/Tag.js';
+
 import {
   expectMultipleError,
   mockHTMLElement,
@@ -25,9 +27,8 @@ const blockClass = `${pkg.prefix}--tag-set`;
 const blockClassOverflow = `${prefix}--tag-set-overflow`;
 
 const tagLabel = (index) => `Tag ${index + 1}`;
-const types = ['red', 'blue', 'cyan', 'high-contrast'];
 const tags = Array.from({ length: 20 }, (v, k) => ({
-  type: types[k % types.length],
+  type: tagTypes[k % tagTypes.length],
   ['data-search']: `${k === 11 ? 'dozen 1100' : Number(k + 1).toString(2)}`, // adds binary value for data-search test
   label: tagLabel(k),
   id: `id-${k}`,
@@ -76,6 +77,16 @@ describe(TagSet.displayName, () => {
     mockElement.mockRestore();
     jest.restoreAllMocks();
     window.ResizeObserver = ResizeObserver;
+  });
+
+  it('Has the same tag types as Carbon Tag', () => {
+    // Same number of tags
+    expect(TagSet.types.length).toEqual(tagTypes.length);
+
+    // Same value for each tag
+    for (let i = 0; i < tagTypes.length; i++) {
+      expect(TagSet.types).toContain(tagTypes[i]);
+    }
   });
 
   it('Renders all as visible tags when space available', () => {


### PR DESCRIPTION
Closes #1066

#### What did you change?

- Added outline tag type to TagSet and PageHeader. 
- Added tests to verify tag types available to the user.

#### How did you test and verify your work?

Ran tests and storybook.
