### PR TITLE
feat: add multiline attribute to tagset

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3284,6 +3284,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   display: inline-flex;
   white-space: nowrap;
 }
+.c4p--tag-set .c4p--tag-set__tag-container--multiline {
+  flex-wrap: wrap;
+}
 .c4p--tag-set .c4p--tag-set__tag-container--hidden {
   position: absolute;
   top: -100vh;

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -42,6 +42,7 @@ export let TagSet = React.forwardRef(
       allTagsModalTarget: allTagsModalTargetIn, // = defaults.allTagsModalTarget,
       className,
       maxVisible,
+      multiline,
       overflowAlign = defaults.overflowAlign,
       overflowClassName,
       overflowDirection = defaults.overflowDirection,
@@ -158,6 +159,10 @@ export let TagSet = React.forwardRef(
     ]);
 
     const checkFullyVisibleTags = useCallback(() => {
+      if (multiline) {
+        return setDisplayCount(maxVisible);
+      }
+
       // how many will fit?
       let willFit = 0;
 
@@ -192,11 +197,11 @@ export let TagSet = React.forwardRef(
       } else {
         setDisplayCount(maxVisible ? Math.min(willFit, maxVisible) : willFit);
       }
-    }, [maxVisible, sizingTags, tagSetRef]);
+    }, [maxVisible, multiline, sizingTags, tagSetRef]);
 
     useEffect(() => {
       checkFullyVisibleTags();
-    }, [checkFullyVisibleTags, maxVisible, sizingTags]);
+    }, [checkFullyVisibleTags, maxVisible, multiline, sizingTags]);
 
     /* don't know how to test resize */
     /* istanbul ignore next */
@@ -247,7 +252,13 @@ export let TagSet = React.forwardRef(
             {hiddenSizingTags}
           </div>
 
-          <div className={`${blockClass}__tag-container`} ref={displayedArea}>
+          <div
+            className={cx([
+              `${blockClass}__tag-container`,
+              multiline && `${blockClass}__tag-container--multiline`,
+            ])}
+            ref={displayedArea}
+          >
             {displayedTags}
           </div>
         </div>
@@ -328,6 +339,10 @@ TagSet.propTypes = {
    * maximum visible tags
    */
   maxVisible: PropTypes.number,
+  /**
+   * display tags in multiple lines
+   */
+  multiline: PropTypes.bool,
   /**
    * overflowAlign from the standard tooltip. Default center.
    */

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.stories.js
@@ -192,6 +192,15 @@ export const ManyTags = prepareStory(Template, {
   },
 });
 
+export const MultilineTags = prepareStory(Template, {
+  args: {
+    tags: manyTags,
+    containerWidth: 500,
+    multiline: true,
+    ...overflowAndModalStrings,
+  },
+});
+
 export const HundredsOfTags = prepareStory(Template, {
   args: {
     tags: hundredsOfTags,

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -48,6 +48,10 @@ $block-class-modal: #{$block-class}-modal;
       white-space: nowrap;
     }
 
+    .#{$block-class}__tag-container--multiline {
+      flex-wrap: wrap;
+    }
+
     .#{$block-class}__tag-container--hidden {
       // This tag container is used to measure the width of all displayable tags
       @include measuring-container;


### PR DESCRIPTION
Contributes to #2078

TagSet with multiline attribute

#### What did you change?
Add a multiline attribute to TagSet

#### How did you test and verify your work?
Open storybook and open the TagSet > multiline story

Result:
![image](https://user-images.githubusercontent.com/3808948/177786312-4b4b28a5-350d-43b8-9de4-5a3710427f26.png)
