### PR TITLE
fix: add select meta panel

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -43,6 +43,7 @@ export let AddSelect = forwardRef(
       influencerTitle,
       items,
       itemsLabel,
+      metaPanelTitle,
       multi,
       noResultsDescription,
       noResultsTitle,
@@ -75,6 +76,7 @@ export let AddSelect = forwardRef(
     const [flatItems, setFlatItems] = useState([]);
     const [globalFilterOpts, setGlobalFilterOpts] = useState([]);
     const [appliedGlobalFilters, setAppliedGlobalFilters] = useState({});
+    const [displayMetalPanel, setDisplayMetaPanel] = useState({});
     const { sortDirection, setSortDirection, sortAttribute, setSortAttribute } =
       useItemSort();
 
@@ -193,6 +195,7 @@ export let AddSelect = forwardRef(
       setPath,
       setSingleSelection,
       singleSelection,
+      setDisplayMetaPanel,
     };
 
     // handlers
@@ -238,11 +241,14 @@ export let AddSelect = forwardRef(
     const sidebarProps = {
       influencerTitle,
       items: flatItems,
+      metaPanelTitle,
       multiSelection,
       noSelectionDescription,
       noSelectionTitle,
       removeIconDescription,
       setMultiSelection,
+      displayMetalPanel,
+      setDisplayMetaPanel,
     };
 
     const setShowBreadsCrumbs = () => {
@@ -409,6 +415,16 @@ AddSelect.propTypes = {
         children: PropTypes.object,
         icon: PropTypes.object,
         id: PropTypes.string.isRequired,
+        meta: PropTypes.oneOfType([
+          PropTypes.arrayOf(
+            PropTypes.shape({
+              id: PropTypes.string,
+              title: PropTypes.string,
+              value: PropTypes.string,
+            })
+          ),
+          PropTypes.node,
+        ]),
         subtitle: PropTypes.string,
         title: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
@@ -416,6 +432,7 @@ AddSelect.propTypes = {
     ),
   }),
   itemsLabel: PropTypes.string,
+  metaPanelTitle: PropTypes.string,
   multi: PropTypes.bool,
   noResultsDescription: PropTypes.string,
   noResultsTitle: PropTypes.string,

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -30,6 +30,7 @@ export let AddSelect = forwardRef(
 
       className,
       clearFiltersText,
+      closeIconDescription,
       columnInputPlaceholder,
       description,
       globalFilters,
@@ -43,6 +44,7 @@ export let AddSelect = forwardRef(
       influencerTitle,
       items,
       itemsLabel,
+      metaIconDescription,
       metaPanelTitle,
       multi,
       noResultsDescription,
@@ -188,6 +190,7 @@ export let AddSelect = forwardRef(
     const itemsToDisplay = getDisplayItems();
 
     const commonListProps = {
+      metaIconDescription,
       multi,
       multiSelection,
       path,
@@ -239,6 +242,7 @@ export let AddSelect = forwardRef(
     };
 
     const sidebarProps = {
+      closeIconDescription,
       influencerTitle,
       items: flatItems,
       metaPanelTitle,
@@ -382,6 +386,7 @@ export let AddSelect = forwardRef(
 AddSelect.propTypes = {
   className: PropTypes.string,
   clearFiltersText: PropTypes.string,
+  closeIconDescription: PropTypes.string,
   columnInputPlaceholder: PropTypes.string,
   description: PropTypes.string,
   globalFilters: PropTypes.arrayOf(
@@ -432,6 +437,7 @@ AddSelect.propTypes = {
     ),
   }),
   itemsLabel: PropTypes.string,
+  metaIconDescription: PropTypes.string,
   metaPanelTitle: PropTypes.string,
   multi: PropTypes.bool,
   noResultsDescription: PropTypes.string,

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import {
+  Button,
   Checkbox,
   RadioButton,
   StructuredListRow,
@@ -24,6 +25,7 @@ const componentName = 'AddSelectList';
 
 export let AddSelectList = ({
   filteredItems,
+  metaIconDescription,
   modifiers,
   multi,
   multiSelection,
@@ -169,7 +171,16 @@ export let AddSelectList = ({
                   )}
                   {item.meta && (
                     <div className={`${blockClass}-hidden-hover`}>
-                      <View16 onClick={() => setDisplayMetaPanel(item)} />
+                      <Button
+                        renderIcon={View16}
+                        iconDescription={metaIconDescription}
+                        tooltipPosition="left"
+                        tooltipAlignment="center"
+                        hasIconOnly
+                        onClick={() => setDisplayMetaPanel(item)}
+                        kind="ghost"
+                        size="sm"
+                      />
                     </div>
                   )}
                 </div>
@@ -184,6 +195,7 @@ export let AddSelectList = ({
 
 AddSelectList.propTypes = {
   filteredItems: PropTypes.array,
+  metaIconDescription: PropTypes.string,
   modifiers: PropTypes.object,
   multi: PropTypes.bool,
   multiSelection: PropTypes.array,

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -15,7 +15,7 @@ import {
   StructuredListCell,
   Dropdown,
 } from 'carbon-components-react';
-import { ChevronRight16 } from '@carbon/icons-react';
+import { ChevronRight16, View16 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { UserProfileImage } from '../UserProfileImage';
@@ -28,6 +28,7 @@ export let AddSelectList = ({
   multi,
   multiSelection,
   path,
+  setDisplayMetaPanel,
   setMultiSelection,
   setPath,
   setSingleSelection,
@@ -148,7 +149,7 @@ export let AddSelectList = ({
                           light
                           label={modifiers?.label}
                           disabled={!isSelected(item.id)}
-                          className={`${blockClass}-dropdown`}
+                          className={`${blockClass}-dropdown ${blockClass}-hidden-hover`}
                         />
                       )}
                     </>
@@ -166,6 +167,11 @@ export let AddSelectList = ({
                   {item.children && (
                     <ChevronRight16 onClick={() => onNavigateItem(item)} />
                   )}
+                  {item.meta && (
+                    <div className={`${blockClass}-hidden-hover`}>
+                      <View16 onClick={() => setDisplayMetaPanel(item)} />
+                    </div>
+                  )}
                 </div>
               </StructuredListCell>
             </StructuredListRow>
@@ -182,6 +188,7 @@ AddSelectList.propTypes = {
   multi: PropTypes.bool,
   multiSelection: PropTypes.array,
   path: PropTypes.array,
+  setDisplayMetaPanel: PropTypes.func,
   setMultiSelection: PropTypes.func,
   setPath: PropTypes.func,
   setSingleSelection: PropTypes.func,

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
@@ -1,10 +1,16 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import { Close16 } from '@carbon/icons-react';
+import { Button } from 'carbon-components-react';
 import { pkg } from '../../settings';
 const componentName = 'AddSelectMetaPanel';
 
-export let AddSelectMetaPanel = ({ meta, setDisplayMetaPanel, title }) => {
+export let AddSelectMetaPanel = ({
+  closeIconDescription,
+  meta,
+  setDisplayMetaPanel,
+  title,
+}) => {
   const blockClass = `${pkg.prefix}--add-select__meta-panel`;
   const onCloseHandler = () => {
     setDisplayMetaPanel({});
@@ -14,7 +20,16 @@ export let AddSelectMetaPanel = ({ meta, setDisplayMetaPanel, title }) => {
     <div className={blockClass}>
       <div className={`${blockClass}-header`}>
         <p className={`${blockClass}-title`}>{title}</p>
-        <Close16 className={`${blockClass}-close`} onClick={onCloseHandler} />
+        <Button
+          renderIcon={Close16}
+          iconDescription={closeIconDescription}
+          tooltipPosition="left"
+          tooltipAlignment="center"
+          hasIconOnly
+          onClick={onCloseHandler}
+          kind="ghost"
+          size="sm"
+        />
       </div>
       {isValidElement(meta)
         ? meta
@@ -29,6 +44,7 @@ export let AddSelectMetaPanel = ({ meta, setDisplayMetaPanel, title }) => {
 };
 
 AddSelectMetaPanel.propTypes = {
+  closeIconDescription: PropTypes.string,
   meta: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
@@ -1,0 +1,46 @@
+import React, { isValidElement } from 'react';
+import PropTypes from 'prop-types';
+import { Close16 } from '@carbon/icons-react';
+import { pkg } from '../../settings';
+const componentName = 'AddSelectMetaPanel';
+
+export let AddSelectMetaPanel = ({ meta, setDisplayMetaPanel, title }) => {
+  const blockClass = `${pkg.prefix}--add-select__meta-panel`;
+  const onCloseHandler = () => {
+    setDisplayMetaPanel({});
+  };
+
+  return (
+    <div className={blockClass}>
+      <div className={`${blockClass}-header`}>
+        <p className={`${blockClass}-title`}>{title}</p>
+        <Close16 className={`${blockClass}-close`} onClick={onCloseHandler} />
+      </div>
+      {isValidElement(meta)
+        ? meta
+        : meta.map((entry) => (
+            <div key={entry.id} className={`${blockClass}-entry`}>
+              <p className={`${blockClass}-entry-title`}>{entry.title}</p>
+              <p className={`${blockClass}-entry-body`}>{entry.value}</p>
+            </div>
+          ))}
+    </div>
+  );
+};
+
+AddSelectMetaPanel.propTypes = {
+  meta: PropTypes.oneOfType([
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        title: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
+    PropTypes.node,
+  ]),
+  setDisplayMetaPanel: PropTypes.func,
+  title: PropTypes.string,
+};
+
+AddSelectMetaPanel.displayName = componentName;

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
@@ -11,15 +11,19 @@ import { SubtractAlt32 } from '@carbon/icons-react';
 import PropTypes from 'prop-types';
 import { NoDataEmptyState } from '../../components/EmptyStates/NoDataEmptyState';
 import { pkg } from '../../settings';
+import { AddSelectMetaPanel } from './AddSelectMetaPanel';
 const componentName = 'AddSelectSidebar';
 
 export let AddSelectSidebar = ({
+  displayMetalPanel,
   influencerTitle,
   items,
+  metaPanelTitle,
   multiSelection,
   noSelectionDescription,
   noSelectionTitle,
   removeIconDescription,
+  setDisplayMetaPanel,
   setMultiSelection,
 }) => {
   const blockClass = `${pkg.prefix}--add-select__sidebar`;
@@ -56,6 +60,16 @@ export let AddSelectSidebar = ({
     </div>
   );
 
+  if (Object.keys(displayMetalPanel).length !== 0) {
+    return (
+      <AddSelectMetaPanel
+        meta={displayMetalPanel.meta}
+        setDisplayMetaPanel={setDisplayMetaPanel}
+        title={metaPanelTitle}
+      />
+    );
+  }
+
   return (
     <div className={blockClass}>
       <div className={`${blockClass}-header`}>
@@ -91,12 +105,15 @@ export let AddSelectSidebar = ({
 };
 
 AddSelectSidebar.propTypes = {
+  displayMetalPanel: PropTypes.object,
   influencerTitle: PropTypes.string,
   items: PropTypes.array,
+  metaPanelTitle: PropTypes.string,
   multiSelection: PropTypes.array,
   noSelectionDescription: PropTypes.string,
   noSelectionTitle: PropTypes.string,
   removeIconDescription: PropTypes.string,
+  setDisplayMetaPanel: PropTypes.func,
   setMultiSelection: PropTypes.func,
 };
 

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
@@ -15,6 +15,7 @@ import { AddSelectMetaPanel } from './AddSelectMetaPanel';
 const componentName = 'AddSelectSidebar';
 
 export let AddSelectSidebar = ({
+  closeIconDescription,
   displayMetalPanel,
   influencerTitle,
   items,
@@ -63,6 +64,7 @@ export let AddSelectSidebar = ({
   if (Object.keys(displayMetalPanel).length !== 0) {
     return (
       <AddSelectMetaPanel
+        closeIconDescription={closeIconDescription}
         meta={displayMetalPanel.meta}
         setDisplayMetaPanel={setDisplayMetaPanel}
         title={metaPanelTitle}
@@ -105,6 +107,7 @@ export let AddSelectSidebar = ({
 };
 
 AddSelectSidebar.propTypes = {
+  closeIconDescription: PropTypes.string,
   displayMetalPanel: PropTypes.object,
   influencerTitle: PropTypes.string,
   items: PropTypes.array,

--- a/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
+++ b/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
@@ -52,11 +52,11 @@
       color: $text-02;
     }
 
-    &-cell:hover .#{$block-class}__selections-dropdown {
+    &-cell:hover .#{$block-class}__selections-hidden-hover {
       visibility: visible;
     }
 
-    &-dropdown {
+    &-hidden-hover {
       visibility: hidden;
     }
 
@@ -64,7 +64,7 @@
       background: #e5e5e5;
     }
 
-    &-row-selected .#{$block-class}__selections-dropdown {
+    &-row-selected .#{$block-class}__selections-hidden-hover {
       visibility: visible;
     }
 
@@ -102,7 +102,7 @@
 
   .#{$block-class}__sub-header {
     display: flex;
-    align-items: end;
+    align-items: flex-end;
     justify-content: space-between;
   }
 
@@ -252,6 +252,38 @@
   button.#{$block-class}__global-filter-toggle {
     border-bottom-color: $ui-04;
     background: $field-01;
+  }
+
+  // meta panel
+  .#{$block-class}__meta-panel {
+    padding: $spacing-05;
+
+    &-close {
+      cursor: pointer;
+    }
+
+    &-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: $spacing-05;
+    }
+
+    &-entry {
+      margin-bottom: $spacing-05;
+    }
+  }
+
+  .#{$block-class}__meta-panel p.#{$block-class}__meta-panel-title {
+    @include carbon--type-style('productive-heading-03');
+  }
+
+  .#{$block-class}__meta-panel p.#{$block-class}__meta-panel-entry-title {
+    @include carbon--type-style('productive-heading-01');
+  }
+
+  .#{$block-class}__meta-panel p.#{$block-class}__meta-panel-entry-body {
+    @include carbon--type-style('body-short-01');
   }
 
   // overrides

--- a/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
+++ b/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
@@ -258,10 +258,6 @@
   .#{$block-class}__meta-panel {
     padding: $spacing-05;
 
-    &-close {
-      cursor: pointer;
-    }
-
     &-header {
       display: flex;
       align-items: center;

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -34,6 +34,7 @@ export default {
 const defaultProps = {
   className: 'placeholder-class',
   clearFiltersText: 'Clear filters',
+  closeIconDescription: 'Close',
   columnInputPlaceholder: 'Find',
   description: 'Select business terms from the list',
   globalSearchLabel: 'test input label',
@@ -81,6 +82,7 @@ const defaultProps = {
     ],
   },
   itemsLabel: 'Business terms',
+  metaIconDescription: 'View meta information',
   metaPanelTitle: 'Personal information',
   noResultsTitle: 'No results',
   noSelectionDescription:

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -17,6 +17,8 @@ import { Button } from 'carbon-components-react';
 // import { action } from '@storybook/addon-actions';
 import image from '../UserProfileImage/headshot.png'; // cspell:disable-line
 import { Group24, Document16 } from '@carbon/icons-react';
+import { pkg } from '../../settings';
+const blockClass = `${pkg.prefix}--add-select__meta-panel`;
 
 export default {
   title: getStoryTitle(MultiAddSelect.displayName),
@@ -44,11 +46,31 @@ const defaultProps = {
         value: '1',
         title: 'item 1',
         subtitle: 'item 1 subtitle',
+        meta: (
+          <div className={`${blockClass}-entry`}>
+            <p className={`${blockClass}-entry-title`}>html support</p>
+            <p className={`${blockClass}-entry-body`}>
+              also supports nodes in the meta attribute
+            </p>
+          </div>
+        ),
       },
       {
         id: '2',
         value: '2',
         title: 'item 2',
+        meta: [
+          {
+            id: 'description',
+            title: 'description',
+            value: 'description text',
+          },
+          {
+            id: 'secondary_category',
+            title: 'secondary category',
+            value: 'knowledge accelerator',
+          },
+        ],
       },
       {
         id: '3',
@@ -59,6 +81,7 @@ const defaultProps = {
     ],
   },
   itemsLabel: 'Business terms',
+  metaPanelTitle: 'Personal information',
   noResultsTitle: 'No results',
   noSelectionDescription:
     'Select a term to include the full set of the governance artifacts it contains in the governance scope.',


### PR DESCRIPTION
Contributes to #1982

<img width="1602" alt="Screen Shot 2022-05-11 at 3 54 12 PM" src="https://user-images.githubusercontent.com/6370760/167945932-71d47325-baae-49fb-b840-13065b61c5da.png">

when an item has a `meta` attribute and you hover over it in the list you should now see an icon that when clicked will open up the metal data panel.