### PR TITLE
fix(user-profile-image): changed prop types to pass test

### DIFF
--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
@@ -185,7 +185,7 @@ UserProfileImage.propTypes = {
   /**
    * Provide a custom icon to use if you need to use an icon other than the included ones
    */
-  icon: PropTypes.object,
+  icon: PropTypes.func,
 
   /**
    * When passing the image prop, supply a full path to the image to be displayed.


### PR DESCRIPTION
Contributes to #2071 

Carbon v11 icons are now a function instead of an object. Changed proptypes to reflect this

#### What did you change?
packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js


