### PR TITLE
fix(SidePanel): fix static panel height without actions

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1084,7 +1084,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--side-panel__container .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation {
   position: fixed;
   z-index: 2;
-  top: calc(var(--c4p--side-panel--title-text-height) + var(--cds-spacing-09, 3rem));
+  top: calc(
+        var(--c4p--side-panel--title-text-height) +
+          var(--c4p--side-panel--label-text-height) + var(--cds-spacing-09, 3rem)
+      );
   background-color: var(--cds-ui-01, #f4f4f4);
 }
 .c4p--side-panel__container .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation.c4p--side-panel__subtitle-text-is-animating {
@@ -1100,12 +1103,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation {
   position: fixed;
   top: var(--cds-spacing-09, 3rem);
-  height: var(--c4p--side-panel--title-text-height);
+  height: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--label-text-height));
 }
 .c4p--side-panel__container .c4p--side-panel__inner-content {
   overflow: auto;
   height: calc(100vh - 3rem);
-  margin-top: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--subtitle-container-height) + var(--c4p--side-panel--action-bar-container-height));
+  margin-top: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--subtitle-container-height) + var(--c4p--side-panel--action-bar-container-height) + var(--c4p--side-panel--label-text-height));
   overflow-x: hidden;
 }
 .c4p--side-panel__container .c4p--side-panel__inner-content-with-actions {
@@ -1114,6 +1117,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--side-panel__container .c4p--side-panel__inner-content.c4p--side-panel__static-inner-content {
   height: calc(100vh - (var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--subtitle-container-height) + var(--c4p--side-panel--action-bar-container-height)) + -1 * (var(--cds-spacing-09, 3rem) + var(--cds-spacing-10, 4rem)));
   padding-top: var(--cds-spacing-05, 1rem);
+}
+.c4p--side-panel__container .c4p--side-panel__inner-content.c4p--side-panel__static-inner-content-no-actions {
+  height: calc(100vh - (var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--subtitle-container-height) + var(--c4p--side-panel--action-bar-container-height) + var(--c4p--side-panel--label-text-height)));
 }
 .c4p--side-panel__container .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   position: fixed;

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -379,11 +379,13 @@ export let SidePanel = React.forwardRef(
         const actionToolbarElement = document.querySelector(
           `.${blockClass}__action-toolbar`
         );
+        const labelText = document.querySelector(`.${blockClass}__label-text`);
         const sidePanelSubtitleElementHeight =
           sidePanelSubtitleElement?.offsetHeight || 0;
         const sidePanelActionBarElementHeight =
           actionToolbarElement?.offsetHeight || 0;
         const titleHeight = sidePanelTitleElement?.offsetHeight + 24;
+        const labelHeight = labelText?.offsetHeight || 0;
         sidePanelOuter?.style.setProperty(
           `--${blockClass}--title-text-height`,
           `${titleHeight}px`
@@ -395,6 +397,10 @@ export let SidePanel = React.forwardRef(
         sidePanelOuter?.style.setProperty(
           `--${blockClass}--action-bar-container-height`,
           `${sidePanelActionBarElementHeight}px`
+        );
+        sidePanelOuter?.style.setProperty(
+          `--${blockClass}--label-text-height`,
+          `${labelHeight}px`
         );
       }
     }, [
@@ -740,6 +746,8 @@ export let SidePanel = React.forwardRef(
               ref={sidePanelInnerRef}
               className={cx(`${blockClass}__inner-content`, {
                 [`${blockClass}__static-inner-content`]: !animateTitle,
+                [`${blockClass}__static-inner-content-no-actions`]:
+                  !animateTitle && !actions?.length,
                 [`${blockClass}__inner-content-with-actions`]:
                   actions && actions.length,
               })}

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -278,7 +278,10 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       position: fixed;
       z-index: 2;
       // stylelint-disable-next-line carbon/layout-token-use
-      top: calc(var(--#{$block-class}--title-text-height) + #{$spacing-09});
+      top: calc(
+        var(--#{$block-class}--title-text-height) +
+          var(--#{$block-class}--label-text-height) + #{$spacing-09}
+      );
       background-color: $ui-01;
     }
 
@@ -298,7 +301,10 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
     .#{$block-class}__title-container.#{$block-class}__title-container--no-title-animation {
       position: fixed;
       top: $spacing-09;
-      height: var(--#{$block-class}--title-text-height);
+      height: calc(
+        var(--#{$block-class}--title-text-height) +
+          var(--#{$block-class}--label-text-height)
+      );
     }
 
     .#{$block-class}__inner-content {
@@ -308,7 +314,8 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       margin-top: calc(
         var(--#{$block-class}--title-text-height) +
           var(--#{$block-class}--subtitle-container-height) +
-          var(--#{$block-class}--action-bar-container-height)
+          var(--#{$block-class}--action-bar-container-height) +
+          var(--#{$block-class}--label-text-height)
       );
       overflow-x: hidden;
     }
@@ -329,6 +336,18 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
           ) + (calc(-1 * (#{$spacing-09} + #{$spacing-10})))
       );
       padding-top: $spacing-05;
+    }
+
+    .#{$block-class}__inner-content.#{$block-class}__static-inner-content-no-actions {
+      height: calc(
+        100vh -
+          calc(
+            var(--#{$block-class}--title-text-height) +
+              var(--#{$block-class}--subtitle-container-height) +
+              var(--#{$block-class}--action-bar-container-height) +
+              var(--#{$block-class}--label-text-height)
+          )
+      );
     }
 
     .#{$block-class}__action-toolbar.#{$block-class}__action-toolbar-no-animation {


### PR DESCRIPTION
Contributes to #1941 

Fixes the panel height when there are no action buttons provided and `animateTitle` is set to false. I also noticed some spacing issues when the label text is provided which I addressed here as well.

#### What did you change?
```
packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
```
#### How did you test and verify your work?
Storybook