### PR TITLE
fix: filename and extension default state

### DIFF
--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-import React, { useState, useRef, forwardRef } from 'react';
+import React, { useState, useRef, forwardRef, useEffect } from 'react';
 import {
   Button,
   ComposedModal,
@@ -70,12 +70,15 @@ export let ExportModal = forwardRef(
     },
     ref
   ) => {
-    const [name, setName] = useState(filename);
+    const [name, setName] = useState('');
     const [dirtyInput, setDirtyInput] = useState(false);
     // by default (if it exists) use the first extension in the extension array
-    const [extension, setExtension] = useState(
-      preformattedExtensions?.[0]?.extension
-    );
+    const [extension, setExtension] = useState('');
+
+    useEffect(() => {
+      setName(filename);
+      setExtension(preformattedExtensions?.[0]?.extension);
+    }, [filename, preformattedExtensions]);
 
     const onNameChangeHandler = (evt) => {
       setName(evt.target.value);


### PR DESCRIPTION
Contributes to #1946 

fixes a very silly and easy bug where default props were being improperly used to set the default state of the filename and extension. since `useEffect` was not being used changes to those props where not properly being updated in the component.