### PR TITLE
feat(DataSpreadsheet): support variable column width

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -592,6 +592,7 @@ export let DataSpreadsheet = React.forwardRef(
         : null;
       setCellEditorValue(activeCellValue);
       cellEditorRulerRef.current.textContent = activeCellValue;
+      cellEditorRef.current.style.width = activeCellRef?.current.style.width;
     };
 
     // Sets the initial placement of the cell editor cursor at the end of the text area

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
@@ -56,6 +56,7 @@ const columnData = [
     accessor: (row, index) => index,
     Cell: ({ cell: { value } }) => <NumericLayout value={value} />,
     placement: 'right',
+    width: 275,
   },
   {
     Header: 'Pet type',

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -131,6 +131,7 @@ export const DataSpreadsheetBody = forwardRef(
               ref,
               area,
               blockClass,
+              columns,
               defaultColumn,
               selectionAreas,
               setSelectionAreas,
@@ -149,6 +150,7 @@ export const DataSpreadsheetBody = forwardRef(
       ref,
       activeCellCoordinates,
       setActiveCellInsideSelectionArea,
+      columns,
     ]);
 
     const populateSelectionAreaCellData = ({

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -147,7 +147,7 @@ export const DataSpreadsheetHeader = forwardRef(
                   onClick={handleColumnHeaderClick(index)}
                   style={{
                     height: defaultColumn?.rowHeight,
-                    width: defaultColumn?.width,
+                    width: column?.width || defaultColumn?.width,
                   }}
                   className={cx(
                     `${blockClass}__th`,

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -171,6 +171,7 @@
 
       &[data-active-row-index='header'],
       &[data-active-column-index='header'] {
+        z-index: 4;
         background-color: transparent;
       }
 

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/createCellSelectionArea.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/createCellSelectionArea.js
@@ -13,6 +13,7 @@ export const createCellSelectionArea = ({
   ref,
   area,
   blockClass,
+  columns,
   defaultColumn,
   selectionAreas,
   setSelectionAreas,
@@ -34,14 +35,18 @@ export const createCellSelectionArea = ({
     );
     activeCellElement.setAttribute('data-selection-id', area.matcher);
   }
+  let selectionAreaVariableWidth = 0;
+  columns.forEach((item, index) => {
+    if (index >= lowestColumnIndex && index <= greatestColumnIndex) {
+      selectionAreaVariableWidth += item?.width || defaultColumn?.width;
+    }
+  });
   const point1Element =
     document.querySelector(
       `[data-row-index="${area.point1.row}"][data-column-index="${area.point1.column}"]`
-    ) || document.querySelector(`.${blockClass}__body--td`); // if we can't find the point1 element (this can happen in the case where a virtualized row is not present anymore in the DOM), we get the default height/width of the first body cell we find
-  const selectionAreaCellWidth = point1Element.offsetWidth;
+    ) || document.querySelector(`.${blockClass}__body--td`); // if we can't find the point1 element (this can happen in the case where a virtualized row is not present anymore in the DOM), we get the default height of the first body cell we find
+
   const selectionAreaCellHeight = point1Element.offsetHeight;
-  const selectionAreaTotalWidth =
-    selectionAreaCellWidth * (greatestColumnIndex - lowestColumnIndex + 1);
   const selectionAreaTotalHeight =
     selectionAreaCellHeight * (greatestRowIndex - lowestRowIndex + 1);
   const bodyContainer = document.querySelector(
@@ -62,7 +67,7 @@ export const createCellSelectionArea = ({
         bodyContainer.getBoundingClientRect().left
       : lowestColumnIndex === 0
       ? 0 + (defaultColumn.rowHeaderWidth - 4)
-      : selectionAreaCellWidth * lowestColumnIndex +
+      : defaultColumn.width * lowestColumnIndex +
         (defaultColumn.rowHeaderWidth - 4), // calculate left value here if virtualized row is not in DOM, accounting for row header cell width (including borders)
   };
   const selectionAreaElement =
@@ -70,7 +75,7 @@ export const createCellSelectionArea = ({
     document.createElement('div');
   selectionAreaElement.classList.add(`${blockClass}__selection-area--element`);
   selectionAreaElement.setAttribute('data-matcher-id', area.matcher);
-  selectionAreaElement.style.width = px(selectionAreaTotalWidth);
+  selectionAreaElement.style.width = px(selectionAreaVariableWidth);
   selectionAreaElement.style.height = px(selectionAreaTotalHeight);
   selectionAreaElement.style.left = px(relativePosition.left);
   selectionAreaElement.style.top = px(relativePosition.top);


### PR DESCRIPTION
Contributes to #1944 

Adds support for variable column width, this can be done by adding a `width` property to the column you wish to give the custom width to, via the columns prop. Updates were also made to `createCellSelectionArea.js` so that when you create a selection area, it works with different column widths. Similarly, `useSpreadsheetEdit.js` was also updated so that the dynamic size of the cell editor is set according to the size of the next column.

Previously, cell selections and the dynamic sizing of the cell editor both assumed the width of all columns were the same.

See interaction below:

https://user-images.githubusercontent.com/10215203/165186520-90a1410d-c564-402d-a3c5-13e762625621.mov



#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.stories.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetEdit.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/createCellSelectionArea.js
```
#### How did you test and verify your work?
Storybook