### PR TITLE
Spreadsheet multiple column reorder

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -680,6 +680,7 @@ export let DataSpreadsheet = React.forwardRef(
         isKeyboard,
         setSelectionAreaData,
         index,
+        currentMatcher,
       };
       // Select an entire column
       if (
@@ -810,6 +811,7 @@ export let DataSpreadsheet = React.forwardRef(
             activeCellCoordinates={activeCellCoordinates}
             cellSize={cellSize}
             columns={columns}
+            currentMatcher={currentMatcher}
             defaultColumn={defaultColumn}
             headerGroups={headerGroups}
             rows={rows}

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
@@ -200,6 +200,7 @@ export const DataSpreadsheetBody = forwardRef(
       rows,
       activeCellCoordinates,
       defaultColumn,
+      selectionAreas,
     });
 
     // Make sure that if the cellSize prop changes, the active
@@ -487,7 +488,12 @@ export const DataSpreadsheetBody = forwardRef(
                         activeCellCoordinates?.row === index ||
                         checkActiveHeaderCell(index, selectionAreas, 'row'),
                       [`${blockClass}__td-th--selected-header`]:
-                        checkSelectedHeaderCell(index, selectionAreas, 'row'),
+                        checkSelectedHeaderCell(
+                          index,
+                          selectionAreas,
+                          'row',
+                          columns
+                        ),
                     }
                   )}
                   style={{
@@ -542,6 +548,7 @@ export const DataSpreadsheetBody = forwardRef(
         handleBodyCellClick,
         handleBodyCellHover,
         defaultColumn,
+        columns,
       ]
     );
 

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
@@ -211,6 +211,7 @@
       z-index: 4;
       width: $spacing-01;
       background-color: $interactive-01;
+      pointer-events: none;
     }
     .#{$block-class}__th--active-header,
     .#{$block-class}__td-th--active-header.#{$block-class}__td {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
@@ -8,7 +8,6 @@
 import { useEffect } from 'react';
 import { px } from '@carbon/layout';
 import { pkg } from '../../../settings';
-import { getScrollbarWidth } from '../../../global/js/utils/getScrollbarWidth';
 import { moveColumnIndicatorLine } from '../utils/moveColumnIndicatorLine';
 
 // Used specifically for reordering columns, will move the position of the
@@ -38,7 +37,6 @@ export const useSpreadsheetMouseMove = ({
         spreadsheetCoords,
         leftScrollAmount: scrollAmount,
       });
-      const scrollbarWidth = getScrollbarWidth();
       const spreadsheetWrapperElement = ref.current;
       spreadsheetWrapperElement.getBoundingClientRect();
       const xPositionRelativeToSpreadsheet =
@@ -56,14 +54,9 @@ export const useSpreadsheetMouseMove = ({
       // Moves the position of the cloned selection area to follow mouse, and
       // add the amount horizontally scrolled
       clonedSelectionElement.style.left = px(
-        totalSpreadsheetScrollingWidth -
-          clonedSelectionWidth -
-          scrollbarWidth >=
-          clonePlacement
+        totalSpreadsheetScrollingWidth - clonedSelectionWidth >= clonePlacement
           ? clonePlacement + scrollAmount
-          : totalSpreadsheetScrollingWidth -
-              clonedSelectionWidth -
-              scrollbarWidth
+          : totalSpreadsheetScrollingWidth - clonedSelectionWidth
       );
     };
     if (headerCellHoldActive) {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
@@ -28,10 +28,15 @@ export const useSpreadsheetMouseMove = ({
         ref.current.addEventListener('mousemove', handleMouseMove);
       }
       const spreadsheetCoords = ref.current.getBoundingClientRect();
+      const listContainer = ref.current.querySelector(
+        `.${blockClass}__list--container`
+      );
+      const scrollAmount = listContainer.scrollLeft;
       moveColumnIndicatorLine({
         clonedSelectionElement,
         ref,
         spreadsheetCoords,
+        leftScrollAmount: scrollAmount,
       });
       const scrollbarWidth = getScrollbarWidth();
       const spreadsheetWrapperElement = ref.current;
@@ -41,18 +46,24 @@ export const useSpreadsheetMouseMove = ({
       const offsetXValue = clonedSelectionElement?.getAttribute(
         'data-clone-offset-x'
       );
-      const totalSpreadsheetWidth = ref.current.offsetWidth;
+
+      const totalSpreadsheetScrollingWidth = listContainer.scrollWidth;
       const clonedSelectionWidth = clonedSelectionElement.offsetWidth;
       const clonePlacement = Math.max(
         xPositionRelativeToSpreadsheet - offsetXValue,
         defaultColumn?.rowHeaderWidth
       );
-      // Moves the position of the cloned selection area to follow mouse
+      // Moves the position of the cloned selection area to follow mouse, and
+      // add the amount horizontally scrolled
       clonedSelectionElement.style.left = px(
-        totalSpreadsheetWidth - clonedSelectionWidth - scrollbarWidth >=
+        totalSpreadsheetScrollingWidth -
+          clonedSelectionWidth -
+          scrollbarWidth >=
           clonePlacement
-          ? clonePlacement
-          : totalSpreadsheetWidth - clonedSelectionWidth - scrollbarWidth
+          ? clonePlacement + scrollAmount
+          : totalSpreadsheetScrollingWidth -
+              clonedSelectionWidth -
+              scrollbarWidth
       );
     };
     if (headerCellHoldActive) {

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
@@ -60,8 +60,12 @@ export const useSpreadsheetMouseUp = ({
           const spreadsheetPosition = ref.current.getBoundingClientRect();
           const newIndexPosition =
             columnToMoveToElement.getBoundingClientRect();
+          const listContainer = ref.current.querySelector(
+            `.${blockClass}__list--container`
+          );
+          const leftScrollAmount = listContainer.scrollLeft;
           const relativeNewPosition =
-            newIndexPosition.left - spreadsheetPosition.left;
+            newIndexPosition.left - spreadsheetPosition.left + leftScrollAmount;
           const cloneColumnWidth = selectionAreaCloneElement.offsetWidth;
           let columnsWidthUpToNewIndex = 0;
           const newIndexLessThanStarting = newColumnIndex < originalColumnIndex;

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
@@ -26,6 +26,7 @@ export const useSpreadsheetMouseUp = ({
   activeCellCoordinates,
   rows,
   defaultColumn,
+  selectionAreas,
 }) => {
   useEffect(() => {
     const handleMouseUp = (event) => {
@@ -43,10 +44,19 @@ export const useSpreadsheetMouseUp = ({
           const closestCell = event.target.closest(
             `.${blockClass}--interactive-cell-element`
           );
-          const newColumnIndex = closestCell?.getAttribute('data-column-index');
-          const originalColumnIndex = selectionAreaCloneElement?.getAttribute(
-            'data-column-index-original'
+          const newColumnIndex = parseInt?.(
+            closestCell?.getAttribute('data-column-index')
           );
+          const originalColumnIndex = parseInt?.(
+            selectionAreaCloneElement?.getAttribute(
+              'data-column-index-original'
+            )
+          );
+          const selectionAreaToClone = selectionAreas.filter(
+            (item) => item?.matcher === currentMatcher
+          );
+          const selectionAreaIndexArray =
+            selectionAreaToClone[0].header.selectedIndexList;
           const columnToMoveToElement = ref.current.querySelector(
             `[data-row-index="header"][data-column-index="${newColumnIndex}"]`
           );
@@ -58,34 +68,15 @@ export const useSpreadsheetMouseUp = ({
             `[data-matcher-id="${currentMatcher}"]`
           );
           const spreadsheetPosition = ref.current.getBoundingClientRect();
-          const newIndexPosition =
-            columnToMoveToElement.getBoundingClientRect();
           const listContainer = ref.current.querySelector(
             `.${blockClass}__list--container`
           );
           const leftScrollAmount = listContainer.scrollLeft;
-          const relativeNewPosition =
-            newIndexPosition.left - spreadsheetPosition.left + leftScrollAmount;
-          const cloneColumnWidth = selectionAreaCloneElement.offsetWidth;
-          let columnsWidthUpToNewIndex = 0;
           const newIndexLessThanStarting = newColumnIndex < originalColumnIndex;
-          visibleColumns.forEach((item, index) => {
-            if (
-              newIndexLessThanStarting &&
-              index === visibleColumns.length - 1
-            ) {
-              return;
-            }
-            if (index <= newColumnIndex) {
-              columnsWidthUpToNewIndex += item?.width || defaultColumn?.width;
-            }
-          });
-          const updatedSelectionAreaPlacement = newIndexLessThanStarting
-            ? relativeNewPosition
-            : columnsWidthUpToNewIndex -
-              cloneColumnWidth +
-              defaultColumn?.rowHeaderWidth;
-          selectionAreaToMove.style.left = px(updatedSelectionAreaPlacement);
+          const newIndexGreater = newColumnIndex > originalColumnIndex;
+          const differenceBetweenOldNewIndex = newIndexGreater
+            ? newColumnIndex - originalColumnIndex
+            : originalColumnIndex - newColumnIndex;
           setSelectionAreas((prev) => {
             const selectionAreaClone = deepCloneObject(prev);
             if (originalColumnIndex === newColumnIndex) {
@@ -97,30 +88,83 @@ export const useSpreadsheetMouseUp = ({
             if (indexOfItemToUpdate === -1) {
               return prev;
             }
-            selectionAreaClone[indexOfItemToUpdate].header.index =
-              Number(newColumnIndex);
-            selectionAreaClone[indexOfItemToUpdate].point1.column =
-              Number(newColumnIndex);
-            selectionAreaClone[indexOfItemToUpdate].point2.column =
-              Number(newColumnIndex);
+            if (!selectionAreaIndexArray.includes(newColumnIndex)) {
+              // We need to not add just the newColumnIndex, but an array of indexes
+              // if there are multiple columns
+              const newIndexArray = newIndexGreater
+                ? selectionAreaIndexArray.map(
+                    (num) => num + differenceBetweenOldNewIndex
+                  )
+                : selectionAreaIndexArray.map(
+                    (num) => num - differenceBetweenOldNewIndex
+                  );
+              selectionAreaClone[indexOfItemToUpdate].header.selectedIndexList =
+                newIndexArray;
+              selectionAreaClone[indexOfItemToUpdate].point1.column = Math.min(
+                ...newIndexArray
+              );
+              selectionAreaClone[indexOfItemToUpdate].point2.column = Math.max(
+                ...newIndexArray
+              );
+            }
             return selectionAreaClone;
           });
-          const columnIdArray = visibleColumns.map((column) => column.id);
-          const columnIdArrayClone = [...columnIdArray];
-          // Remove one element at the original index
-          columnIdArrayClone.splice(originalColumnIndex, 1);
-          // Add one element at the new index
-          columnIdArrayClone.splice(
-            newColumnIndex,
-            0,
-            columnIdArray[originalColumnIndex]
-          );
-          setColumnOrder(columnIdArrayClone); // Function provided by useTable (react-table) hook to reorder columns
-          const newCellCoords = {
-            ...activeCellCoordinates,
-            column: Number(newColumnIndex),
-          };
-          setActiveCellCoordinates(newCellCoords);
+          // Only reorder columns if the new index is _not_ part of the
+          // selectionAreaIndexArray, meaning the new placement is outside
+          // of the current selection area. Similarly, the active cell position
+          // should only be changed under the same condition.
+          if (!selectionAreaIndexArray.includes(newColumnIndex)) {
+            const deleteCount = selectionAreaIndexArray.length;
+            const startIndex = Math.min(...selectionAreaIndexArray);
+            const columnIdArray = visibleColumns.map((column) => column.id);
+            const columnIdArrayClone = [...columnIdArray];
+            const getNewColumnOrder = () => {
+              const newColumnList = [];
+              selectionAreaIndexArray.map((index) => {
+                return newColumnList.push(columnIdArray[index]);
+              });
+              return newColumnList;
+            };
+            // Remove one element at the original index
+            columnIdArrayClone.splice(startIndex, deleteCount);
+            const originalPointIndex = selectionAreaIndexArray.findIndex(
+              (item) => item === originalColumnIndex
+            );
+            const updatedNewIndexWithNewOrder =
+              newColumnIndex - originalPointIndex;
+            // Add one element at the new index
+            columnIdArrayClone.splice(
+              updatedNewIndexWithNewOrder,
+              0,
+              ...getNewColumnOrder()
+            );
+            setColumnOrder(columnIdArrayClone); // Function provided by useTable (react-table) hook to reorder columns
+            const newCellCoords = {
+              ...activeCellCoordinates,
+              column: newIndexGreater
+                ? activeCellCoordinates.column + differenceBetweenOldNewIndex
+                : activeCellCoordinates.column - differenceBetweenOldNewIndex,
+            };
+            setActiveCellCoordinates(newCellCoords);
+            const firstSelectedHeader = Array.from(
+              ref.current.querySelectorAll(
+                `.${blockClass}__th--selected-header`
+              )
+            )[0];
+            const firstSelectedHeaderCoords =
+              firstSelectedHeader.getBoundingClientRect();
+            const newRelativePosition =
+              firstSelectedHeaderCoords.left -
+              spreadsheetPosition.left +
+              leftScrollAmount;
+            // console.log(firstSelectedHeaderCoords.left - spreadsheetPosition.left + leftScrollAmount);
+            const updatedSelectionAreaPlacement = newIndexLessThanStarting
+              ? newRelativePosition
+              : newColumnIndex === originalColumnIndex
+              ? selectionAreaToMove.style.left
+              : newRelativePosition;
+            selectionAreaToMove.style.left = px(updatedSelectionAreaPlacement);
+          }
           // Remove the cloned column and indicator elements
           const indicatorLineElement = ref.current.querySelector(
             `.${blockClass}__reorder-indicator-line`
@@ -175,5 +219,6 @@ export const useSpreadsheetMouseUp = ({
     activeCellCoordinates,
     rows,
     defaultColumn,
+    selectionAreas,
   ]);
 };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
@@ -10,13 +10,39 @@ import { deepCloneObject } from '../../../global/js/utils/deepCloneObject';
 export const checkSelectedHeaderCell = (
   headerIndex,
   selectionAreas,
-  headerType
+  headerType,
+  items
 ) => {
   const areasCloned = deepCloneObject(selectionAreas);
   const isSelectedHeader = areasCloned.some((area) => {
-    return (
-      area?.header?.type === headerType && headerIndex === area?.header?.index
+    const oppositeType = headerType === 'column' ? 'row' : 'column';
+    const minOppositeSelection = Math.min(
+      area?.point1?.[oppositeType],
+      area?.point2?.[oppositeType]
     );
+    const maxOppositeSelection = Math.max(
+      area?.point1?.[oppositeType],
+      area?.point2?.[oppositeType]
+    );
+
+    const minSelection = Math.min(
+      area?.point1?.[headerType],
+      area?.point2?.[headerType]
+    );
+    const maxSelection = Math.max(
+      area?.point1?.[headerType],
+      area?.point2?.[headerType]
+    );
+    const isTrueSelectedState =
+      items?.length - 1 === maxOppositeSelection && minOppositeSelection === 0;
+    // console.log({minSelection, maxSelection});
+    // Iterate over all columns included in the selection area
+    for (let i = minSelection; i <= maxSelection; i++) {
+      if (headerIndex === i && isTrueSelectedState) {
+        return true;
+      }
+    }
+    return false;
   });
   return isSelectedHeader;
 };

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
@@ -10,11 +10,28 @@ import uuidv4 from '../../../global/js/utils/uuidv4';
 import { removeCellSelections } from './removeCellSelections';
 import { checkActiveHeaderCell } from './checkActiveHeaderCell';
 
+const getSelectedItemIndexList = ({ indexList, newIndex, activeCellIndex }) => {
+  const lowestIndex =
+    newIndex > activeCellIndex
+      ? activeCellIndex
+      : Math.min(...indexList, newIndex);
+  const highestIndex =
+    newIndex < activeCellIndex
+      ? activeCellIndex
+      : Math.max(...indexList, newIndex);
+  const newIndexList = [];
+  for (let i = lowestIndex; i <= highestIndex; i++) {
+    newIndexList.push(i);
+  }
+  return [...newIndexList];
+};
+
 export const handleHeaderCellSelection = ({
   type,
   activeCellCoordinates,
   rows,
   columns,
+  currentMatcher,
   setActiveCellCoordinates,
   setCurrentMatcher,
   setSelectionAreas,
@@ -23,6 +40,7 @@ export const handleHeaderCellSelection = ({
   isKeyboard,
   setSelectionAreaData,
   isHoldingCommandKey,
+  isHoldingShiftKey,
 }) => {
   if (!isHoldingCommandKey) {
     setSelectionAreaData([]);
@@ -39,11 +57,13 @@ export const handleHeaderCellSelection = ({
     column: type === 'column' ? columnValue : columns.length - 1,
   };
   const tempMatcher = uuidv4();
-  setActiveCellCoordinates({
-    row: type === 'column' ? 0 : rowValue,
-    column: type === 'column' ? columnValue : 0,
-  });
-  setCurrentMatcher(tempMatcher);
+  if (!isHoldingShiftKey) {
+    setActiveCellCoordinates({
+      row: type === 'column' ? 0 : rowValue,
+      column: type === 'column' ? columnValue : 0,
+    });
+    setCurrentMatcher(tempMatcher);
+  }
   const newSelectionArea = {
     point1,
     point2,
@@ -51,7 +71,7 @@ export const handleHeaderCellSelection = ({
     matcher: tempMatcher,
     header: {
       type,
-      index: type === 'column' ? columnValue : rowValue,
+      selectedIndexList: [type === 'column' ? columnValue : rowValue],
     },
   };
   setSelectionAreas((prev) => {
@@ -76,6 +96,88 @@ export const handleHeaderCellSelection = ({
         return prev;
       }
       return [...prev, newSelectionArea];
+    }
+    if (isHoldingShiftKey) {
+      const selectionsFromHeaderCell = selectionsClone.filter(
+        (item) => item.header?.type
+      );
+      // Shift/click behavior should not occur unless there are activeCellCoordinates set
+      const currentSelectionArea = selectionsFromHeaderCell.filter(
+        (item) => item.matcher === currentMatcher
+      )[0];
+      const originalAreaIndex = Math.max(
+        currentSelectionArea?.point1[type],
+        currentSelectionArea?.point2[type],
+        activeCellCoordinates?.[type]
+      );
+      const newIndexValue = type === 'column' ? columnValue : rowValue;
+      const newPoint = {
+        row: originalAreaIndex < newIndexValue ? rows.length - 1 : 0,
+        column: columnValue,
+      };
+      const selectionAreasClone = deepCloneObject(prev);
+      const indexOfCurrentArea = selectionAreasClone.findIndex(
+        (item) => item.matcher === currentMatcher
+      );
+      const newIndexList = getSelectedItemIndexList({
+        indexList: selectionAreasClone[indexOfCurrentArea]?.header
+          ?.selectedIndexList || [type === 'column' ? columnValue : rowValue],
+        newIndex: newIndexValue,
+        activeCellIndex: activeCellCoordinates?.[type],
+      });
+      const setPoint1 = (value) => {
+        return value < newIndexValue
+          ? {
+              row: type === 'column' ? 0 : Math.min(...newIndexList),
+              column: type === 'column' ? Math.min(...newIndexList) : 0,
+            }
+          : newPoint;
+      };
+      const setPoint2 = (value) => {
+        return value < newIndexValue
+          ? newPoint
+          : {
+              row:
+                type === 'column' ? rows.length - 1 : Math.max(...newIndexList),
+              column:
+                type === 'column'
+                  ? Math.max(...newIndexList)
+                  : columns.length - 1,
+            };
+      };
+      // If there is no active cell set and shift is clicked on a header cell
+      if (
+        !activeCellCoordinates ||
+        typeof activeCellCoordinates === 'undefined'
+      ) {
+        // Need to set positioning of active cell because it doesn't exist yet
+        setCurrentMatcher(tempMatcher);
+        const firstSelectionArea = {
+          point1: setPoint1(type === 'column' ? columnValue : rowValue),
+          point2: setPoint2(type === 'column' ? columnValue : rowValue),
+          areaCreated: false,
+          matcher: tempMatcher,
+          header: {
+            type,
+            selectedIndexList: [type === 'column' ? columnValue : rowValue],
+          },
+        };
+        setActiveCellCoordinates({
+          row: type === 'column' ? 0 : rowValue,
+          column: type === 'column' ? columnValue : 0,
+        });
+        return [firstSelectionArea];
+      }
+      selectionAreasClone[indexOfCurrentArea].point1 = setPoint1(
+        activeCellCoordinates?.[type]
+      );
+      selectionAreasClone[indexOfCurrentArea].point2 = setPoint2(
+        activeCellCoordinates?.[type]
+      );
+      selectionAreasClone[indexOfCurrentArea].areaCreated = false;
+      selectionAreasClone[indexOfCurrentArea].header.selectedIndexList =
+        newIndexList;
+      return selectionAreasClone;
     }
     return [newSelectionArea];
   });

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/moveColumnIndicatorLine.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/moveColumnIndicatorLine.js
@@ -13,6 +13,7 @@ export const moveColumnIndicatorLine = ({
   clonedSelectionElement,
   ref,
   spreadsheetCoords,
+  leftScrollAmount,
 }) => {
   const closestCell = event.target.closest(
     `.${blockClass}--interactive-cell-element`
@@ -34,12 +35,13 @@ export const moveColumnIndicatorLine = ({
       closestCellCoords.left -
         spreadsheetCoords.left +
         closestCell.offsetWidth -
-        2
+        2 +
+        leftScrollAmount
     );
   }
   if (Number(newColumnIndex) < Number(originalColumnIndex)) {
     indicatorLineElement.style.left = px(
-      closestCellCoords.left - spreadsheetCoords.left
+      closestCellCoords.left - spreadsheetCoords.left + leftScrollAmount
     );
   }
   if (Number(newColumnIndex) === Number(originalColumnIndex)) {


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1976

Adds support for reordering multiple columns. To achieve this, it required adding the ability to select multiple columns as part of the same selection area. To do this, you can use the Shift key when there is a column header already previously selected.

This also required making changes to how it is detected whether or not a header cell should be in a selected state or not (this happens in `checkSelectedHeaderCell.js`).

See interaction below:
https://user-images.githubusercontent.com/10215203/169886868-12becbbe-5f74-4725-a81e-2c5857c2b104.mov



#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetBody.js
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheetHeader.js
packages/cloud-cognitive/src/components/DataSpreadsheet/_data-spreadsheet.scss
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseMove.js
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useSpreadsheetMouseUp.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/checkSelectedHeaderCell.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleHeaderCellSelection.js
```
#### How did you test and verify your work?
Storybook