### PR TITLE
fix(ReleaseAction): run yarn again after renaming package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Rename to ibm-cloud-cognitive for legacy publish
         run: |
           yarn json -I -f packages/cloud-cognitive/package.json -e 'this.name="@carbon/ibm-cloud-cognitive"'
+          yarn
           git add .
           git commit -m "chore: rename package for simultaneous publish"
 


### PR DESCRIPTION
Contributes to #2011 

With the new yarn version, renaming a workspace requires `yarn` to be run again. See [here](https://github.com/yarnpkg/berry/issues/2317) for details.

#### What did you change?
`release.yml`
