### PR TITLE
fix(DataSpreadsheet): support reordering columns with horizontal scroll

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
@@ -28,10 +28,15 @@ export const useSpreadsheetMouseMove = ({
         ref.current.addEventListener('mousemove', handleMouseMove);
       }
       const spreadsheetCoords = ref.current.getBoundingClientRect();
+      const listContainer = ref.current.querySelector(
+        `.${blockClass}__list--container`
+      );
+      const scrollAmount = listContainer.scrollLeft;
       moveColumnIndicatorLine({
         clonedSelectionElement,
         ref,
         spreadsheetCoords,
+        leftScrollAmount: scrollAmount,
       });
       const scrollbarWidth = getScrollbarWidth();
       const spreadsheetWrapperElement = ref.current;
@@ -41,18 +46,24 @@ export const useSpreadsheetMouseMove = ({
       const offsetXValue = clonedSelectionElement?.getAttribute(
         'data-clone-offset-x'
       );
-      const totalSpreadsheetWidth = ref.current.offsetWidth;
+
+      const totalSpreadsheetScrollingWidth = listContainer.scrollWidth;
       const clonedSelectionWidth = clonedSelectionElement.offsetWidth;
       const clonePlacement = Math.max(
         xPositionRelativeToSpreadsheet - offsetXValue,
         defaultColumn?.rowHeaderWidth
       );
-      // Moves the position of the cloned selection area to follow mouse
+      // Moves the position of the cloned selection area to follow mouse, and
+      // add the amount horizontally scrolled
       clonedSelectionElement.style.left = px(
-        totalSpreadsheetWidth - clonedSelectionWidth - scrollbarWidth >=
+        totalSpreadsheetScrollingWidth -
+          clonedSelectionWidth -
+          scrollbarWidth >=
           clonePlacement
-          ? clonePlacement
-          : totalSpreadsheetWidth - clonedSelectionWidth - scrollbarWidth
+          ? clonePlacement + scrollAmount
+          : totalSpreadsheetScrollingWidth -
+              clonedSelectionWidth -
+              scrollbarWidth
       );
     };
     if (headerCellHoldActive) {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
@@ -60,8 +60,12 @@ export const useSpreadsheetMouseUp = ({
           const spreadsheetPosition = ref.current.getBoundingClientRect();
           const newIndexPosition =
             columnToMoveToElement.getBoundingClientRect();
+          const listContainer = ref.current.querySelector(
+            `.${blockClass}__list--container`
+          );
+          const leftScrollAmount = listContainer.scrollLeft;
           const relativeNewPosition =
-            newIndexPosition.left - spreadsheetPosition.left;
+            newIndexPosition.left - spreadsheetPosition.left + leftScrollAmount;
           const cloneColumnWidth = selectionAreaCloneElement.offsetWidth;
           let columnsWidthUpToNewIndex = 0;
           const newIndexLessThanStarting = newColumnIndex < originalColumnIndex;

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/moveColumnIndicatorLine.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/moveColumnIndicatorLine.js
@@ -13,6 +13,7 @@ export const moveColumnIndicatorLine = ({
   clonedSelectionElement,
   ref,
   spreadsheetCoords,
+  leftScrollAmount,
 }) => {
   const closestCell = event.target.closest(
     `.${blockClass}--interactive-cell-element`
@@ -34,12 +35,13 @@ export const moveColumnIndicatorLine = ({
       closestCellCoords.left -
         spreadsheetCoords.left +
         closestCell.offsetWidth -
-        2
+        2 +
+        leftScrollAmount
     );
   }
   if (Number(newColumnIndex) < Number(originalColumnIndex)) {
     indicatorLineElement.style.left = px(
-      closestCellCoords.left - spreadsheetCoords.left
+      closestCellCoords.left - spreadsheetCoords.left + leftScrollAmount
     );
   }
   if (Number(newColumnIndex) === Number(originalColumnIndex)) {


### PR DESCRIPTION
Contributes to #1976 

Addresses issues where if you have a spreadsheet with horizontal scrolling the placement of elements during/after column reordering was incorrect because it wasn't accounting for the amount scrolled horizontally. Now the cloned selection element as well as the indicator line are positioned correctly.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/moveColumnIndicatorLine.js
```
#### How did you test and verify your work?
Storybook, with the story named `With many columns`