### PR TITLE
fix: Add select modifier functionality

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -82,6 +82,7 @@ export let AddSelect = forwardRef(
     const [displayMetalPanel, setDisplayMetaPanel] = useState({});
     const { sortDirection, setSortDirection, sortAttribute, setSortAttribute } =
       useItemSort();
+    const [appliedModifiers, setAppliedModifiers] = useState([]);
 
     useEffect(() => {
       const { entries } = items;
@@ -94,6 +95,16 @@ export let AddSelect = forwardRef(
             flattenedItems
           );
           setGlobalFilterOpts(globalFilterValues);
+        }
+        if (items.modifiers) {
+          const modifiersToApply = flattenedItems.map((item) => {
+            const modifierAttribute = items.modifiers.id;
+            return {
+              id: item.id,
+              [modifierAttribute]: item[modifierAttribute],
+            };
+          });
+          setAppliedModifiers(modifiersToApply);
         }
         // multi select with nested data needs to be normalized
         if (entries.find((entry) => entry.children)) {
@@ -213,7 +224,16 @@ export let AddSelect = forwardRef(
     };
 
     const submitHandler = () => {
-      onSubmit(multi ? multiSelection : singleSelection);
+      if (multi && appliedModifiers.length > 0) {
+        const selections = multiSelection.map((item) => {
+          return appliedModifiers.find((mod) => mod.id === item);
+        });
+        onSubmit(selections);
+      } else if (multi && appliedModifiers.length === 0) {
+        onSubmit(multiSelection);
+      } else {
+        onSubmit(singleSelection);
+      }
     };
 
     const classNames = cx(className, blockClass, {
@@ -255,6 +275,8 @@ export let AddSelect = forwardRef(
       setMultiSelection,
       displayMetalPanel,
       setDisplayMetaPanel,
+      modifiers: items.modifiers,
+      appliedModifiers,
     };
 
     const setShowBreadsCrumbs = () => {
@@ -352,7 +374,9 @@ export let AddSelect = forwardRef(
               <AddSelectList
                 {...commonListProps}
                 filteredItems={itemsToDisplay}
-                modifiers={items?.modifiers}
+                modifiers={items.modifiers}
+                appliedModifiers={appliedModifiers}
+                setAppliedModifiers={setAppliedModifiers}
               />
             ) : (
               <div className={`${blockClass}__body`}>
@@ -407,6 +431,7 @@ AddSelect.propTypes = {
   influencerTitle: PropTypes.string,
   items: PropTypes.shape({
     modifiers: PropTypes.shape({
+      id: PropTypes.string,
       label: PropTypes.string,
       options: PropTypes.array,
     }),

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -24,6 +24,7 @@ import { pkg } from '../../settings';
 const componentName = 'AddSelectList';
 
 export let AddSelectList = ({
+  appliedModifiers,
   filteredItems,
   metaIconDescription,
   modifiers,
@@ -31,6 +32,7 @@ export let AddSelectList = ({
   multiSelection,
   navIconDescription,
   path,
+  setAppliedModifiers,
   setDisplayMetaPanel,
   setMultiSelection,
   setPath,
@@ -38,6 +40,7 @@ export let AddSelectList = ({
   singleSelection,
 }) => {
   const blockClass = `${pkg.prefix}--add-select__selections`;
+  const hasModifiers = modifiers?.options?.length > 0;
 
   const handleSingleSelection = (value) => {
     setSingleSelection(value);
@@ -96,6 +99,16 @@ export let AddSelectList = ({
 
   const getItemIcon = ({ icon: Icon }) => <Icon />;
 
+  const modifierHandler = (id, selectedItem) => {
+    const modifiersClone = [...appliedModifiers];
+    const modifierIdx = modifiersClone.findIndex((item) => item.id === id);
+    modifiersClone[modifierIdx] = {
+      id,
+      [modifiers.id]: selectedItem,
+    };
+    setAppliedModifiers(modifiersClone);
+  };
+
   return (
     <div className={`${blockClass}-wrapper`}>
       <StructuredListWrapper selection className={`${blockClass}`}>
@@ -144,15 +157,19 @@ export let AddSelectList = ({
                           </div>
                         </div>
                       </div>
-                      {modifiers?.options?.length && (
+                      {hasModifiers && (
                         <Dropdown
                           id={`${item.id}-modifier`}
                           type="inline"
-                          items={modifiers?.options}
+                          items={modifiers.options}
                           light
-                          label={modifiers?.label}
+                          label={modifiers.label}
                           disabled={!isSelected(item.id)}
                           className={`${blockClass}-dropdown ${blockClass}-hidden-hover`}
+                          initialSelectedItem={item[modifiers.id]}
+                          onChange={({ selectedItem }) =>
+                            modifierHandler(item.id, selectedItem)
+                          }
                         />
                       )}
                     </>
@@ -163,8 +180,8 @@ export let AddSelectList = ({
                       id={item.id}
                       value={item.value}
                       labelText={item.title}
-                      onChange={handleSingleSelection}
-                      selected={item.value === singleSelection}
+                      onChange={() => handleSingleSelection(item.id)}
+                      selected={item.id === singleSelection}
                     />
                   )}
                   {item.children && (
@@ -204,6 +221,7 @@ export let AddSelectList = ({
 };
 
 AddSelectList.propTypes = {
+  appliedModifiers: PropTypes.array,
   filteredItems: PropTypes.array,
   metaIconDescription: PropTypes.string,
   modifiers: PropTypes.object,
@@ -211,6 +229,7 @@ AddSelectList.propTypes = {
   multiSelection: PropTypes.array,
   navIconDescription: PropTypes.string,
   path: PropTypes.array,
+  setAppliedModifiers: PropTypes.func,
   setDisplayMetaPanel: PropTypes.func,
   setMultiSelection: PropTypes.func,
   setPath: PropTypes.func,

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
@@ -15,11 +15,13 @@ import { AddSelectMetaPanel } from './AddSelectMetaPanel';
 const componentName = 'AddSelectSidebar';
 
 export let AddSelectSidebar = ({
+  appliedModifiers,
   closeIconDescription,
   displayMetalPanel,
   influencerTitle,
   items,
   metaPanelTitle,
+  modifiers,
   multiSelection,
   noSelectionDescription,
   noSelectionTitle,
@@ -28,6 +30,8 @@ export let AddSelectSidebar = ({
   setMultiSelection,
 }) => {
   const blockClass = `${pkg.prefix}--add-select__sidebar`;
+  const hasModifiers = modifiers?.options?.length > 0;
+  const hasSelections = multiSelection.length > 0;
 
   const handleItemRemove = (id) => {
     const newSelections = multiSelection.filter((v) => v !== id);
@@ -43,17 +47,28 @@ export let AddSelectSidebar = ({
     return acc;
   }, []);
 
-  const getTitle = ({ title, subtitle, id }) => (
+  const getTitle = (item) => (
     <div className={`${blockClass}-accordion-title`}>
       <div className={`${blockClass}-selected-item`}>
-        <p className={`${blockClass}-selected-item-title`}>{title}</p>
-        <p className={`${blockClass}-selected-item-subtitle`}>{subtitle}</p>
+        <p className={`${blockClass}-selected-item-title`}>{item.title}</p>
+        <p className={`${blockClass}-selected-item-subtitle`}>
+          {item.subtitle}
+        </p>
       </div>
+      {hasModifiers && (
+        <div>
+          {
+            appliedModifiers.find((modifier) => modifier.id === item.id)[
+              modifiers.id
+            ]
+          }
+        </div>
+      )}
       <Button
         renderIcon={SubtractAlt32}
         iconDescription={removeIconDescription}
         hasIconOnly
-        onClick={() => handleItemRemove(id)}
+        onClick={() => handleItemRemove(item.id)}
         kind="ghost"
         className={`${blockClass}-item-remove-button`}
         size="sm"
@@ -80,7 +95,7 @@ export let AddSelectSidebar = ({
           {multiSelection.length}
         </Tag>
       </div>
-      {multiSelection.length > 0 ? (
+      {hasSelections ? (
         <Accordion align="start">
           {sidebarItems.map((item) => (
             <AccordionItem title={getTitle(item)} key={item.id}>
@@ -107,11 +122,13 @@ export let AddSelectSidebar = ({
 };
 
 AddSelectSidebar.propTypes = {
+  appliedModifiers: PropTypes.array,
   closeIconDescription: PropTypes.string,
   displayMetalPanel: PropTypes.object,
   influencerTitle: PropTypes.string,
   items: PropTypes.array,
   metaPanelTitle: PropTypes.string,
+  modifiers: PropTypes.object,
   multiSelection: PropTypes.array,
   noSelectionDescription: PropTypes.string,
   noSelectionTitle: PropTypes.string,

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -190,6 +190,7 @@ export const WithModifiers = prepareStory(Template, {
     ...defaultProps,
     items: {
       modifiers: {
+        id: 'role',
         label: 'Role',
         options: ['editor', 'viewer', 'admin'],
       },
@@ -199,17 +200,20 @@ export const WithModifiers = prepareStory(Template, {
           value: '1',
           title: 'item 1',
           subtitle: 'item 1 subtitle',
+          role: 'editor',
         },
         {
           id: '2',
           value: '2',
           title: 'item 2',
+          role: 'editor',
         },
         {
           id: '3',
           value: '3',
           title: 'item 3',
           subtitle: 'item 3 subtitle',
+          role: 'admin',
         },
       ],
     },


### PR DESCRIPTION
Contributes to #2018 

adds modifier functionality to add select multi select. now when the user passes in a modifier object, onMount the existing modifiers will be added to state in `appliedModifiers` which looks like `[{ id: some_id, [modifier_attribute]: some_value }]`

when `onSubmit` is called it now checks for these modifiers and instead of just sending an array of id's it will send an array of objects with the id's and the modifier values.