### PR TITLE
chore(Datagrid): add sticky actions example, fix docs page

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -22,7 +22,7 @@ import { Datagrid } from '.';
 <!-- TODO: One example per designed use case. -->
 
 <Canvas>
-  <Story id={getStoryId(Datagrid.displayName, 'datagrid')} />
+  <Story id={getStoryId(Datagrid.displayName, 'basic-usage')} />
 </Canvas>
 
 ## Code sample

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -9,8 +9,8 @@
 import React, { useState, useEffect } from 'react';
 // TODO: import action to handle events if required.
 // import { action } from '@storybook/addon-actions';
-import namor from 'namor';
 import { useColumnOrder } from 'react-table';
+import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 
@@ -35,6 +35,8 @@ import {
   useDisableSelectRows,
   useCustomizeColumns,
   useSelectAllWithToggle,
+  useStickyColumn,
+  useActionsColumn,
 } from '.';
 import {
   /*StickyActionsColumn,*/ CustomizeColumnStory,
@@ -74,63 +76,6 @@ const Wrapper = ({ children }) => (
     {children}
   </div>
 );
-
-const range = (len) => {
-  const arr = [];
-  for (let i = 0; i < len; i++) {
-    arr.push(i);
-  }
-  return arr;
-};
-
-const newPerson = () => {
-  const statusChance = Math.random();
-  return {
-    firstName: namor.generate({ words: 1, numbers: 0 }),
-    lastName: namor.generate({ words: 1, numbers: 0 }),
-    age: Math.floor(Math.random() * 30),
-    visits: Math.floor(Math.random() * 100),
-    progress: Math.floor(Math.random() * 100),
-    someone1: namor.generate({ words: 1, numbers: 0 }),
-    someone2: namor.generate({ words: 1, numbers: 0 }),
-    someone3: namor.generate({ words: 1, numbers: 0 }),
-    someone4: namor.generate({ words: 1, numbers: 0 }),
-    someone5: namor.generate({ words: 1, numbers: 0 }),
-    someone6: namor.generate({ words: 1, numbers: 0 }),
-    someone7: namor.generate({ words: 1, numbers: 0 }),
-    someone8: namor.generate({ words: 1, numbers: 0 }),
-    someone9: namor.generate({ words: 1, numbers: 0 }),
-    someone10: namor.generate({ words: 1, numbers: 0 }),
-    someone11: namor.generate({ words: 1, numbers: 0 }),
-    someone12: namor.generate({ words: 1, numbers: 0 }),
-    someone13: namor.generate({ words: 1, numbers: 0 }),
-    someone14: namor.generate({ words: 1, numbers: 0 }),
-    someone15: namor.generate({ words: 1, numbers: 0 }),
-    someone16: namor.generate({ words: 1, numbers: 0 }),
-    someone17: namor.generate({ words: 1, numbers: 0 }),
-    someone18: namor.generate({ words: 1, numbers: 0 }),
-    someone19: namor.generate({ words: 1, numbers: 0 }),
-    someone20: namor.generate({ words: 1, numbers: 0 }),
-    status:
-      statusChance > 0.66
-        ? 'relationship'
-        : statusChance > 0.33
-        ? 'complicated'
-        : 'single',
-  };
-};
-
-export const makeData = (...lens) => {
-  const makeDataLevel = (depth = 0) => {
-    const len = lens[depth];
-    return range(len).map(() => ({
-      ...newPerson(),
-      subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
-    }));
-  };
-
-  return makeDataLevel();
-};
 
 const defaultHeader = [
   {
@@ -894,19 +839,6 @@ NestedRows.story = {
   },
 };
 
-const newPersonWithTwoLines = () => {
-  return {
-    firstName: (
-      <>
-        <div>{namor.generate({ words: 1, numbers: 0 })}</div>
-        <div>{namor.generate({ words: 1, numbers: 0 })}</div>
-      </>
-    ),
-    lastName: namor.generate({ words: 1, numbers: 0 }),
-    age: Math.floor(Math.random() * 30),
-  };
-};
-
 const makeDataWithTwoLines = (length) =>
   range(length).map(() => newPersonWithTwoLines());
 
@@ -941,4 +873,71 @@ export const TopAlignment = () => {
   );
 
   return <Datagrid datagridState={{ ...datagridState }} />;
+};
+
+export const StickyActionsColumn = () => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: '',
+        accessor: 'actions',
+        sticky: 'right',
+        width: 60,
+        isAction: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const [msg, setMsg] = useState('click action menu');
+  const onActionClick = (actionId, row) => {
+    const { original } = row;
+    setMsg(
+      `Clicked [${actionId}] on row: <${original.firstName} ${original.lastName}>`
+    );
+  };
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      rowActions: [
+        {
+          id: 'edit',
+          itemText: 'Edit',
+          onClick: onActionClick,
+        },
+        {
+          id: 'vote',
+          itemText: 'Vote',
+          onClick: onActionClick,
+          shouldHideMenuItem: (row) => row.original.age <= 18,
+        },
+        {
+          id: 'retire',
+          itemText: 'Retire',
+          onClick: onActionClick,
+          disabled: false,
+          shouldDisableMenuItem: (row) => row.original.age <= 60,
+        },
+        {
+          id: 'delete',
+          itemText: 'Delete',
+          hasDivider: true,
+          isDelete: true,
+          onClick: onActionClick,
+        },
+      ],
+    },
+    useStickyColumn,
+    useActionsColumn
+  );
+  return (
+    <Wrapper>
+      <h3>{msg}</h3>
+      <Datagrid datagridState={{ ...datagridState }} />
+      <p>More details documentation check the Notes section below</p>
+    </Wrapper>
+  );
 };

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories/StickyActionsColumnStory.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories/StickyActionsColumnStory.js
@@ -1,183 +1,102 @@
-import React, { useState, useEffect } from 'react';
-import { Datagrid, useActionsColumn, useDatagrid, useStickyColumn } from '..';
-import { defaultHeader, makeData, Wrapper } from './common';
+// import React, { useState, useEffect } from 'react';
+// import { Datagrid, useActionsColumn, useDatagrid, useStickyColumn } from '..';
+// import { defaultHeader, makeData, Wrapper } from './common';
 
-const StickyActionsColumn = () => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader,
-      {
-        Header: '',
-        accessor: 'actions',
-        sticky: 'right',
-        width: 60,
-        isAction: true,
-      },
-    ],
-    []
-  );
-  const [data, setData] = useState([]);
-  const [msg, setMsg] = useState('click action menu');
-  const onActionClick = (actionId, row) => {
-    const { original } = row;
-    setMsg(
-      `Clicked [${actionId}] on row: <${original.firstName} ${original.lastName}>`
-    );
-  };
-  const [isFetching, setIsFetching] = useState(true);
+// StickyActionsColumn.story = {
+//   parameters: {
+//     notes: `
+//     Sticky column and actions column can be used at the same time like the demo above. Following is the doc for each of them.
 
-  useEffect(() => {
-    const fetchData = () =>
-      new Promise((resolve) => {
-        setIsFetching(true);
-        setTimeout(() => {
-          setData(data.concat(makeData(30, 5, 2)));
-          resolve();
-        }, 1000);
-      }).then(() => setIsFetching(false));
-    fetchData();
-  }, [data]);
+//     # Sticky column
+//     This will make the column mark with \`sticky: "right"\` to be sticky on the right.
 
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      isFetching,
-      rowActions: [
-        {
-          id: 'edit',
-          itemText: 'Edit',
-          onClick: onActionClick,
-        },
-        {
-          id: 'vote',
-          itemText: 'Vote',
-          onClick: onActionClick,
-          shouldHideMenuItem: (row) => row.original.age <= 18,
-        },
-        {
-          id: 'retire',
-          itemText: 'Retire',
-          onClick: onActionClick,
-          disabled: false,
-          shouldDisableMenuItem: (row) => row.original.age <= 60,
-        },
-        {
-          id: 'delete',
-          itemText: 'Delete',
-          hasDivider: true,
-          isDelete: true,
-          onClick: onActionClick,
-        },
-      ],
-    },
-    useStickyColumn,
-    useActionsColumn
-  );
-  return (
-    <Wrapper>
-      <h3>{msg}</h3>
-      <Datagrid {...datagridState} />
-      <p>More details documentation check the Notes section below</p>
-    </Wrapper>
-  );
-};
+//     ## Incompatible with following plugins:
+//     - \`useInfiniteScroll\`
 
-StickyActionsColumn.story = {
-  parameters: {
-    notes: `
-    Sticky column and actions column can be used at the same time like the demo above. Following is the doc for each of them.
+//     ## Sample usage:
 
-    # Sticky column
-    This will make the column mark with \`sticky: "right"\` to be sticky on the right.
+//     1. include the \`useStickyColumn\` hook
+//     2. add \`sticky="right"\` to the column object
 
-    ## Incompatible with following plugins:
-    - \`useInfiniteScroll\`
+//     \`\`\`js
+//     const columns = [
+//       ... // other columns
+//       {
+//         Header: "",
+//         accessor: "actions",
+//         sticky: "right",
+//         width: 60,
+//       },
+//     ]
+//     const datagridState = useDatagrid(
+//       {
+//         columns,
+//         data,
+//       },
+//       useStickyColumn
+//     );
+//     \`\`\`
+//     \`\`\`html
+//     <Datagrid {...datagridState} />
+//     \`\`\`
 
-    ## Sample usage:
-    
-    1. include the \`useStickyColumn\` hook
-    2. add \`sticky="right"\` to the column object
+//     # Actions column
+//     This will add OverflowMenu component to the cells on the column mark with \`isAction: true\`. Each action button callback will include the actionId and row object
 
-    \`\`\`js
-    const columns = [
-      ... // other columns
-      {
-        Header: "",
-        accessor: "actions",
-        sticky: "right",
-        width: 60,
-      },
-    ]
-    const datagridState = useDatagrid(
-      {
-        columns,
-        data,
-      },
-      useStickyColumn
-    );
-    \`\`\`
-    \`\`\`html
-    <Datagrid {...datagridState} />
-    \`\`\`
+//     ## Sample usage:
+//     1. include \`useActionsColumn\` hook
+//     2. add \`isAction = true\` to the column object in which you which to add the overflow menu actions
+//     3. add \`rowActions = []\` array to the props
+//       - \`rowActions[].id\` for callback to identify the action is called
+//       - \`rowActions[].onClick(actionId: string, row: Row, event: ClickEvent)\` callback on menuitem clicked. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+//       - \`rowActions[].shouldHideMenuItem(row: Row)\` callback to hide this menuitem. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+//       - \`rowActions[].shouldDisableMenuItem(row: Row)\` callback to disable this menuitem. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+//         - This will override \`rowActions[].disabled\` (from Carbon) because \`shouldDisableMenuItem\` is more specific to the row.
+//       - each action object can take all the props from \`OverflowMenuItem\` props, see [carbon docs](https://react.carbondesignsystem.com/?path=/docs/components-overflowmenu--default#overflowmenu)
 
-    # Actions column
-    This will add OverflowMenu component to the cells on the column mark with \`isAction: true\`. Each action button callback will include the actionId and row object
+//     \`\`\`js
+//     const columns = [
+//       ... // other columns
+//       {
+//         Header: "",
+//         accessor: "actions",
+//         isAction: true,
+//       },
+//     ]
+//     const onActionClick = (actionId, row, event) => {};
+//     const datagridState = useDatagrid(
+//       {
+//         columns,
+//         data,
+//         rowActions: [
+//           {
+//             id: 'edit',
+//             itemText: 'Edit',
+//             onClick: onActionClick
+//           },
+//           {
+//             id: 'hidden',
+//             itemText: 'Hidden item',
+//             onClick: onActionClick,
+//             shouldHideMenuItem: () => true,
+//           },
+//           {
+//             id: 'delete',
+//             itemText: 'Delete',
+//             hasDivider: true,
+//             isDelete: true,
+//             onClick: onActionClick
+//           },
+//         ]
+//       },
+//       useActionsColumn,
+//     );
+//     \`\`\`
+//     \`\`\`html
+//     <Datagrid {...datagridState} />
+//     \`\`\`
+//     `,
+//   },
+// };
 
-    ## Sample usage:
-    1. include \`useActionsColumn\` hook
-    2. add \`isAction = true\` to the column object in which you which to add the overflow menu actions
-    3. add \`rowActions = []\` array to the props
-      - \`rowActions[].id\` for callback to identify the action is called
-      - \`rowActions[].onClick(actionId: string, row: Row, event: ClickEvent)\` callback on menuitem clicked. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
-      - \`rowActions[].shouldHideMenuItem(row: Row)\` callback to hide this menuitem. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
-      - \`rowActions[].shouldDisableMenuItem(row: Row)\` callback to disable this menuitem. [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
-        - This will override \`rowActions[].disabled\` (from Carbon) because \`shouldDisableMenuItem\` is more specific to the row.
-      - each action object can take all the props from \`OverflowMenuItem\` props, see [carbon docs](https://react.carbondesignsystem.com/?path=/docs/components-overflowmenu--default#overflowmenu)
-
-    \`\`\`js
-    const columns = [
-      ... // other columns
-      {
-        Header: "",
-        accessor: "actions",
-        isAction: true,
-      },
-    ]
-    const onActionClick = (actionId, row, event) => {};
-    const datagridState = useDatagrid(
-      {
-        columns,
-        data,
-        rowActions: [
-          {
-            id: 'edit',
-            itemText: 'Edit',
-            onClick: onActionClick
-          },
-          {
-            id: 'hidden',
-            itemText: 'Hidden item',
-            onClick: onActionClick,
-            shouldHideMenuItem: () => true,
-          },
-          {
-            id: 'delete',
-            itemText: 'Delete',
-            hasDivider: true,
-            isDelete: true,
-            onClick: onActionClick
-          },
-        ]
-      },
-      useActionsColumn,
-    );
-    \`\`\`
-    \`\`\`html
-    <Datagrid {...datagridState} />
-    \`\`\`
-    `,
-  },
-};
-
-export default StickyActionsColumn;
+// export default StickyActionsColumn;

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -10,7 +10,7 @@ import { render, screen } from '@testing-library/react'; // https://testing-libr
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { useDatagrid } from '.';
-import { makeData } from './Datagrid.stories';
+import { makeData } from './utils/makeData';
 
 import { carbon } from '../../settings';
 import { expectWarn } from '../../global/js/utils/test-helper';

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import namor from 'namor';
+
+export const makeData = (...lens) => {
+  const makeDataLevel = (depth = 0) => {
+    const len = lens[depth];
+    return range(len).map(() => ({
+      ...newPerson(),
+      subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+    }));
+  };
+
+  return makeDataLevel();
+};
+
+export const range = (len) => {
+  const arr = [];
+  for (let i = 0; i < len; i++) {
+    arr.push(i);
+  }
+  return arr;
+};
+
+const newPerson = () => {
+  const statusChance = Math.random();
+  return {
+    firstName: namor.generate({ words: 1, numbers: 0 }),
+    lastName: namor.generate({ words: 1, numbers: 0 }),
+    age: Math.floor(Math.random() * 30),
+    visits: Math.floor(Math.random() * 100),
+    progress: Math.floor(Math.random() * 100),
+    someone1: namor.generate({ words: 1, numbers: 0 }),
+    someone2: namor.generate({ words: 1, numbers: 0 }),
+    someone3: namor.generate({ words: 1, numbers: 0 }),
+    someone4: namor.generate({ words: 1, numbers: 0 }),
+    someone5: namor.generate({ words: 1, numbers: 0 }),
+    someone6: namor.generate({ words: 1, numbers: 0 }),
+    someone7: namor.generate({ words: 1, numbers: 0 }),
+    someone8: namor.generate({ words: 1, numbers: 0 }),
+    someone9: namor.generate({ words: 1, numbers: 0 }),
+    someone10: namor.generate({ words: 1, numbers: 0 }),
+    someone11: namor.generate({ words: 1, numbers: 0 }),
+    someone12: namor.generate({ words: 1, numbers: 0 }),
+    someone13: namor.generate({ words: 1, numbers: 0 }),
+    someone14: namor.generate({ words: 1, numbers: 0 }),
+    someone15: namor.generate({ words: 1, numbers: 0 }),
+    someone16: namor.generate({ words: 1, numbers: 0 }),
+    someone17: namor.generate({ words: 1, numbers: 0 }),
+    someone18: namor.generate({ words: 1, numbers: 0 }),
+    someone19: namor.generate({ words: 1, numbers: 0 }),
+    someone20: namor.generate({ words: 1, numbers: 0 }),
+    status:
+      statusChance > 0.66
+        ? 'relationship'
+        : statusChance > 0.33
+        ? 'complicated'
+        : 'single',
+  };
+};
+
+export const newPersonWithTwoLines = () => {
+  return {
+    firstName: (
+      <>
+        <div>{namor.generate({ words: 1, numbers: 0 })}</div>
+        <div>{namor.generate({ words: 1, numbers: 0 })}</div>
+      </>
+    ),
+    lastName: namor.generate({ words: 1, numbers: 0 }),
+    age: Math.floor(Math.random() * 30),
+  };
+};


### PR DESCRIPTION
Contributes to #1609 

Adds a story for sticky row actions. Also fixed the docs tab for the Datagrid which wasn't loading previously. Lastly, the `makeData` function was being exported inside of the `.stories.js` file which made it appear in storybook as a story. I moved it, along with a few other utilities, into it's own separate file so it can be used for the stories and for testing.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories/StickyActionsColumnStory.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
```
#### How did you test and verify your work?
Storybook

See overflow menu from sticky row actions in screenshot below:
![image (86)](https://user-images.githubusercontent.com/10215203/175044867-bf64257f-9446-4987-bdfa-5b53881be8d2.png)

