### PR TITLE
fix(DataSpreadsheet): updates to keys pressed custom hook

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
@@ -7,6 +7,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePreviousValue } from '../../../global/js/hooks';
+import { includesMeta } from '../utils/handleMultipleKeys';
 
 const hasFocus = () => typeof document !== 'undefined' && document.hasFocus();
 
@@ -43,6 +44,15 @@ export const useMultipleKeyTracking = ({
           // Prevent multiple keys of the same type being added to our keysPressedList array
           if (keysPressedList.includes(event.code)) {
             return;
+          }
+          // Because keyup events are lost when using the Command key
+          // we need to remove the previously pressed key so that we
+          // do not have keys in the pressed list that should not be
+          if (includesMeta(keysPressedList) && keysPressedList.length > 1) {
+            const clonedKeys = [...keysPressedList];
+            clonedKeys.pop();
+            clonedKeys.push(event.code);
+            return setKeysPressedList([...new Set(clonedKeys)]);
           }
           const tempKeys = [...keysPressedList];
           tempKeys.push(event.code);

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleMultipleKeys.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleMultipleKeys.js
@@ -14,7 +14,7 @@ export const includesShift = (arr) => {
   return false;
 };
 
-const includesMeta = (arr) => {
+export const includesMeta = (arr) => {
   if (arr.includes('MetaLeft') || arr.includes('MetaRight')) {
     return true;
   }


### PR DESCRIPTION
Contributes to @lee-chase's comment in https://github.com/carbon-design-system/ibm-cloud-cognitive/pull/1898

When using the command key, keyup events from other keys are lost so I made some updates to the `useMultipleKeyTracking` hook so that all other keys are cleared out. This fixes the problem @lee-chase noticed in the review of #1898 

#### What did you change?
`useMultipleKeyTracking.js`
#### How did you test and verify your work?
Storybook