### PR TITLE
fix(ReleaseAction): #2011 release fix attempt 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,16 @@ jobs:
         run: yarn lerna publish --create-release github --yes
 
       - name: Rename to ibm-cloud-cognitive for legacy publish
-        run: |
-          yarn json -I -f packages/cloud-cognitive/package.json -e 'this.name="@carbon/ibm-cloud-cognitive"'
-          git add .
-          git commit -m "chore: rename package for simultaneous publish"
+        run: yarn json -I -f packages/cloud-cognitive/package.json -e 'this.name="@carbon/ibm-cloud-cognitive"'
 
       # Run yarn again after renaming package, required after move to yarn berry
-      - name: Install
+      - name: Install after rename
         run: yarn
+      
+      - name: Commit for legacy package
+        run: |
+          git add .
+          git commit -m "chore: rename package for simultaneous publish"
 
       - name: Publish with old name
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,12 @@ jobs:
           git add .
           git commit -m "chore: rename package for simultaneous publish"
 
+      # Run yarn again after renaming package, required after move to yarn berry
+      - name: Install
+        run: yarn
+
       - name: Publish with old name
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          yarn
-          yarn lerna publish from-package --yes
+        run: yarn lerna publish from-package --yes


### PR DESCRIPTION
Contributes to #2011 

Created a separate step to install dependencies after renaming package to support the legacy name to help narrow down what may still be causing release flow to not finish successfully.

#### What did you change?
`release.yml`
#### How did you test and verify your work?
The last release workflow failed so I believe breaking the install into it's own separate step will help