### PR TITLE
chore: finish up add select testing

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -8,7 +8,7 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { AddSelectBody } from './AddSelectBody';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import { getGlobalFilterValues, normalize } from './add-select-utils';
 import { Document16 } from '@carbon/icons-react';
 import image from '../UserProfileImage/headshot.png'; // cspell:disable-line
@@ -287,26 +287,27 @@ describe(componentName, () => {
     const childrenBtn = document.querySelectorAll(
       `.${blockClass}__selections-view-children`
     );
-    expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(1);
-    expect(
-      document.querySelectorAll('.bx--breadcrumb-item')[0].textContent
-    ).toBe('Business terms');
+    const breadcrumbClass = `.${carbon.prefix}--breadcrumb-item`;
+    expect(document.querySelectorAll(breadcrumbClass).length).toEqual(1);
+    expect(document.querySelectorAll(breadcrumbClass)[0].textContent).toBe(
+      'Business terms'
+    );
     fireEvent.click(childrenBtn[0]);
-    expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(2);
-    expect(
-      document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
-    ).toBe('California');
-    fireEvent.click(document.querySelectorAll('.bx--breadcrumb-item')[0]);
-    expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(1);
+    expect(document.querySelectorAll(breadcrumbClass).length).toEqual(2);
+    expect(document.querySelectorAll(breadcrumbClass)[1].textContent).toBe(
+      'California'
+    );
+    fireEvent.click(document.querySelectorAll(breadcrumbClass)[0]);
+    expect(document.querySelectorAll(breadcrumbClass).length).toEqual(1);
     fireEvent.click(childrenBtn[0]);
     fireEvent.click(childrenBtn[1]);
-    expect(
-      document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
-    ).toBe('Georgia');
+    expect(document.querySelectorAll(breadcrumbClass)[1].textContent).toBe(
+      'Georgia'
+    );
     fireEvent.click(childrenBtn[1]);
-    expect(
-      document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
-    ).toBe('Georgia');
+    expect(document.querySelectorAll(breadcrumbClass)[1].textContent).toBe(
+      'Georgia'
+    );
   });
 
   it('handles multi select submit', () => {
@@ -341,7 +342,7 @@ describe(componentName, () => {
     const dropdown = document.querySelector('#add-select-modifier-1 button');
     fireEvent.click(dropdown);
     const modifierOpts = document.querySelectorAll(
-      '#add-select-modifier-1 .bx--list-box__menu-item'
+      `#add-select-modifier-1 .${carbon.prefix}--list-box__menu-item`
     );
     fireEvent.click(modifierOpts[1]);
     fireEvent.click(opt2);
@@ -419,7 +420,7 @@ describe(componentName, () => {
     fireEvent.click(screen.getByText('default'));
     fireEvent.click(screen.getByText('Apply'));
     expect(screen.getByText('tag: default'));
-    const closeIcon = document.querySelector('.bx--tag button');
+    const closeIcon = document.querySelector(`.${carbon.prefix}--tag button`);
     fireEvent.click(closeIcon);
     expect(screen.queryByText('tag: default')).toBeNull();
   });

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -10,6 +10,8 @@ import React from 'react';
 import { AddSelectBody } from './AddSelectBody';
 import { pkg } from '../../settings';
 import { getGlobalFilterValues, normalize } from './add-select-utils';
+import { Document16 } from '@carbon/icons-react';
+import image from '../UserProfileImage/headshot.png'; // cspell:disable-line
 
 const blockClass = `${pkg.prefix}--add-select`;
 const componentName = AddSelectBody.name;
@@ -20,6 +22,7 @@ const defaultItems = {
       title: 'Kansas',
       value: 'kansas',
       tag: 'default',
+      subtitle: 'test subtitle',
     },
     {
       id: '2',
@@ -167,6 +170,31 @@ const itemsWithMeta = {
   ],
 };
 
+const itemWithIcon = {
+  entries: [
+    {
+      id: '1',
+      value: 'kansas',
+      title: 'Kansas',
+      icon: Document16,
+    },
+  ],
+};
+
+const itemWithAvatar = {
+  entries: [
+    {
+      id: '1',
+      value: 'kansas',
+      title: 'Kansas',
+      avatar: {
+        src: image,
+        alt: 'head shot',
+      },
+    },
+  ],
+};
+
 describe(componentName, () => {
   const { ResizeObserver } = window;
 
@@ -226,7 +254,7 @@ describe(componentName, () => {
   it('displays child items', () => {
     render(<AddSelectBody {...singleHierarchyProps} />);
     const childrenButton = document.querySelector(
-      `.${pkg.prefix}--add-select__selections-view-children`
+      `.${blockClass}__selections-view-children`
     );
     expect(screen.queryByText('Los Angeles')).toBeNull();
     fireEvent.click(childrenButton);
@@ -236,7 +264,7 @@ describe(componentName, () => {
   it('displays breadcrumbs', () => {
     render(<AddSelectBody {...singleHierarchyProps} />);
     const childrenButton = document.querySelector(
-      `.${pkg.prefix}--add-select__selections-view-children`
+      `.${blockClass}__selections-view-children`
     );
     expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(1);
     expect(
@@ -276,41 +304,28 @@ describe(componentName, () => {
     const submitBtn = screen.getByText('Add');
     const opt1 = screen.getByLabelText('Kansas');
     const opt2 = screen.getByLabelText('Texas');
+    const opt3 = screen.getByLabelText('Florida');
     fireEvent.click(opt1);
+    const dropdown = document.querySelector('#add-select-modifier-1 button');
+    fireEvent.click(dropdown);
+    const modifierOpts = document.querySelectorAll(
+      '#add-select-modifier-1 .bx--list-box__menu-item'
+    );
+    fireEvent.click(modifierOpts[1]);
     fireEvent.click(opt2);
+    fireEvent.click(opt3);
+    fireEvent.click(opt3);
     fireEvent.click(submitBtn);
     expect(onSubmit).toBeCalledWith([
       {
         id: '1',
-        role: 'editor',
+        role: 'admin',
       },
       {
         id: '2',
         role: 'editor',
       },
     ]);
-  });
-
-  it('handles multi select with hierarchy', () => {
-    const newProps = {
-      ...multiProps,
-      items: hierarchyItems,
-      useNormalizedItems: true,
-      normalizedItems: normalize(hierarchyItems),
-    };
-    render(<AddSelectBody {...newProps} />);
-    expect(
-      document.querySelector(`.${blockClass}__columns`)
-    ).toBeInTheDocument();
-    const opt1 = screen.getByLabelText('Kansas');
-    const opt2 = screen.getByLabelText('Texas');
-    fireEvent.click(opt1);
-    fireEvent.click(opt2);
-    expect(
-      document.querySelectorAll(
-        `.${pkg.prefix}--add-select__sidebar-selected-item-title`
-      ).length
-    ).toBe(2);
   });
 
   it('handles items with meta data', () => {
@@ -323,6 +338,24 @@ describe(componentName, () => {
     expect(metaBtn);
     fireEvent.click(metaBtn);
     expect(screen.getByText(newProps.metaPanelTitle));
+  });
+
+  it('handles items with icons', () => {
+    const newProps = {
+      ...multiProps,
+      items: itemWithIcon,
+    };
+    render(<AddSelectBody {...newProps} />);
+    expect(document.querySelector(`${blockClass}__selections-cell-icon`));
+  });
+
+  it('handles items with avatar', () => {
+    const newProps = {
+      ...multiProps,
+      items: itemWithAvatar,
+    };
+    render(<AddSelectBody {...newProps} />);
+    expect(document.querySelector(`${blockClass}-cell-avatar`));
   });
 
   it('filters with global filters', () => {
@@ -339,14 +372,58 @@ describe(componentName, () => {
       globalFilterOpts: getGlobalFilterValues(globalFilters, normalizedItems),
     };
     render(<AddSelectBody {...newProps} />);
-    const filterToggle = screen.getByLabelText('Filter');
-    fireEvent.click(filterToggle);
-    const dropdown = screen.getByTitle('Choose an option');
-    fireEvent.click(dropdown);
-    const value = screen.getByText('default');
-    fireEvent.click(value);
-    const applyBtn = screen.getByText('Apply');
-    fireEvent.click(applyBtn);
-    expect(screen.queryByText('kansas'));
+    fireEvent.click(screen.getByLabelText('Filter'));
+    fireEvent.click(screen.getByTitle('Choose an option'));
+    fireEvent.click(screen.getByText('default'));
+    fireEvent.click(screen.getByText('Apply'));
+    expect(screen.getByText('tag: default'));
+    // test clear filters
+    const clearFiltersBtn = screen.getByText('Clear filters');
+    fireEvent.click(clearFiltersBtn);
+    expect(screen.queryByText('tag: default')).toBeNull();
+    // test clear tag
+    fireEvent.click(screen.getByLabelText('Filter'));
+    fireEvent.click(screen.getByTitle('Choose an option'));
+    fireEvent.click(screen.getByText('default'));
+    fireEvent.click(screen.getByText('Apply'));
+    expect(screen.getByText('tag: default'));
+    const closeIcon = document.querySelector('.bx--tag button');
+    fireEvent.click(closeIcon);
+    expect(screen.queryByText('tag: default')).toBeNull();
+  });
+
+  it('filters columns', () => {
+    const normalizedItems = normalize(hierarchyItems);
+    const newProps = {
+      ...multiProps,
+      items: hierarchyItems,
+      useNormalizedItems: true,
+      normalizedItems,
+    };
+    render(<AddSelectBody {...newProps} />);
+    const input = screen.getByPlaceholderText('Find');
+    fireEvent.change(input, { target: { value: 'florida' } });
+    expect(screen.findByText('florida'));
+    fireEvent.change(input, { target: { value: '' } });
+    const selectAll = document.querySelector(
+      '.c4p--add-select__column__select-all'
+    );
+    fireEvent.click(selectAll);
+    expect(
+      document.querySelectorAll('.c4p--add-select__sidebar-accordion-title')
+        .length
+    ).toBe(4);
+    fireEvent.click(selectAll);
+    expect(
+      document.querySelectorAll('.c4p--add-select__sidebar-accordion-title')
+        .length
+    ).toBe(0);
+    fireEvent.click(
+      document.querySelector(`.c4p--add-select__selections-view-children`)
+    );
+    expect(screen.findByText('Los Angeles'));
+    const globalSearch = screen.getByPlaceholderText('Find business terms');
+    fireEvent.change(globalSearch, { target: { value: 'florida' } });
+    fireEvent.change(globalSearch, { target: { value: '' } });
   });
 });

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -80,6 +80,20 @@ const hierarchyItems = {
         ],
       },
     },
+    {
+      id: '6',
+      title: 'Georgia',
+      value: 'georgia',
+      children: {
+        entries: [
+          {
+            id: '7',
+            title: 'Atlanta',
+            value: 'atl',
+          },
+        ],
+      },
+    },
   ],
 };
 
@@ -261,20 +275,38 @@ describe(componentName, () => {
     expect(screen.queryByText('Los Angeles'));
   });
 
-  it('displays breadcrumbs', () => {
-    render(<AddSelectBody {...singleHierarchyProps} />);
-    const childrenButton = document.querySelector(
+  it('handles breadcrumbs', () => {
+    const normalizedItems = normalize(hierarchyItems);
+    const newProps = {
+      ...multiProps,
+      items: hierarchyItems,
+      useNormalizedItems: true,
+      normalizedItems,
+    };
+    render(<AddSelectBody {...newProps} />);
+    const childrenBtn = document.querySelectorAll(
       `.${blockClass}__selections-view-children`
     );
     expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(1);
     expect(
       document.querySelectorAll('.bx--breadcrumb-item')[0].textContent
-    ).toBe('Categories');
-    fireEvent.click(childrenButton);
+    ).toBe('Business terms');
+    fireEvent.click(childrenBtn[0]);
     expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(2);
     expect(
       document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
     ).toBe('California');
+    fireEvent.click(document.querySelectorAll('.bx--breadcrumb-item')[0]);
+    expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(1);
+    fireEvent.click(childrenBtn[0]);
+    fireEvent.click(childrenBtn[1]);
+    expect(
+      document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
+    ).toBe('Georgia');
+    fireEvent.click(childrenBtn[1]);
+    expect(
+      document.querySelectorAll('.bx--breadcrumb-item')[1].textContent
+    ).toBe('Georgia');
   });
 
   it('handles multi select submit', () => {
@@ -412,7 +444,7 @@ describe(componentName, () => {
     expect(
       document.querySelectorAll('.c4p--add-select__sidebar-accordion-title')
         .length
-    ).toBe(4);
+    ).toBe(5);
     fireEvent.click(selectAll);
     expect(
       document.querySelectorAll('.c4p--add-select__sidebar-accordion-title')

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBreadcrumbs.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBreadcrumbs.test.js
@@ -8,6 +8,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { AddSelectBreadcrumbs } from './AddSelectBreadcrumbs';
+import { carbon } from '../../settings';
 
 const componentName = AddSelectBreadcrumbs.name;
 const defaultProps = {
@@ -68,9 +69,12 @@ describe(componentName, () => {
     render(<AddSelectBreadcrumbs {...newProps} />);
     expect(screen.getByText('default'));
     expect(screen.getByText('level 2'));
-    expect(document.querySelectorAll('.bx--breadcrumb-item').length).toEqual(2);
     expect(
-      document.querySelectorAll('.bx--breadcrumb-item--current').length
+      document.querySelectorAll(`.${carbon.prefix}--breadcrumb-item`).length
+    ).toEqual(2);
+    expect(
+      document.querySelectorAll(`.${carbon.prefix}--breadcrumb-item--current`)
+        .length
     ).toEqual(1);
   });
 });

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
@@ -168,6 +168,7 @@ export let AddSelectColumn = ({
         <div className={`${blockClass}__tag-container`}>
           <Checkbox
             id={`${uuidv4()}-select-all`}
+            className={`${colClass}__select-all`}
             checked={allSelected}
             onChange={selectAllHandler}
             labelText={

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -135,7 +135,7 @@ export let AddSelectList = ({
                       </div>
                       {hasModifiers && (
                         <Dropdown
-                          id={`${item.id}-modifier`}
+                          id={`add-select-modifier-${item.id}`}
                           type="inline"
                           items={modifiers.options}
                           light


### PR DESCRIPTION
Contributes to #2124 

adds additional testing to finish up `AddSelect` coverage.

![Screenshot 2022-07-22 at 16-11-01 Code coverage report for src_components_AddSelect](https://user-images.githubusercontent.com/6370760/180569302-e322deae-427a-435a-8283-94ddc1cd0c38.png)

note- the coverage isn't 100% because an error caused by carbon is preventing me from creating passing tests

<img width="748" alt="Screen Shot 2022-07-22 at 4 13 06 PM" src="https://user-images.githubusercontent.com/6370760/180569407-876c68d3-7261-408e-a987-79bdf4ce1c01.png">
