### PR TITLE
fix(DataSpreadsheet): address cell editing after reorder

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -729,7 +729,7 @@ export let DataSpreadsheet = React.forwardRef(
       activeCellRef,
       cellEditorRef,
       cellEditorRulerRef,
-      columns,
+      visibleColumns,
       defaultColumn,
       cellEditorValue,
     });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -582,6 +582,7 @@ export let DataSpreadsheet = React.forwardRef(
 
     const startEditMode = () => {
       setIsEditing(true);
+      setClickAndHoldActive(false);
       const activeCellFullData =
         typeof activeCellCoordinates?.column === 'number' &&
         typeof activeCellCoordinates?.row === 'number'
@@ -590,9 +591,7 @@ export let DataSpreadsheet = React.forwardRef(
             ]
           : null;
       const activeCellValue = activeCellFullData
-        ? Object.values(activeCellFullData.row.values)[
-            activeCellCoordinates?.column
-          ]
+        ? activeCellFullData.row.cells[activeCellCoordinates?.column].value
         : null;
       setCellEditorValue(activeCellValue);
       cellEditorRulerRef.current.textContent = activeCellValue;

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetEdit.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetEdit.js
@@ -17,7 +17,7 @@ export const useSpreadsheetEdit = ({
   activeCellRef,
   cellEditorRef,
   cellEditorRulerRef,
-  columns,
+  visibleColumns,
   defaultColumn,
   cellEditorValue,
   blockClass = `${pkg.prefix}--data-spreadsheet`,
@@ -52,7 +52,7 @@ export const useSpreadsheetEdit = ({
 
       if (rulerWidth < cellEditorCurrentWidth) {
         const currentColumnWidth =
-          columns[nextIndex]?.width || defaultColumn?.width;
+          visibleColumns[nextIndex]?.width || defaultColumn?.width;
         // If the contents of the cell editor is deleted past the point of the next column
         if (rulerWidth < cellEditorCurrentWidth - currentColumnWidth) {
           cellEditorRef.current.style.width = px(
@@ -69,15 +69,15 @@ export const useSpreadsheetEdit = ({
       }
       if (rulerWidth >= cellEditorCurrentWidth) {
         setNextIndex((prev) => {
-          if (prev === columns.length - 1) {
+          if (prev === visibleColumns.length - 1) {
             return prev;
           }
           return prev + 1;
         });
-        const onLastColumnIndex = nextIndex + 1 === columns.length;
+        const onLastColumnIndex = nextIndex + 1 === visibleColumns.length;
         const nextColumnWidth = onLastColumnIndex
           ? 0
-          : columns[nextIndex + 1]?.width || defaultColumn?.width;
+          : visibleColumns[nextIndex + 1]?.width || defaultColumn?.width;
         const startingRowPosition = activeCellCoordinates?.row;
         const totalRows = rows.length;
         const totalCellEditorMaxHeight =
@@ -114,12 +114,11 @@ export const useSpreadsheetEdit = ({
     activeCellCoordinates,
     rows,
     cellEditorValue,
-    columns.length,
     defaultColumn,
     activeCellRef,
     cellEditorRef,
     cellEditorRulerRef,
-    columns,
+    visibleColumns,
     blockClass,
     previousState?.cellEditorValue,
     nextIndex,


### PR DESCRIPTION
Contributes to #1961 

Similar to #1960, there was one more place where the DataSpreadsheet component was getting a value based on the original order of the columns and not the new reordered version of the columns.

FYI @mitchellbernstein this will fix the two bugs you noticed earlier today 😅 

#### What did you change?
`DataSpreadsheet.js`
`useSpreadsheetEdit.js`
#### How did you test and verify your work?
Storybook