### PR TITLE
chore(DataSpreadsheet): address some items from design review

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -590,6 +590,24 @@ export let DataSpreadsheet = React.forwardRef(
       return;
     };
 
+    // Mouse down on active cell
+    const handleActiveCellMouseDown = () => {
+      if (
+        activeCellCoordinates?.row !== 'header' ||
+        activeCellCoordinates?.column !== 'header'
+      ) {
+        const tempMatcher = uuidv4();
+        setClickAndHoldActive(true);
+        removeCellSelections({ spreadsheetRef });
+        setSelectionAreas([
+          { point1: activeCellCoordinates, matcher: tempMatcher },
+        ]);
+        setCurrentMatcher(tempMatcher);
+        setSelectionAreaData([]);
+      }
+      return;
+    };
+
     // Go into edit mode if 'Enter' key is pressed on activeCellRef
     const handleActiveCellKeyDown = (event) => {
       const { key } = event;
@@ -860,6 +878,7 @@ export let DataSpreadsheet = React.forwardRef(
             defaultEmptyRowCount={defaultEmptyRowCount}
           />
           <button
+            onMouseDown={handleActiveCellMouseDown}
             onClick={handleActiveCellClick}
             onKeyDown={handleActiveCellKeyDown}
             onDoubleClick={handleActiveCellDoubleClick}
@@ -883,7 +902,7 @@ export let DataSpreadsheet = React.forwardRef(
             labelText=""
             aria-labelledby={
               activeCellCoordinates
-                ? `[data-row-index="${activeCellCoordinates?.row}"][data-column-index="${activeCellCoordinates?.column}"]`
+                ? `#${blockClass}__cell--${activeCellCoordinates?.row}--${activeCellCoordinates?.column}`
                 : null
             }
             className={cx(

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -391,6 +391,7 @@ export const DataSpreadsheetBody = forwardRef(
               {/* ROW HEADER BUTTON */}
               <div role="rowheader">
                 <button
+                  id={`${blockClass}__cell--${index}--header`}
                   tabIndex={-1}
                   data-row-index={index}
                   data-column-index="header"
@@ -426,6 +427,7 @@ export const DataSpreadsheetBody = forwardRef(
                   }}
                 >
                   <button
+                    id={`${blockClass}__cell--${cell.row.index}--${index}`}
                     tabIndex={-1}
                     data-row-index={cell.row.index}
                     data-column-index={index}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -105,6 +105,7 @@ export const DataSpreadsheetHeader = forwardRef(
               }}
             >
               <button
+                id={`${blockClass}__cell--header--header`}
                 data-row-index="header"
                 data-column-index="header"
                 type="button"
@@ -133,6 +134,7 @@ export const DataSpreadsheetHeader = forwardRef(
                 {...column.getHeaderProps()}
               >
                 <button
+                  id={`${blockClass}__cell--header--${index}`}
                   data-row-index="header"
                   data-column-index={index}
                   tabIndex={-1}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -59,6 +59,10 @@
       color: $text-01;
     }
 
+    .#{$block-class}__body--td {
+      color: $text-02;
+    }
+
     [role="'columnheader'"]:last-child,
     [role="'gridcell'"]:last-child {
       border-right: 1px solid $text-03;
@@ -113,6 +117,7 @@
       padding: 0 calc(#{$spacing-03} + 1px) 0 $spacing-03;
       margin: 0;
       background-color: $body-cell-background;
+      color: $text-01;
       resize: none;
       &.#{$carbon-prefix}--text-area {
         min-width: initial;
@@ -183,7 +188,7 @@
         height: 100%;
         background-color: $interactive-01;
         content: '';
-        opacity: 0.25;
+        opacity: 0.2;
       }
     }
     .#{$block-class}__th--active-header,


### PR DESCRIPTION
Contributes to #1916 

Addresses some of the design review feedback.

Specifically:
• Remove selection areas if you click and drag on active cell that is already part of a selection area
• Change opacity on selection areas
• Color of body cells changed to `text-02` by default, hover/selected/active states use `text-01`
• Each cell needs unique id
• `aria-labelledby` needs to be an id, cannot be a css selector

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
```
#### How did you test and verify your work?
Storybook