### PR TITLE
chore(DataSpreadsheet): add cell id selection area data

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -180,7 +180,11 @@ export const DataSpreadsheetBody = forwardRef(
           columnIndex <= columnEnd;
           columnIndex++
         ) {
-          cellContainer.push([rowIndex, columnIndex]);
+          cellContainer.push([
+            rowIndex,
+            columnIndex,
+            `${blockClass}__cell--${rowIndex}--${columnIndex}`,
+          ]);
         }
       }
       return cellContainer;


### PR DESCRIPTION
Contributes to #1976 

As suggested by @janhassel, the selection area data should include the id of each cell

#### What did you change?
`DataSpreadsheetBody.js`
#### How did you test and verify your work?
Storybook, in the actions tab you can see that the id for each selected cell is now included in the callback of `onSelectionAreaChange`