### PR TITLE
feat(DataSpreadsheet): support horizontal scrolling/add sticky headers

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -83,6 +83,7 @@ export let DataSpreadsheet = React.forwardRef(
       id,
       onActiveCellChange = defaults.onActiveCellChange,
       onSelectionAreaChange = defaults.onSelectionAreaChange,
+      totalVisibleColumns,
 
       // Collect any other property values passed in.
       ...rest
@@ -799,6 +800,7 @@ export let DataSpreadsheet = React.forwardRef(
             setSelectionAreas={setSelectionAreas}
             setCurrentMatcher={setCurrentMatcher}
             setSelectionAreaData={setSelectionAreaData}
+            totalVisibleColumns={totalVisibleColumns}
             updateActiveCellCoordinates={updateActiveCellCoordinates}
           />
 
@@ -831,6 +833,7 @@ export let DataSpreadsheet = React.forwardRef(
             columns={columns}
             defaultEmptyRowCount={defaultEmptyRowCount}
             setActiveCellInsideSelectionArea={setActiveCellInsideSelectionArea}
+            totalVisibleColumns={totalVisibleColumns}
           />
           <button
             onMouseDown={handleActiveCellMouseDown}
@@ -958,6 +961,12 @@ DataSpreadsheet.propTypes = {
    * The event handler that is called when the selection area values change
    */
   onSelectionAreaChange: PropTypes.func,
+
+  /**
+   * The total number of columns to be initially visible, additional columns will be rendered and
+   * visible via horizontal scrollbar
+   */
+  totalVisibleColumns: PropTypes.number,
 
   /* TODO: add types and DocGen for all props. */
 };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -86,7 +86,7 @@ const columnData = [
 ];
 
 const Template = ({ ...args }) => {
-  const [data, setData] = useState(() => generateData(16));
+  const [data, setData] = useState(() => generateData({ rows: 16 }));
   const columns = useMemo(() => columnData, []);
 
   return (
@@ -101,7 +101,7 @@ const Template = ({ ...args }) => {
 };
 
 const LargeTemplate = ({ ...args }) => {
-  const [data, setData] = useState(() => generateData(1000));
+  const [data, setData] = useState(() => generateData({ rows: 1000 }));
   const columns = useMemo(() => columnData, []);
 
   return (
@@ -133,6 +133,37 @@ const EmptyWithCellsTemplate = ({ ...args }) => {
   );
 };
 
+const WithManyColumns = ({ ...args }) => {
+  const [data, setData] = useState(() =>
+    generateData({ rows: 24, extraColumns: true })
+  );
+  const columnDataClone = useMemo(
+    () => [
+      ...columnData,
+      {
+        Header: 'Owner name',
+        accessor: 'ownerName',
+      },
+      {
+        Header: 'Weight',
+        accessor: 'weight',
+      },
+    ],
+    []
+  );
+  const columns = useMemo(() => columnDataClone, [columnDataClone]);
+
+  return (
+    <DataSpreadsheet
+      columns={columns}
+      data={data}
+      onDataUpdate={setData}
+      id="spreadsheet--id"
+      {...args}
+    />
+  );
+};
+
 export const dataSpreadsheet = prepareStory(Template, {
   storyName: 'Basic spreadsheet',
   args: {},
@@ -149,5 +180,12 @@ export const emptyWithCells = prepareStory(EmptyWithCellsTemplate, {
   storyName: 'Empty with cells',
   args: {
     defaultEmptyRowCount: 24,
+  },
+});
+
+export const withManyColumns = prepareStory(WithManyColumns, {
+  storyName: 'With many columns',
+  args: {
+    totalVisibleColumns: 5,
   },
 });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
@@ -23,7 +23,7 @@ const componentName = DataSpreadsheet.displayName;
 // values to use
 const className = `class-${uuidv4()}`;
 const dataTestId = uuidv4();
-const data = generateData(16);
+const data = generateData({ rows: 16 });
 const defaultProps = {
   columns: [
     {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -8,12 +8,12 @@
 import React, { forwardRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { px } from '@carbon/layout';
 import { pkg } from '../../settings';
 import { usePreviousValue } from '../../global/js/hooks';
 import { checkActiveHeaderCell } from './utils/checkActiveHeaderCell';
 import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
 import { selectAllCells } from './utils/selectAllCells';
+import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
 
 const blockClass = `${pkg.prefix}--data-spreadsheet`;
 
@@ -32,6 +32,7 @@ export const DataSpreadsheetHeader = forwardRef(
       setSelectionAreas,
       setSelectionAreaData,
       rows,
+      totalVisibleColumns,
       updateActiveCellCoordinates,
     },
     ref
@@ -89,18 +90,23 @@ export const DataSpreadsheetHeader = forwardRef(
             {...headerGroup.getHeaderGroupProps()}
             style={{
               ...headerGroup.getHeaderGroupProps().style,
-              width: px(
-                parseInt(headerGroup.getHeaderGroupProps().style.width) +
-                  scrollBarSizeValue
-              ),
+              width: getSpreadsheetWidth({
+                type: 'header',
+                headerGroup,
+                scrollBarSizeValue,
+                totalVisibleColumns,
+                defaultColumn,
+              }),
+              overflow: 'hidden',
             }}
             className={`${blockClass}__tr`}
           >
             {/* SELECT ALL BUTTON */}
             <div
               role="columnheader"
+              className={`${blockClass}__select-all-cell-container`}
               style={{
-                width: defaultColumn?.rowHeaderWidth - 4,
+                width: defaultColumn?.rowHeaderWidth,
                 height: defaultColumn?.rowHeight,
               }}
             >
@@ -141,6 +147,7 @@ export const DataSpreadsheetHeader = forwardRef(
                   onClick={handleColumnHeaderClick(index)}
                   style={{
                     height: defaultColumn?.rowHeight,
+                    width: defaultColumn?.width,
                   }}
                   className={cx(
                     `${blockClass}__th`,
@@ -231,6 +238,12 @@ DataSpreadsheetHeader.propTypes = {
    * Setter fn for selectionAreas value
    */
   setSelectionAreas: PropTypes.func,
+
+  /**
+   * The total number of columns to be initially visible, additional columns will be rendered and
+   * visible via horizontal scrollbar
+   */
+  totalVisibleColumns: PropTypes.number,
 
   /**
    * Function used to update the active cell coordinates

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -81,7 +81,13 @@
       }
     }
     .#{$block-class}__th--select-all {
-      min-width: calc(#{$spacing-10} - #{$spacing-02});
+      width: $spacing-10;
+    }
+    .#{$block-class}__td-th--cell-container,
+    .#{$block-class}__select-all-cell-container {
+      position: sticky;
+      z-index: 4;
+      left: 0;
     }
     .#{$block-class}__td-th.#{$block-class}__td {
       @include carbon--font-weight('semibold');

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/generateData.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/generateData.js
@@ -53,23 +53,34 @@ const range = (len) => {
   return arr;
 };
 
-const newPet = () => {
-  return {
+const newPet = (extraColumns) => {
+  const extraDataProps = extraColumns && {
+    ownerName: petNames[Math.floor(Math.random() * petNames.length)],
+    weight: Math.floor(Math.random() * 40),
+  };
+  const defaultPet = {
     petType: pets[Math.floor(Math.random() * pets.length)],
     firstName: petNames[Math.floor(Math.random() * petNames.length)],
     age: Math.floor(Math.random() * 30),
     visits: Math.floor(Math.random() * 40),
     health: Math.floor(Math.random() * 100),
   };
+  if (extraColumns) {
+    return {
+      ...defaultPet,
+      ...extraDataProps,
+    };
+  }
+  return defaultPet;
 };
 
-export const generateData = (...lens) => {
+export const generateData = ({ rows, extraColumns }) => {
   const makeDataLevel = (depth = 0) => {
+    const lens = [rows];
     const len = lens[depth];
     return range(len).map(() => {
       return {
-        ...newPet(),
-        subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+        ...newPet(extraColumns),
       };
     });
   };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getSpreadsheetWidth.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getSpreadsheetWidth.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { px } from '@carbon/layout';
+
+export const getSpreadsheetWidth = ({
+  type,
+  headerGroup,
+  scrollBarSizeValue,
+  totalVisibleColumns,
+  defaultColumn,
+  totalColumnsWidth,
+}) => {
+  const additionalWidth = scrollBarSizeValue + defaultColumn.rowHeaderWidth;
+  if (!totalVisibleColumns) {
+    if (type === 'header') {
+      return px(
+        parseInt(headerGroup.getHeaderGroupProps().style.width) +
+          scrollBarSizeValue
+      );
+    }
+    if (type !== 'header') {
+      return totalColumnsWidth + additionalWidth;
+    }
+  }
+  if (totalVisibleColumns) {
+    return totalVisibleColumns * defaultColumn?.width + additionalWidth;
+  }
+};

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getSpreadsheetWidth.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getSpreadsheetWidth.js
@@ -20,7 +20,7 @@ export const getSpreadsheetWidth = ({
     if (type === 'header') {
       return px(
         parseInt(headerGroup.getHeaderGroupProps().style.width) +
-          scrollBarSizeValue
+          additionalWidth
       );
     }
     if (type !== 'header') {


### PR DESCRIPTION
Contributes to #1928 

This adds support for horizontal scrolling within the spreadsheet, along with adding position sticky to the row header cells when there is horizontal scrolling. The total width of the spreadsheet gets determined by the new prop `totalVisibleColumns`.

The width of the cells within the spreadsheet were also not correct based on the value they were supposed to be, they now match the designs and the custom size you can optionally provide.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/generateData.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getSpreadsheetWidth.js
```
#### How did you test and verify your work?
Storybook