### PR TITLE
fix(ReleaseAction): run yarn before publsh, not after rename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Rename to ibm-cloud-cognitive for legacy publish
         run: |
           yarn json -I -f packages/cloud-cognitive/package.json -e 'this.name="@carbon/ibm-cloud-cognitive"'
-          yarn
           git add .
           git commit -m "chore: rename package for simultaneous publish"
 
@@ -52,4 +51,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn lerna publish from-package --yes
+        run: |
+          yarn
+          yarn lerna publish from-package --yes


### PR DESCRIPTION
Contributes to #2011 

Upon the last PR addressing this issue, I tried running the release workflow and noticed the same behavior. I realized that running `yarn` was required _before_ the publish of the legacy package, not _after_ actually renaming it. I think this will fix all of the release issues after the yarn upgrade.

#### What did you change?
`release.yml`
#### How did you test and verify your work?
Will test after merging by running the release workflow