### PR TITLE
fix(ModifiedTabs): add back default tabs value

### DIFF
--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.js
@@ -22,6 +22,7 @@ const defaults = {
   newTabContent: 'Your new tab will be here soon',
   onNewTab: undefined,
   onCloseTab: undefined,
+  tabs: [],
 };
 
 export let ModifiedTabs = forwardRef(


### PR DESCRIPTION
This fixes the `index-all-enabled.test.js` tests because `ModifiedTabs` needs a default value for the `tabs` prop.

#### What did you change?
`ModifiedTabs.js`
#### How did you test and verify your work?
Confirmed by running the tests in `index-all-enabled.test.js`.