### PR TITLE
feat: merged left panel content and datagrid on same horizontal level

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSidebar.js
@@ -38,7 +38,7 @@ export let AddSelectSidebar = ({
     const selectedItem = items.find((item) => item.id === cur);
     // certain properties should not be displayed in the sidebar
     // eslint-disable-next-line no-unused-vars
-    const { icon, avatar, ...newItem } = selectedItem;
+    const { meta, icon, avatar, ...newItem } = selectedItem;
     acc.push(newItem);
     return acc;
   }, []);

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -776,14 +776,22 @@ export const LeftPanel = () => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
   const datagridState = useDatagrid({
+    leftPanel: {
+      isOpen: true, // this toggling will happen from datagridActions.
+      panelContent: (
+        <div style={{ display: 'inline' }}>
+          Panel content will go here along with any button interactions
+        </div>
+      ),
+    },
     columns,
     data,
-    leftPanel: {
+    /*leftPanel: {
       isOpen: true, // this toggling will happen from datagridActions.
       panelContent: (
         <div>Panel content will go here along with any button interactions</div>
       ),
-    },
+    },*/
     DatagridActions,
     DatagridBatchActions,
   });

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/Datagrid.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/Datagrid.js
@@ -98,6 +98,7 @@ export let Datagrid = React.forwardRef(({ datagridState, ...rest }, ref) => {
       {leftPanel && (
         <div
           className={`${blockClass}__grid-container ${blockClass}__displayFlex`}
+          style={{ display: 'inherit' }}
         >
           {leftPanel && leftPanel.isOpen && (
             <div className={`${blockClass}__datagridLeftPanel`}>


### PR DESCRIPTION
Contributes to #1891 

{{short description}}
The datagrid table (on the right) and the panel content (on the left)  are now horizontally aligned on the same level, instead of being vertically stacked on each other (in our case, the panel content was on top of the datagrid table).

#### What did you change?
The change that I made is, I changed the div with the classes <b>c4p--datagrid__grid-container</b> and <b>c4p--datagrid__displayFlex</b>, to have a display value of inherit.

#### How did you test and verify your work?
I tested and verified my work by ensuring that I received the expected result (panel content and datagrid table next to each other) when running storybook.

<img width="1680" alt="Screenshot 2022-06-23 at 9 31 31 AM" src="https://user-images.githubusercontent.com/105299556/175648357-b82491ed-1cad-4674-8759-cd0f6f2662b3.png">

