### PR TITLE
chore: change frequency of dependency github action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Update packages # Updates dependencies every Friday
 
 on:
   schedule:
-    - cron: '0 4 * * FRI'
+    - cron: '0 4 1,15 * *' # Updates will happen every 1st/15th of the month
 
 jobs:
   carbon:


### PR DESCRIPTION
Contributes to #1984 

Change cron syntax in github action so that dependency update PRs occur on the 1st and 15th of every month.

#### What did you change?
```
.github/workflows/update.yml
```
#### How did you test and verify your work?
Checked cron syntax [here](https://crontab.guru/#0_4_1,15_*_*)