### PR TITLE
fix(Datagrid): fix issue in StickyActionColumn tests

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -837,14 +837,11 @@ const StickyActionsColumn = ({ ...rest }) => {
           id: 'vote',
           itemText: 'Vote',
           onClick: onActionClick,
-          shouldHideMenuItem: (row) => row.original.age <= 18,
         },
         {
           id: 'retire',
           itemText: 'Retire',
           onClick: onActionClick,
-          disabled: false,
-          shouldDisableMenuItem: (row) => row.original.age <= 60,
         },
         {
           id: 'delete',
@@ -2528,13 +2525,12 @@ describe(componentName, () => {
         .getElementsByClassName('c4p--datagrid__actions-column-content')[0]
         .getElementsByTagName('button')[0]
     );
-
     expect(
       document
         .getElementsByTagName('ul')[0]
         .getElementsByTagName('li')[2]
         .getElementsByTagName('button')[0].textContent
-    ).toEqual('Delete');
+    ).toEqual('Retire');
     fireEvent.click(
       document
         .getElementsByTagName('ul')[0]
@@ -2542,7 +2538,7 @@ describe(componentName, () => {
         .getElementsByTagName('button')[0]
     );
     expect(document.getElementsByTagName('h3')[0].textContent).toMatch(
-      'Clicked [delete] on row:'
+      'Clicked [retire] on row:'
     );
   });
 });


### PR DESCRIPTION
I noticed that our release workflow failed earlier this week, stemming from an issue in the Datagrid StickyActionColumn tests. There was logic to hide some of the overflow menu items based on the data that is randomly generated. Unfortunately, because this data is random, we can't always know for certain which overflow menu item we're clicking on in the test. To fix this I just removed the `shouldHideMenuItem` prop from the array of menu items.

After we review/merge this, I'll run the release workflow again.

#### What did you change?
`Datagrid.test.js`
#### How did you test and verify your work?
Ran tests and ci-check locally