### PR TITLE
chore(card overflow): height issue fixed

### DIFF
--- a/packages/cloud-cognitive/src/components/Card/Card.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.js
@@ -113,7 +113,7 @@ export let Card = forwardRef(
                 renderIcon={Icon}
                 hasIconOnly
                 onClick={onClick}
-                size={actionsPlacement === 'top' ? 'sm' : 'field'}
+                size="sm"
                 iconDescription={iconDescription}
                 kind="ghost"
                 href={href}


### PR DESCRIPTION
Contributes to #2017 

Overflow menu icon needs to have a height of 40px. Currently it is 48px.

#### What did you change?
Added extra styles for height in card.scss.

#### How did you test and verify your work?
storybook
