### PR TITLE
fix(ComboButton): remove getInstanceId and use our internal uuid util

### DIFF
--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
@@ -12,14 +12,11 @@ import {
   OverflowMenu,
 } from 'carbon-components-react';
 
-import setupGetInstanceId from 'carbon-components-react/lib/tools/setupGetInstanceId';
-
 import classnames from 'classnames';
 import { node, shape, string } from 'prop-types';
+import uuidv4 from '../../global/js/utils/uuidv4';
 
 import React, { Children, createElement, useRef, useState } from 'react';
-
-const getInstanceId = setupGetInstanceId();
 
 const blockClass = 'security--combo-button';
 
@@ -36,7 +33,7 @@ const ComboButton = ({
   // Collect any other property values passed in.
   ...rest
 }) => {
-  const { current: instanceId } = useRef(getInstanceId());
+  const { current: instanceId } = useRef(uuidv4());
   const [isOpen, setIsOpen] = useState(false);
 
   const [primaryAction, ...restActions] = Children.toArray(children)


### PR DESCRIPTION
Contributes to ComboButton import still causing build issues.

You can see that [this code sandbox](https://codesandbox.io/s/practical-meadow-c1sgm0?file=/src/App.js) is still have issues starting up because of the import of `setupGetInstanceId` from `carbon-components-react/lib/tools/setupGetInstanceId`. To make sure that we don't run into this issue again, I just replaced `setupGetInstanceId` with our own internal uuid utility.

#### What did you change?
`ComboButton.js`
#### How did you test and verify your work?
Storybook