### PR TITLE
fix: header row horizontal scroll and scrollbar style

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/styles/datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/datagrid.scss
@@ -134,7 +134,14 @@
     }
   }
 }
+.#{$block-class}__grid-container::-webkit-scrollbar-thumb {
+  background-color: $text-03;
+}
 
+.#{$block-class}__grid-container::-webkit-scrollbar {
+  width: 6px;
+  background-color: $ui-background;
+}
 .#{$block-class}__grid-container {
   display: block;
   overflow: auto;
@@ -150,7 +157,7 @@
 
   .#{$block-class}__table-simple {
     display: flex;
-    overflow: hidden;
+    overflow: auto;
     max-height: 100%;
     flex-direction: column;
   }
@@ -301,6 +308,7 @@
 }
 
 .#{$block-class}__simple-body {
+  display:table;
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
@@ -322,6 +330,14 @@
   min-width: 0 !important;
 }
 
+.#{$block-class}__table-simple::-webkit-scrollbar {
+  width: 6px;
+  background-color: $ui-background;
+}
+
+.#{$block-class}__table-simple::-webkit-scrollbar-thumb {
+  background-color: $text-03;
+}
 .#{$block-class}__sticky.#{$block-class}__simple-body {
   overflow: auto;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/datagrid.scss
@@ -308,8 +308,8 @@
 }
 
 .#{$block-class}__simple-body {
-  display:table;
   position: relative;
+  display: table;
   overflow-x: hidden;
   overflow-y: auto;
   //makes thin scrollbar in chrome and firefox


### PR DESCRIPTION
When doing horizontal scrolling in datagrid, header row would not scroll;

In certain datagrid stories(eg., Empty State, Infinite Scroll, Ten Thousand Entries) , the style of scroll bar is set to browser's default style instead of IBM's scrollbar style.


#### What did you change?
`datagrid.scss` 
Changed overflow and display configs so that header row can scroll properly when overflow occurs.
Added selectors to change the scrollbar style of stories to improve consistency

#### How did you test and verify your work?
verified visually in storybook.