### PR TITLE
feat(DataSpreadsheet): support shortcuts when user agent is not mac

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -41,7 +41,7 @@ import { createActiveCellFn } from './utils/createActiveCellFn';
 import { getCellSize } from './utils/getCellSize';
 import {
   handleMultipleKeys,
-  includesMeta,
+  includesResourceKey,
   includesShift,
 } from './utils/handleMultipleKeys';
 import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
@@ -115,7 +115,7 @@ export let DataSpreadsheet = React.forwardRef(
       }),
       [cellSizeValue]
     );
-    const { keysPressedList } = useMultipleKeyTracking({
+    const { keysPressedList, usingMac } = useMultipleKeyTracking({
       ref: multiKeyTrackingRef,
       containerHasFocus,
       isEditing,
@@ -391,6 +391,7 @@ export let DataSpreadsheet = React.forwardRef(
             removeCellSelections,
             blockClass,
             setCurrentMatcher,
+            usingMac,
           });
         }
         // Allow arrow key navigation if there are less than two activeKeys OR
@@ -403,14 +404,14 @@ export let DataSpreadsheet = React.forwardRef(
           switch (key) {
             // HOME
             case 'Home': {
-              if (includesMeta(keysPressedList)) {
+              if (includesResourceKey(keysPressedList, usingMac)) {
                 return;
               }
               handleHomeEndKey({ type: 'home' });
               break;
             }
             case 'End': {
-              if (includesMeta(keysPressedList)) {
+              if (includesResourceKey(keysPressedList, usingMac)) {
                 return;
               }
               handleHomeEndKey({ type: 'end' });
@@ -535,6 +536,7 @@ export let DataSpreadsheet = React.forwardRef(
         selectionAreas,
         handleHomeEndKey,
         keysPressedList,
+        usingMac,
       ]
     );
 

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react';
 import { usePreviousValue } from '../../../global/js/hooks';
-import { includesMeta } from '../utils/handleMultipleKeys';
+import { includesResourceKey } from '../utils/handleMultipleKeys';
 
 const hasFocus = () => typeof document !== 'undefined' && document.hasFocus();
 
@@ -16,6 +16,7 @@ export const useMultipleKeyTracking = ({
   containerHasFocus,
   isEditing,
 }) => {
+  const [usingMac, setUsingMac] = useState('');
   const [windowFocused, setWindowFocused] = useState(hasFocus);
   const [keysPressedList, setKeysPressedList] = useState([]);
   const previousState = usePreviousValue({ isEditing, windowFocused });
@@ -23,6 +24,12 @@ export const useMultipleKeyTracking = ({
   // useEffect to check for window focus, if window loses focus
   // we need to clear out the keysPressedList
   useEffect(() => {
+    const userAgentString = window.navigator.userAgent;
+    if (userAgentString.includes('Macintosh')) {
+      setUsingMac(true);
+    } else {
+      setUsingMac(false);
+    }
     setWindowFocused(hasFocus());
     const onWindowFocus = () => setWindowFocused(true);
     const onWindowBlur = () => setWindowFocused(false);
@@ -48,7 +55,10 @@ export const useMultipleKeyTracking = ({
           // Because keyup events are lost when using the Command key
           // we need to remove the previously pressed keys so that we
           // do not have keys in the pressed list that should not be
-          if (includesMeta(keysPressedList) && keysPressedList.length > 1) {
+          if (
+            includesResourceKey(keysPressedList, usingMac) &&
+            keysPressedList.length > 1
+          ) {
             const clonedKeys = [...keysPressedList];
             const filteredClonedKeys = clonedKeys.filter(
               (item) => item === 'MetaLeft' || item === 'MetaRight'
@@ -94,6 +104,7 @@ export const useMultipleKeyTracking = ({
     previousState?.isEditing,
     windowFocused,
     previousState?.windowFocused,
+    usingMac,
   ]);
-  return { keysPressedList, windowFocused };
+  return { keysPressedList, windowFocused, usingMac };
 };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleMultipleKeys.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleMultipleKeys.js
@@ -9,6 +9,15 @@ import { deepCloneObject } from '../../../global/js/utils/deepCloneObject';
 import uuidv4 from '../../../global/js/utils/uuidv4';
 import { selectAllCells } from './selectAllCells';
 
+export const includesResourceKey = (arr, usingMac) => {
+  if (usingMac) {
+    return includesMeta(arr);
+  }
+  if (!usingMac) {
+    return includesControl(arr);
+  }
+};
+
 export const includesShift = (arr) => {
   if (arr.includes('ShiftLeft') || arr.includes('ShiftRight')) {
     return true;
@@ -16,7 +25,7 @@ export const includesShift = (arr) => {
   return false;
 };
 
-export const includesMeta = (arr) => {
+const includesMeta = (arr) => {
   if (arr.includes('MetaLeft') || arr.includes('MetaRight')) {
     return true;
   }
@@ -44,6 +53,7 @@ export const handleMultipleKeys = ({
   removeCellSelections,
   blockClass,
   setCurrentMatcher,
+  usingMac,
 }) => {
   const selectionAreasClone = deepCloneObject(selectionAreas);
   const indexOfCurrentArea = selectionAreasClone.findIndex(
@@ -137,7 +147,10 @@ export const handleMultipleKeys = ({
     setSelectionAreas(selectionAreasClone);
   }
   // CMD + a (select all)
-  if (includesMeta(keysPressedList) && keysPressedList.includes('KeyA')) {
+  if (
+    includesResourceKey(keysPressedList, usingMac) &&
+    keysPressedList.includes('KeyA')
+  ) {
     event.preventDefault();
     const selectionPoint1 = {
       row: 0,
@@ -260,7 +273,10 @@ export const handleMultipleKeys = ({
   }
 
   // CMD + HOME (Selects first cell in first row)
-  if (includesMeta(keysPressedList) && keysPressedList.includes('Home')) {
+  if (
+    includesResourceKey(keysPressedList, usingMac) &&
+    keysPressedList.includes('Home')
+  ) {
     const scrollElement = spreadsheetRef.current.querySelector(
       `.${blockClass}__list--container`
     );
@@ -277,7 +293,10 @@ export const handleMultipleKeys = ({
   }
 
   // CMD + END (Selects last cell in last row)
-  if (includesMeta(keysPressedList) && keysPressedList.includes('End')) {
+  if (
+    includesResourceKey(keysPressedList, usingMac) &&
+    keysPressedList.includes('End')
+  ) {
     const scrollElement = spreadsheetRef.current.querySelector(
       `.${blockClass}__list--container`
     );


### PR DESCRIPTION
Contributes to #1912 

If the user agent is not `Macintosh`, some of the keyboard shortcuts needed to be updated. For example, `CMD+A` should become `CTRL+A`. I updated the `useMultipleKeyTracking` hook to return a `usingMac` boolean variable so we can correctly set the keyboard shortcuts.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleMultipleKeys.js
```
#### How did you test and verify your work?
To test this you can:
1. open the browser devtools
2. Click the overflow menu on the right (next to the close icon)
3. Hover over `More tools`
4. Click on `Network conditions`
5. Scroll down to `User agent` section
6. Uncheck `Use browser default` and from the dropdown select `Chrome - Windows` and refresh the page

After these steps, you should be able to test the shortcuts as if you were using Windows