### PR TITLE
fix(ComboButton): change import of overflow menu and fix styles

### DIFF
--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
@@ -6,9 +6,12 @@
  */
 
 import { ChevronDown16, ChevronUp16 } from '@carbon/icons-react';
-import { Button, OverflowMenuItem } from 'carbon-components-react';
+import {
+  Button,
+  OverflowMenuItem,
+  OverflowMenu,
+} from 'carbon-components-react';
 
-import { OverflowMenu } from 'carbon-components-react/lib/components/OverflowMenu/OverflowMenu';
 import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
 
 import classnames from 'classnames';

--- a/packages/cloud-cognitive/src/components/ComboButton/_combo-button.scss
+++ b/packages/cloud-cognitive/src/components/ComboButton/_combo-button.scss
@@ -25,7 +25,8 @@
     @include text-overflow;
   }
 
-  .#{$security--prefix}--combo-button__overflow-menu {
+  .#{$security--prefix}--combo-button
+    .#{$security--prefix}--combo-button__overflow-menu {
     width: carbon--mini-units($count: 6);
     height: auto;
     border-left: carbon--rem($px: 1px) solid $ui-03;


### PR DESCRIPTION
Addresses an issue brought up over slack, in regards to overall usage of our library. The way the `OverflowMenu` component was being imported in the ComboButton component was breaking things. I changed it to be imported in the same way other carbon react components are imported.

#### What did you change?
`ComboButton.js`
`_combo-button.scss`
#### How did you test and verify your work?
Storybook