### PR TITLE
fix: select all duplicates in add select columns

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
@@ -74,7 +74,8 @@ export let AddSelectColumn = ({
   const selectAllHandler = (checked) => {
     const itemIds = entries.map((item) => item.id);
     if (checked) {
-      setMultiSelection([...multiSelection, ...itemIds]);
+      const newSelections = [...new Set([...multiSelection, ...itemIds])];
+      setMultiSelection(newSelections);
     } else {
       const newItems = multiSelection.filter((i) => !itemIds.includes(i));
       setMultiSelection(newItems);


### PR DESCRIPTION
Contributes to #2131 

fixes an issue where if you selected an item in a column and then clicked select all it would add duplicate entries of that item.