### PR TITLE
feat(DataSpreadsheet): add selected row/column header state

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
@@ -155,6 +155,9 @@ describe(componentName, () => {
     const selectionArea = ref?.current.querySelector(
       `.${blockClass}__selection-area--element`
     );
+    expect(firstColumnHeaderCell).toHaveClass(
+      `${blockClass}__th--selected-header`
+    );
     expect(selectionArea).toBeInTheDocument();
     expect(onSelectionAreaChangeFn).toHaveBeenCalledTimes(1);
   });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -19,6 +19,7 @@ import { usePreviousValue } from '../../global/js/hooks';
 import { removeCellSelections } from './utils/removeCellSelections';
 import { createCellSelectionArea } from './utils/createCellSelectionArea';
 import { checkActiveHeaderCell } from './utils/checkActiveHeaderCell';
+import { checkSelectedHeaderCell } from './utils/checkSelectedHeaderCell';
 import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
 import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
 
@@ -442,6 +443,8 @@ export const DataSpreadsheetBody = forwardRef(
                       [`${blockClass}__td-th--active-header`]:
                         activeCellCoordinates?.row === index ||
                         checkActiveHeaderCell(index, selectionAreas, 'row'),
+                      [`${blockClass}__td-th--selected-header`]:
+                        checkSelectedHeaderCell(index, selectionAreas, 'row'),
                     }
                   )}
                   style={{

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -11,6 +11,7 @@ import cx from 'classnames';
 import { pkg } from '../../settings';
 import { usePreviousValue } from '../../global/js/hooks';
 import { checkActiveHeaderCell } from './utils/checkActiveHeaderCell';
+import { checkSelectedHeaderCell } from './utils/checkSelectedHeaderCell';
 import { handleHeaderCellSelection } from './utils/handleHeaderCellSelection';
 import { selectAllCells } from './utils/selectAllCells';
 import { getSpreadsheetWidth } from './utils/getSpreadsheetWidth';
@@ -156,6 +157,12 @@ export const DataSpreadsheetHeader = forwardRef(
                       [`${blockClass}__th--active-header`]:
                         activeCellCoordinates?.column === index ||
                         checkActiveHeaderCell(index, selectionAreas, 'column'),
+                      [`${blockClass}__th--selected-header`]:
+                        checkSelectedHeaderCell(
+                          index,
+                          selectionAreas,
+                          'column'
+                        ),
                     }
                   )}
                   type="button"

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -215,6 +215,15 @@
     .#{$block-class}__td-th--active-header.#{$block-class}__td {
       background-color: $hover-selected-ui;
     }
+    .#{$block-class}__th--selected-header,
+    .#{$block-class}__td-th--selected-header.#{$block-class}__td {
+      background-color: $inverse-02;
+      color: $text-04;
+
+      &:hover {
+        background-color: $inverse-02;
+      }
+    }
     .#{$block-class}__list--container {
       overscroll-behavior: none;
     }

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { deepCloneObject } from '../../../global/js/utils/deepCloneObject';
+
+export const checkSelectedHeaderCell = (
+  headerIndex,
+  selectionAreas,
+  headerType
+) => {
+  const areasCloned = deepCloneObject(selectionAreas);
+  const isSelectedHeader = areasCloned.some((area) => {
+    return (
+      area?.header?.type === headerType && headerIndex === area?.header?.index
+    );
+  });
+  return isSelectedHeader;
+};

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
@@ -58,10 +58,10 @@ export const handleHeaderCellSelection = ({
     const selectionsClone = deepCloneObject(prev);
     if (isHoldingCommandKey) {
       const selectionsFromHeaderCell = selectionsClone.filter(
-        (item) => item.header.type
+        (item) => item.header?.type
       );
       const previouslyCreatedHeaderSelection = selectionsFromHeaderCell.filter(
-        (item) => item.header.type === type
+        (item) => item.header?.type === type
       );
       const isHeaderPartOfPreviousSelection = checkActiveHeaderCell(
         index,


### PR DESCRIPTION
Contributes partially to #1953 

Adds a selected state to column/row header cells when they are selected either by click or enter key.

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/10215203/165747325-dfb02ec6-6413-47de-af80-daf6d1c11ce6.png">


#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.test.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
```
#### How did you test and verify your work?
Storybook and added to tests