### PR TITLE
fix: when export modal closes the input should be reset

### DIFF
--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
@@ -78,7 +78,7 @@ export let ExportModal = forwardRef(
     useEffect(() => {
       setName(filename);
       setExtension(preformattedExtensions?.[0]?.extension);
-    }, [filename, preformattedExtensions]);
+    }, [filename, preformattedExtensions, open]);
 
     const onNameChangeHandler = (evt) => {
       setName(evt.target.value);


### PR DESCRIPTION
small bug brought to my attention in the pal-dev channel. when a user edits the input and closes it via submit or cancel and then re-opens the modal the previous input still persists. this should reset it properly when the modal closes.