### PR TITLE
fix(DataSpreadsheet): update header cell border colors

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -12,6 +12,10 @@
 // Define all component styles in a mixin which is then exported using
 // the Carbon import-once mechanism.
 @mixin set-header-borders {
+  border-right: 1px solid $active-ui;
+  border-bottom: 1px solid $active-ui;
+}
+@mixin set-active-header-borders {
   border-right: 1px solid $text-03;
   border-bottom: 1px solid $text-03;
 }
@@ -214,6 +218,8 @@
     }
     .#{$block-class}__th--active-header,
     .#{$block-class}__td-th--active-header.#{$block-class}__td {
+      @include set-active-header-borders();
+
       background-color: $hover-selected-ui;
     }
     .#{$block-class}__th--selected-header,


### PR DESCRIPTION
Contributes to #1976 

Updates the border colors depending on the state of the header cell (default vs active).

#### What did you change?
`_data-spreadsheet.scss`
#### How did you test and verify your work?
Storybook