### PR TITLE
build(GithubActions): avoid lockfile issues with yarn env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Run yarn again after renaming package, required after move to yarn berry
       - name: Install after rename
-        run: yarn
+        run: yarn --immutable --immutable-cache
       
       - name: Commit for legacy package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Run yarn again after renaming package, required after move to yarn berry
       - name: Install after rename
-        run: yarn --immutable --immutable-cache
+        run: YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
       
       - name: Commit for legacy package
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Update Carbon packages
         run: |
           yarn upgrade:carbon
-          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
 
       - name: Create PR
         id: create-pr

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install
-        run: yarn
+        run: yarn --immutable --immutable-cache
 
       - name: Update Carbon packages
         run: |
           yarn upgrade:carbon
-          yarn
+          yarn install --immutable --immutable-cache
 
       - name: Create PR
         id: create-pr
@@ -72,13 +72,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install
-        run: yarn
+        run: yarn --immutable --immutable-cache
 
       - name: Update packages
         run: |
           yarn upgrade:automatic
           rm yarn.lock
-          yarn
+          yarn --immutable --immutable-cache
 
       - name: Create PR
         id: create-pr

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install
-        run: yarn --immutable --immutable-cache
+        run: yarn
 
       - name: Update Carbon packages
         run: |
           yarn upgrade:carbon
-          yarn install --immutable --immutable-cache
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
       - name: Create PR
         id: create-pr
@@ -72,13 +72,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install
-        run: yarn --immutable --immutable-cache
+        run: yarn
 
       - name: Update packages
         run: |
           yarn upgrade:automatic
           rm yarn.lock
-          yarn --immutable --immutable-cache
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
 
       - name: Create PR
         id: create-pr


### PR DESCRIPTION
Contributes to #2040 

Our `update` and `release` workflows have been failing after the yarn upgrade because of lock file changes. These lock file changes are intended, using the yarn env variable `YARN_ENABLE_IMMUTABLE_INSTALLS` should help in the actions that we have that require lock file changes.

#### What did you change?
```
.github/workflows/release.yml
.github/workflows/update.yml
```


Thanks @joshblack and @tay1orjones for the tips here 🥳 