### PR TITLE
feat(DataSpreadsheet): add support for multi row/column selections

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -104,6 +104,7 @@
     "datagrid",
     "namor",
     "Prefs",
-    "listbox"
+    "listbox",
+    "overscroll"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -105,6 +105,7 @@
     "namor",
     "Prefs",
     "listbox",
-    "overscroll"
+    "overscroll",
+    "rowgroup"
   ]
 }

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -323,7 +323,8 @@ export const DataSpreadsheetBody = forwardRef(
 
     const handleRowHeaderClick = useCallback(
       (index) => {
-        return () => {
+        return (event) => {
+          const isHoldingCommandKey = event.metaKey || event.ctrlKey;
           handleHeaderCellSelection({
             type: 'row',
             activeCellCoordinates,
@@ -335,6 +336,7 @@ export const DataSpreadsheetBody = forwardRef(
             spreadsheetRef: ref,
             index,
             setSelectionAreaData,
+            isHoldingCommandKey,
           });
         };
       },
@@ -384,7 +386,7 @@ export const DataSpreadsheetBody = forwardRef(
               {...row.getRowProps({ style })}
               className={cx(`${blockClass}__tr`)}
               data-row-index={index}
-              aria-rowindex={index}
+              aria-rowindex={index + 1}
             >
               {/* ROW HEADER BUTTON */}
               <div role="rowheader">
@@ -415,7 +417,7 @@ export const DataSpreadsheetBody = forwardRef(
               {row.cells.map((cell, index) => (
                 <div
                   key={`cell_${index}`}
-                  aria-colindex={index}
+                  aria-colindex={index + 1}
                   {...cell.getCellProps()}
                   role="gridcell"
                   style={{

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -49,7 +49,8 @@ export const DataSpreadsheetHeader = forwardRef(
     }, [cellSize, ref, scrollBarSize, previousState?.cellSize]);
 
     const handleColumnHeaderClick = (index) => {
-      return () => {
+      return (event) => {
+        const isHoldingCommandKey = event.metaKey || event.ctrlKey;
         handleHeaderCellSelection({
           type: 'column',
           activeCellCoordinates,
@@ -61,12 +62,13 @@ export const DataSpreadsheetHeader = forwardRef(
           spreadsheetRef: ref,
           index,
           setSelectionAreaData,
+          isHoldingCommandKey,
         });
       };
     };
 
     return (
-      <div className={cx(`${blockClass}__header--container`)}>
+      <div className={cx(`${blockClass}__header--container`)} role="rowgroup">
         {headerGroups.map((headerGroup, index) => (
           <div
             key={`header_${index}`}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -190,6 +190,9 @@
     .#{$block-class}__td-th--active-header.#{$block-class}__td {
       background-color: $hover-selected-ui;
     }
+    .#{$block-class}__list--container {
+      overscroll-behavior: none;
+    }
   }
 }
 


### PR DESCRIPTION
Contributes to #1907 

This allows you to select multiple columns/rows via header cells. To do this, it is the same interaction as in the body of the spreadsheet, command + click or shift + arrow key.

#### What did you change?
```
cspell.json
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
```
#### How did you test and verify your work?
Storybook