### PR TITLE
fix: a11y issue profile-button (#1978)

### DIFF
--- a/packages/security/src/components/Header/Header.js
+++ b/packages/security/src/components/Header/Header.js
@@ -33,8 +33,11 @@ import HeaderPopoverHeader from './HeaderPopoverHeader';
 import HeaderPopoverLinkSecondary from './HeaderPopoverLinkSecondary';
 
 import { defaultProps, namespace, propTypes } from './constants';
+import { carbonPrefix } from '../../globals/namespace';
 
 const headerButtonNamespace = `${namespace}__button`;
+const assistiveTextClass = `${carbonPrefix}--assistive-text`;
+const profileButtonAssistiveTextId = `${namespace}__profile__button--assistive-text`;
 
 const getPopoverLabelId = (string) => `${namespace}__popover__label--${string}`;
 
@@ -461,11 +464,17 @@ export default class Header extends Component {
           <button
             aria-expanded={isActive.profile}
             aria-haspopup={isUserActive}
-            aria-label={labels.profile.button}
+            aria-describedby={profileButtonAssistiveTextId}
             className={profileButtonClasses}
             onClick={() => this.toggle('profile')}
             type="button"
           >
+            <span
+              id={profileButtonAssistiveTextId}
+              className={assistiveTextClass}
+            >
+              {labels.profile.button}
+            </span>
             <ProfileImage profile={profile} />
           </button>
           {this.renderProfile()}

--- a/packages/security/src/components/Header/__tests__/Header-test.js
+++ b/packages/security/src/components/Header/__tests__/Header-test.js
@@ -47,8 +47,6 @@ describe('Header', () => {
   const hasNotificationsClass = () =>
     getNotificationsButton().hasClass(`${namespace}__button--notifications`);
 
-  const { button } = labels.profile;
-
   describe('Render Props tests', () => {
     it('should render login and signup buttons via a render prop', () => {
       const linksProp = {
@@ -112,7 +110,9 @@ describe('Header', () => {
 
   describe('Rendering', () => {
     const doesPopoverExist = () => doesElementExist(`.${namespace}__popover`);
-    const getProfileButton = () => getIconButton(button);
+    const profileButtonAssistiveTextId = `${namespace}__profile__button--assistive-text`;
+    const getProfileButton = () =>
+      header.find(`button[aria-describedby="${profileButtonAssistiveTextId}"]`);
 
     it('renders correctly', () => {
       expect(header).toMatchSnapshot();


### PR DESCRIPTION
Contributes to #1978

Fix for accessibility issue with the profile button in the Security Header Shell.

#### What did you change?
Switch from using aria-label to using aria-describedby + accessibility text.  aria-label requires the aria-label matches the button text.  In this case we want the assistive text to be different than the username/initials used in the button.

#### How did you test and verify your work?

- Ran IBM accessibility checker and verified no accessibility issues.
- Verified unit tests passed.
