### PR TITLE
feat(DataSpreadsheet): rename cellSize props to match carbon data table

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -59,7 +59,7 @@ const componentName = 'DataSpreadsheet';
 
 // Default values for props
 const defaults = {
-  cellSize: 'standard',
+  cellSize: 'sm',
   columns: Object.freeze([]),
   data: Object.freeze([]),
   defaultEmptyRowCount: 16,
@@ -939,7 +939,7 @@ DataSpreadsheet.propTypes = {
   /**
    * Specifies the cell height
    */
-  cellSize: PropTypes.oneOf(['compact', 'standard', 'medium', 'large']),
+  cellSize: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * Provide an optional class to be applied to the containing node.

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
@@ -254,7 +254,7 @@ DataSpreadsheetHeader.propTypes = {
   /**
    * Specifies the cell height
    */
-  cellSize: PropTypes.oneOf(['compact', 'standard', 'medium', 'large']),
+  cellSize: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 
   /**
    * All of the spreadsheet columns

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getCellSize.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getCellSize.js
@@ -7,10 +7,10 @@
 
 import {
   baseFontSize,
-  sizeXSmall as compact,
-  sizeSmall as standard,
-  sizeMedium as medium,
-  sizeLarge as large,
+  sizeXSmall as xs,
+  sizeSmall as sm,
+  sizeMedium as md,
+  sizeLarge as lg,
 } from '@carbon/layout';
 
 const getSizeInPixels = (carbonSize) =>
@@ -18,15 +18,15 @@ const getSizeInPixels = (carbonSize) =>
 
 export const getCellSize = (cellSize) => {
   switch (cellSize) {
-    case 'compact':
-      return getSizeInPixels(compact);
-    case 'standard':
-      return getSizeInPixels(standard);
-    case 'medium':
-      return getSizeInPixels(medium);
-    case 'large':
-      return getSizeInPixels(large);
+    case 'xs':
+      return getSizeInPixels(xs);
+    case 'sm':
+      return getSizeInPixels(sm);
+    case 'md':
+      return getSizeInPixels(md);
+    case 'lg':
+      return getSizeInPixels(lg);
     default:
-      return getSizeInPixels(standard);
+      return getSizeInPixels(sm);
   }
 };


### PR DESCRIPTION
Contributes to #1995 

Changes `cellSize` prop to match the sizes from Carbon's data table.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/getCellSize.js
```
#### How did you test and verify your work?
Storybook