### PR TITLE
build(actions): update how env variable is instantiated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
 
       # Run yarn again after renaming package, required after move to yarn berry
       - name: Install after rename
-        run: YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+        run: yarn
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
       
       - name: Commit for legacy package
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Update Carbon packages
         run: |
           yarn upgrade:carbon
-          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+          yarn
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Create PR
         id: create-pr
@@ -78,7 +80,9 @@ jobs:
         run: |
           yarn upgrade:automatic
           rm yarn.lock
-          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+          yarn
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Create PR
         id: create-pr


### PR DESCRIPTION
Contributes to #2040 

I think because the yarn environment variables were not initialized correct within the workflow file, they didn't work as expected. I changed it to follow the guidance from github on [setting env variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables#about-environment-variables) within a workflow file

#### What did you change?
`update.yml`
`release.yml`