### PR TITLE
chore: use carbon prefix from settings file

### DIFF
--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.test.js
@@ -8,6 +8,7 @@
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { carbon } from '../../settings';
 
 import { APIKeyModal } from '.';
 
@@ -17,7 +18,6 @@ Object.assign(navigator, {
   },
 });
 
-const carbonPrefix = 'cds';
 const componentName = APIKeyModal.displayName;
 const defaultProps = {
   apiKey: '',
@@ -89,11 +89,11 @@ describe(componentName, () => {
     const { getByText, container, getByLabelText } = render(
       <APIKeyModal {...props} />
     );
-    expect(container.querySelector(`.${carbonPrefix}--text-input`).value).toBe(
+    expect(container.querySelector(`.${carbon.prefix}--text-input`).value).toBe(
       props.apiKey
     );
     getByText(props.apiKeyLabel);
-    click(container.querySelector(`.${carbonPrefix}--btn--primary`));
+    click(container.querySelector(`.${carbon.prefix}--btn--primary`));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(props.apiKey);
     getByLabelText(defaultProps.copyIconDescription);
   });
@@ -112,7 +112,7 @@ describe(componentName, () => {
       <APIKeyModal {...props} />
     );
 
-    const nameInput = container.querySelector(`.${carbonPrefix}--text-input`);
+    const nameInput = container.querySelector(`.${carbon.prefix}--text-input`);
     const createButton = getByText(props.generateButtonText);
 
     change(nameInput, { target: { value: 'test-key' } });
@@ -124,7 +124,7 @@ describe(componentName, () => {
     rerender(<APIKeyModal {...props} apiKey="444-444-444-444" />);
     await waitFor(() => getByText(props.downloadLinkText));
     getByText(props.downloadBodyText);
-    expect(container.querySelector(`.${carbonPrefix}--text-input`).value).toBe(
+    expect(container.querySelector(`.${carbon.prefix}--text-input`).value).toBe(
       '444-444-444-444'
     );
     click(getByText(props.copyButtonText));
@@ -148,7 +148,7 @@ describe(componentName, () => {
       <APIKeyModal {...props} />
     );
 
-    const nameInput = container.querySelector(`.${carbonPrefix}--text-input`);
+    const nameInput = container.querySelector(`.${carbon.prefix}--text-input`);
     const createButton = getByText(props.generateButtonText);
 
     change(nameInput, { target: { value: 'test-key' } });
@@ -237,7 +237,7 @@ describe(componentName, () => {
     expect(onRequestGenerate).toHaveBeenCalled();
     rerender(<APIKeyModal {...props} />);
     rerender(<APIKeyModal {...props} apiKey="abc-123" />);
-    expect(container.querySelector(`.${carbonPrefix}--text-input`).value).toBe(
+    expect(container.querySelector(`.${carbon.prefix}--text-input`).value).toBe(
       'abc-123'
     );
     getByText(props.generateSuccessBody);
@@ -262,7 +262,7 @@ describe(componentName, () => {
       <APIKeyModal {...props} />
     );
 
-    const nameInput = container.querySelector(`.${carbonPrefix}--text-input`);
+    const nameInput = container.querySelector(`.${carbon.prefix}--text-input`);
     const editButton = getByText(props.editButtonText);
     expect(nameInput.value).toBe(props.apiKeyName);
     getByText(props.editButtonText);
@@ -284,21 +284,23 @@ describe(componentName, () => {
       <APIKeyModal {...props} />
     );
     await waitFor(() => getByText(props.downloadLinkText));
-    expect(container.querySelector(`.${carbonPrefix}--text-input`).value).toBe(
+    expect(container.querySelector(`.${carbon.prefix}--text-input`).value).toBe(
       props.apiKey
     );
     expect(
-      container.querySelector(`.${carbonPrefix}--text-input`)
+      container.querySelector(`.${carbon.prefix}--text-input`)
     ).toHaveAttribute('type', 'password');
-    mouseOver(container.querySelector(`.${carbonPrefix}--icon-visibility-on`));
+    mouseOver(container.querySelector(`.${carbon.prefix}--icon-visibility-on`));
     await waitFor(() => getByText(defaultProps.showAPIKeyLabel));
-    click(container.querySelector(`.${carbonPrefix}--icon-visibility-on`));
-    mouseOver(container.querySelector(`.${carbonPrefix}--icon-visibility-off`));
+    click(container.querySelector(`.${carbon.prefix}--icon-visibility-on`));
+    mouseOver(
+      container.querySelector(`.${carbon.prefix}--icon-visibility-off`)
+    );
     await waitFor(() => getByText(defaultProps.hideAPIKeyLabel));
     rerender(<APIKeyModal {...props} hasAPIKeyVisibilityToggle={false} />);
     await waitFor(() => getByText(props.downloadLinkText));
     expect(
-      container.querySelector(`.${carbonPrefix}--text-input`)
+      container.querySelector(`.${carbon.prefix}--text-input`)
     ).toHaveAttribute('type', 'text');
   });
 

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.test.js
@@ -11,7 +11,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
@@ -23,7 +23,6 @@ import ansibleLogo from './_story-assets/ansible-logo.png';
 import grafanaLogo from './_story-assets/grafana-logo.png';
 import jsLogo from './_story-assets/js-logo.png';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--about-modal`;
 const componentName = AboutModal.displayName;
 
@@ -150,7 +149,7 @@ describe(componentName, () => {
   it('renders a clickable carbon tab for additional info', () => {
     renderComponent({ additionalInfo, open: true });
     const tabToSelect = screen.getByRole('tab', { name: tabLabel2 });
-    const tabSelected = `${carbonPrefix}--tabs__nav-item--selected`;
+    const tabSelected = `${carbon.prefix}--tabs__nav-item--selected`;
     expect(tabToSelect).not.toHaveClass(tabSelected);
     userEvent.click(tabToSelect);
     expect(tabToSelect).toHaveClass(tabSelected);

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
@@ -11,9 +11,8 @@ import { ActionBar } from '.';
 import { Lightning, Bee } from '@carbon/icons-react';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 const blockClass = `${pkg.prefix}--action-bar`;
-const carbonPrefix = 'cds';
 
 const actions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => ({
   key: `key is this num ${num}`,
@@ -117,10 +116,10 @@ describe(ActionBar.displayName, () => {
     );
 
     screen.getByText(/Action 01/, {
-      selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+      selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
     });
     screen.getByText(/Action 10/, {
-      selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+      selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
     });
   });
 
@@ -136,7 +135,7 @@ describe(ActionBar.displayName, () => {
 
     expect(
       screen.queryByText(/Action 10/, {
-        selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+        selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
       })
     ).toBeNull();
 
@@ -187,15 +186,15 @@ describe(ActionBar.displayName, () => {
     );
 
     screen.getByText(/Action 01/, {
-      selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+      selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
     });
     screen.getByText(/Action 02/, {
-      selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+      selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
     });
 
     expect(
       screen.queryByText(/Action 03/, {
-        selector: `.${blockClass}__displayed-items .${carbonPrefix}--popover-content.${carbonPrefix}--tooltip-content`,
+        selector: `.${blockClass}__displayed-items .${carbon.prefix}--popover-content.${carbon.prefix}--tooltip-content`,
       })
     ).toBeNull();
   });

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBarItem.test.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBarItem.test.js
@@ -9,11 +9,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActionBarItem } from '.';
 import uuidv4 from '../../global/js/utils/uuidv4';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 const { click } = fireEvent;
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--action-bar-item`;
 const componentName = ActionBarItem.displayName;
 
@@ -46,7 +45,7 @@ describe(ActionBarItem.displayName, () => {
     );
 
     const actionBarItemElement = container.querySelector(`.${blockClass}`);
-    expect(actionBarItemElement).toHaveClass(`${carbonPrefix}--btn`);
+    expect(actionBarItemElement).toHaveClass(`${carbon.prefix}--btn`);
 
     click(actionBarItemElement);
     expect(myOnClick).toBeCalled();
@@ -70,8 +69,8 @@ describe(ActionBarItem.displayName, () => {
       </ActionBarItem>
     );
     const actionBarItemElement = container.querySelector(`.${blockClass}`);
-    expect(actionBarItemElement).not.toHaveClass(`${carbonPrefix}--btn--lg`);
-    expect(actionBarItemElement).toHaveClass(`${carbonPrefix}--btn--md`);
+    expect(actionBarItemElement).not.toHaveClass(`${carbon.prefix}--btn--lg`);
+    expect(actionBarItemElement).toHaveClass(`${carbon.prefix}--btn--md`);
     expect(actionBarItemElement).toHaveAttribute('type', 'button');
   });
 

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -11,13 +11,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expectMultipleError } from '../../global/js/utils/test-helper';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { ActionSet } from '.';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--action-set`;
 const componentName = ActionSet.displayName;
 
@@ -52,9 +51,9 @@ describe(componentName, () => {
   });
 
   it('renders three action buttons', () => {
-    const primaryButton = `${carbonPrefix}--btn--primary`;
-    const secondaryButton = `${carbonPrefix}--btn--secondary`;
-    const ghostButton = `${carbonPrefix}--btn--ghost`;
+    const primaryButton = `${carbon.prefix}--btn--primary`;
+    const secondaryButton = `${carbon.prefix}--btn--secondary`;
+    const ghostButton = `${carbon.prefix}--btn--ghost`;
     render(<ActionSet size="lg" actions={[actionS, actionP, actionG]} />);
     expect(getByRoleAndLabel('button', labelS)).toHaveClass(secondaryButton);
     expect(getByRoleAndLabel('button', labelP)).toHaveClass(primaryButton);

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.test.js
@@ -10,9 +10,8 @@ import { BreadcrumbWithOverflow } from '.';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
-const carbonPrefix = 'cds';
 const dataTestId = uuidv4();
 const blockClass = `${pkg.prefix}--breadcrumb-with-overflow`;
 
@@ -36,7 +35,7 @@ const sizes = {
 };
 
 const isBreadCrumbItem = function () {
-  return this.classList?.contains(`${carbonPrefix}--breadcrumb-item`) || false;
+  return this.classList?.contains(`${carbon.prefix}--breadcrumb-item`) || false;
 };
 
 // eslint-disable-next-line react/prop-types
@@ -114,7 +113,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
       />
     );
     const visibleBreadcrumbs = screen.getAllByText(/Breadcrumb [0-9]/, {
-      selector: `.${blockClass}__displayed-breadcrumb .${carbonPrefix}--link`,
+      selector: `.${blockClass}__displayed-breadcrumb .${carbon.prefix}--link`,
     });
     expect(visibleBreadcrumbs.length).toEqual(5); // all should be visible
 
@@ -138,7 +137,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
     );
 
     const visibleBreadcrumbs = screen.getAllByText(/Breadcrumb [0-9]/, {
-      selector: `.${blockClass}__displayed-breadcrumb .${carbonPrefix}--link`,
+      selector: `.${blockClass}__displayed-breadcrumb .${carbon.prefix}--link`,
     });
 
     // not enough room
@@ -182,7 +181,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
     );
 
     const visibleBreadcrumbs = screen.getAllByText(/Breadcrumb [0-9]/, {
-      selector: `.${blockClass}__displayed-breadcrumb .${carbonPrefix}--link`,
+      selector: `.${blockClass}__displayed-breadcrumb .${carbon.prefix}--link`,
     });
     // not enough room
     expect(visibleBreadcrumbs.length).toEqual(1);
@@ -208,7 +207,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
     );
 
     const visibleBreadcrumbs = screen.getAllByText(/Breadcrumb [0-9]/, {
-      selector: `.${blockClass}__displayed-breadcrumb .${carbonPrefix}--link`,
+      selector: `.${blockClass}__displayed-breadcrumb .${carbon.prefix}--link`,
     });
     // not enough room
     expect(visibleBreadcrumbs.length).toEqual(3);
@@ -234,7 +233,7 @@ describe(BreadcrumbWithOverflow.displayName, () => {
     );
 
     const visibleBreadcrumbs = screen.getAllByText(/Breadcrumb [0-9]/, {
-      selector: `.${blockClass}__displayed-breadcrumb .${carbonPrefix}--link`,
+      selector: `.${blockClass}__displayed-breadcrumb .${carbon.prefix}--link`,
     });
     // not enough room
     expect(visibleBreadcrumbs.length).toEqual(1);

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import userEvent from '@testing-library/user-event';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
@@ -17,7 +17,6 @@ import { Add } from '@carbon/icons-react';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--button-menu`;
 const componentName = ButtonMenu.displayName;
 
@@ -75,7 +74,7 @@ describe(componentName, () => {
     const svg = screen
       .getByRole('button', { name: menuAriaLabel })
       .querySelector('svg');
-    expect(svg).toHaveClass(`${carbonPrefix}--btn__icon`);
+    expect(svg).toHaveClass(`${carbon.prefix}--btn__icon`);
   });
 
   it('renders label prop', () => {
@@ -85,7 +84,7 @@ describe(componentName, () => {
 
   it('renders size prop', () => {
     renderMenu({ size: 'lg' });
-    expect(screen.getByText(label)).toHaveClass(`${carbonPrefix}--btn--lg`);
+    expect(screen.getByText(label)).toHaveClass(`${carbon.prefix}--btn--lg`);
   });
 
   it('adds additional props to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
@@ -12,7 +12,8 @@ import { ButtonSetWithOverflow } from '.';
 import { Bee16 } from '@carbon/icons-react';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
-const carbonPrefix = 'cds';
+import { carbon } from '../../settings';
+
 const buttons = (handleClick) =>
   [1, 2, 3].map((num) => ({
     renderIcon: !(num % 3) ? Bee16 : null,
@@ -40,7 +41,7 @@ describe(ButtonSetWithOverflow.displayName, () => {
         get: function () {
           let width = 0;
 
-          if (this.classList.contains(`${carbonPrefix}--btn`)) {
+          if (this.classList.contains(`${carbon.prefix}--btn`)) {
             width = buttonWidth;
           } else {
             width = window.innerWidth;
@@ -76,13 +77,13 @@ describe(ButtonSetWithOverflow.displayName, () => {
     );
 
     const action1 = screen.getByText(/Action 1/, {
-      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbonPrefix}--btn`,
+      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbon.prefix}--btn`,
     });
     screen.getByText(/Action 2/, {
-      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbonPrefix}--btn`,
+      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbon.prefix}--btn`,
     });
     screen.getByText(/Action 3/, {
-      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbonPrefix}--btn`,
+      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbon.prefix}--btn`,
     });
 
     userEvent.click(action1);
@@ -103,17 +104,17 @@ describe(ButtonSetWithOverflow.displayName, () => {
     );
 
     const action1 = screen.queryByText(/Action 1/, {
-      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbonPrefix}--btn`,
+      selector: `.${blockClass}__button-container:not(.${blockClass}__button-container--hidden) .${carbon.prefix}--btn`,
     });
     expect(action1).toBeNull();
 
     const comboButton = screen.getByText(/button menu label/, {
-      selector: `.${blockClass}__button-container--hidden+ .${carbonPrefix}--overflow-menu .${carbonPrefix}--btn`,
+      selector: `.${blockClass}__button-container--hidden+ .${carbon.prefix}--overflow-menu .${carbon.prefix}--btn`,
     });
     userEvent.click(comboButton);
 
     const action1a = screen.getByText(/Action 1/, {
-      selector: `.${carbonPrefix}--overflow-menu-options__option-content`,
+      selector: `.${carbon.prefix}--overflow-menu-options__option-content`,
     });
 
     userEvent.click(action1a);

--- a/packages/cloud-cognitive/src/components/Card/Card.test.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.test.js
@@ -10,9 +10,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { Card } from '.';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
-const carbonPrefix = 'cds';
 const componentName = Card.displayName;
 const blockClass = `${pkg.prefix}--card`;
 
@@ -164,7 +163,7 @@ describe(componentName, () => {
     expect(
       container.querySelector(`.${blockClass}__footer .${blockClass}__actions`)
     ).toBeVisible();
-    click(container.querySelector(`.${carbonPrefix}--overflow-menu`));
+    click(container.querySelector(`.${carbon.prefix}--overflow-menu`));
     click(screen.getByText('Edit'));
     expect(onClick).toHaveBeenCalled();
     rerender(<Card {...props} actionsPlacement="top" />);

--- a/packages/cloud-cognitive/src/components/Card/CardFooter.test.js
+++ b/packages/cloud-cognitive/src/components/Card/CardFooter.test.js
@@ -8,8 +8,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { CardFooter } from '.';
+import { carbon } from '../../settings';
 
-const carbonPrefix = 'cds';
 const { name } = CardFooter;
 
 describe(name, () => {
@@ -53,7 +53,7 @@ describe(name, () => {
     const { getByText, container } = render(<CardFooter {...props} />);
     expect(getByText(props.primaryButtonText)).toBeVisible();
     expect(
-      container.querySelector(`.${carbonPrefix}--btn--ghost`)
+      container.querySelector(`.${carbon.prefix}--btn--ghost`)
     ).toBeVisible();
   });
 });

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
@@ -10,18 +10,17 @@ import { render, screen } from '@testing-library/react'; // https://testing-libr
 import userEvent from '@testing-library/user-event';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import { CreateSidePanel } from '.';
 
 const componentName = CreateSidePanel.displayName;
 
-const carbonPrefix = 'cds';
 const title = 'Test Create Side panel';
 const subtitle = 'Test Create Side panel subtitle';
 const formDescription =
   'This is a test description. It has several lines. It should render a side panel.';
-const selectorPrimaryFocus = `.${carbonPrefix}--text-input`;
+const selectorPrimaryFocus = `.${carbon.prefix}--text-input`;
 const formTitle = 'This is a test form title';
 const blockClass = `${pkg.prefix}--create-side-panel`;
 

--- a/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheet/CreateTearsheet.test.js
@@ -14,14 +14,13 @@ import {
   expectWarnAsync,
   expectMultipleWarn,
 } from '../../global/js/utils/test-helper';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import { CreateTearsheet } from './CreateTearsheet';
 import { CreateTearsheetStep } from './CreateTearsheetStep';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 const { prefix } = pkg;
 
-const carbonPrefix = 'cds';
 const createTearsheetBlockClass = `${prefix}--tearsheet-create`;
 const componentName = CreateTearsheet.displayName;
 
@@ -198,7 +197,7 @@ describe(CreateTearsheet.displayName, () => {
       initialStep: 2,
     });
     const createTearsheetSteps = container.querySelector(
-      `.${createTearsheetBlockClass}__content .${carbonPrefix}--form`
+      `.${createTearsheetBlockClass}__content .${carbon.prefix}--form`
     ).children;
     expect(
       createTearsheetSteps[1].classList.contains(
@@ -218,7 +217,7 @@ describe(CreateTearsheet.displayName, () => {
           initialStep: 0,
         });
         const createTearsheetSteps = container.querySelector(
-          `.${createTearsheetBlockClass}__content .${carbonPrefix}--form`
+          `.${createTearsheetBlockClass}__content .${carbon.prefix}--form`
         ).children;
         expect(
           createTearsheetSteps[0].classList.contains(
@@ -237,7 +236,7 @@ describe(CreateTearsheet.displayName, () => {
     const cancelButtonElement = screen.getByText(cancelButtonText);
     click(nextButtonElement);
     const createTearsheetSteps = container.querySelector(
-      `.${createTearsheetBlockClass}__content .${carbonPrefix}--form`
+      `.${createTearsheetBlockClass}__content .${carbon.prefix}--form`
     ).children;
     expect(
       createTearsheetSteps[1].classList.contains(
@@ -281,7 +280,7 @@ describe(CreateTearsheet.displayName, () => {
     });
     click(nextButtonElement);
     const tearsheetChildren = container.querySelector(
-      `.${createTearsheetBlockClass}__content  .${carbonPrefix}--form`
+      `.${createTearsheetBlockClass}__content  .${carbon.prefix}--form`
     ).children;
     expect(
       tearsheetChildren[2].classList.contains(

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -39,6 +39,7 @@ import {
   TableBatchAction,
 } from '@carbon/react';
 import { Download, Restart, Filter, Activity } from '@carbon/icons-react';
+import { carbon } from '../../settings';
 
 // import { DatagridActions, DatagridBatchActions, DatagridPagination, } from './Datagrid.stories';
 
@@ -48,7 +49,6 @@ import userEvent from '@testing-library/user-event';
 
 const dataTestId = uuidv4();
 
-const carbonPrefix = 'cds';
 const componentName = Datagrid.displayName;
 
 const defaultHeader = [
@@ -887,7 +887,7 @@ describe(componentName, () => {
     );
 
     expect(screen.getByRole('table')).toHaveClass(
-      `${carbonPrefix}--data-table`
+      `${carbon.prefix}--data-table`
     );
 
     expect(
@@ -928,7 +928,7 @@ describe(componentName, () => {
 
     for (var i = 0; i < numRows; i++) {
       expect(tableBodyRows[i].classList[1]).toEqual(
-        `${carbonPrefix}--data-table--selected`
+        `${carbon.prefix}--data-table--selected`
       );
     }
 
@@ -944,7 +944,7 @@ describe(componentName, () => {
     );
 
     expect(
-      document.getElementsByClassName(`${carbonPrefix}--search-input`)[0]
+      document.getElementsByClassName(`${carbon.prefix}--search-input`)[0]
     ).toBeDefined();
 
     // Find and click Download button (getByText gets the popover element, so we need to find the button from there)
@@ -1185,10 +1185,10 @@ describe(componentName, () => {
     render(<WithPagination data-testid={dataTestId}></WithPagination>);
 
     expect(
-      document.getElementById(`${carbonPrefix}-pagination-select-4`)
+      document.getElementById(`${carbon.prefix}-pagination-select-4`)
     ).toBeDefined();
     expect(
-      document.getElementById(`${carbonPrefix}-pagination-select-6`)
+      document.getElementById(`${carbon.prefix}-pagination-select-6`)
     ).toBeDefined();
   });
 
@@ -1261,7 +1261,7 @@ describe(componentName, () => {
     const alertMock = jest.spyOn(window, 'alert');
 
     expect(
-      document.getElementsByClassName(`${carbonPrefix}--search-input`)[0]
+      document.getElementsByClassName(`${carbon.prefix}--search-input`)[0]
     ).toBeDefined();
 
     // Find and click Download button (getByText gets the popover element, so we need to find the button from there)
@@ -1341,7 +1341,7 @@ describe(componentName, () => {
       new MouseEvent('click')
     );
 
-    expect(clickableRow).toHaveClass(`${carbonPrefix}--data-table--selected`);
+    expect(clickableRow).toHaveClass(`${carbon.prefix}--data-table--selected`);
 
     expect(
       document
@@ -1455,7 +1455,7 @@ describe(componentName, () => {
 
     fireEvent.click(button);
 
-    expect(row.classList[1]).toEqual(`${carbonPrefix}--data-table--selected`);
+    expect(row.classList[1]).toEqual(`${carbon.prefix}--data-table--selected`);
 
     fireEvent.click(button);
     expect(row.classList['0']).toEqual('c4p--datagrid__carbon-row');
@@ -1489,7 +1489,7 @@ describe(componentName, () => {
     ).toEqual('c4p--datagrid__datagridLeftPanel');
 
     expect(
-      document.getElementsByClassName(`${carbonPrefix}--search-input`)[0]
+      document.getElementsByClassName(`${carbon.prefix}--search-input`)[0]
     ).toBeDefined();
 
     // Find and click Download button (getByText gets the popover element, so we need to find the button from there)
@@ -1614,7 +1614,7 @@ describe(componentName, () => {
         .getByRole('table')
         .getElementsByTagName('tbody')[0]
         .getElementsByTagName('tr')[previousRowNumber].classList[1] ===
-      `.${carbonPrefix}--data-table--selected`
+      `.${carbon.prefix}--data-table--selected`
     ) {
       fireEvent.click(
         screen
@@ -1632,7 +1632,7 @@ describe(componentName, () => {
           .getByRole('table')
           .getElementsByTagName('tbody')[0]
           .getElementsByTagName('tr')[currentRowNumber].classList[1]
-      ).toEqual(`${carbonPrefix}--data-table--selected`);
+      ).toEqual(`${carbon.prefix}--data-table--selected`);
 
       expect(
         screen
@@ -1657,7 +1657,7 @@ describe(componentName, () => {
           .getByRole('table')
           .getElementsByTagName('tbody')[0]
           .getElementsByTagName('tr')[currentRowNumber].classList[1]
-      ).toEqual(`${carbonPrefix}--data-table--selected`);
+      ).toEqual(`${carbon.prefix}--data-table--selected`);
     }
   }
 
@@ -1699,7 +1699,7 @@ describe(componentName, () => {
           .getByRole('table')
           .getElementsByTagName('tbody')[0]
           .getElementsByTagName('tr')[i].classList[1]
-      ).toEqual(`${carbonPrefix}--data-table--selected`);
+      ).toEqual(`${carbon.prefix}--data-table--selected`);
     }
 
     fireEvent.click(
@@ -1744,7 +1744,7 @@ describe(componentName, () => {
     expect(
       document
         .getElementsByClassName(
-          'cds--radio-button-group cds--radio-button-group--vertical cds--radio-button-group--label-right'
+          `${carbon.prefix}--radio-button-group ${carbon.prefix}--radio-button-group--vertical ${carbon.prefix}--radio-button-group--label-right`
         )[0]
         .getElementsByTagName('legend')[0].textContent
     ).toEqual('Row height');
@@ -1759,7 +1759,7 @@ describe(componentName, () => {
 
     var rowSize = document
       .getElementsByClassName(
-        'cds--radio-button-group cds--radio-button-group--vertical cds--radio-button-group--label-right'
+        `${carbon.prefix}--radio-button-group ${carbon.prefix}--radio-button-group--vertical ${carbon.prefix}--radio-button-group--label-right`
       )[0]
       .getElementsByTagName('div').length;
 
@@ -1767,7 +1767,7 @@ describe(componentName, () => {
       expect(
         document
           .getElementsByClassName(
-            'cds--radio-button-group cds--radio-button-group--vertical cds--radio-button-group--label-right'
+            `${carbon.prefix}--radio-button-group ${carbon.prefix}--radio-button-group--vertical ${carbon.prefix}--radio-button-group--label-right`
           )[0]
           .getElementsByTagName('div')
           .item(j)
@@ -1910,7 +1910,7 @@ describe(componentName, () => {
           .getByRole('table')
           .getElementsByTagName('tbody')[0]
           .getElementsByTagName('tr')[i].classList[1]
-      ).toEqual(`${carbonPrefix}--data-table--selected`);
+      ).toEqual(`${carbon.prefix}--data-table--selected`);
     }
 
     expect(
@@ -1955,7 +1955,7 @@ describe(componentName, () => {
 
     for (var i = 0; i < rows.length; i++) {
       expect(rows.item(i).classList[1]).toEqual(
-        `${carbonPrefix}--data-table--selected`
+        `${carbon.prefix}--data-table--selected`
       );
     }
 
@@ -1984,7 +1984,7 @@ describe(componentName, () => {
     );
 
     expect(selectIndividualRow.classList[1]).toEqual(
-      `${carbonPrefix}--data-table--selected`
+      `${carbon.prefix}--data-table--selected`
     );
   });
 
@@ -2059,7 +2059,7 @@ describe(componentName, () => {
 
     for (var i = 0; i < topAlignmentRows.length; i++) {
       expect(topAlignmentRows[i].classList[1]).toEqual(
-        `${carbonPrefix}--data-table--selected`
+        `${carbon.prefix}--data-table--selected`
       );
     }
 
@@ -2073,18 +2073,18 @@ describe(componentName, () => {
           .getElementsByTagName('input')[0]
       );
       expect(topAlignmentRows[j].classList[1]).toEqual(
-        `${carbonPrefix}--data-table--selected`
+        `${carbon.prefix}--data-table--selected`
       );
     }
 
     fireEvent.click(allRowsCheckBox);
 
     expect(
-      document.getElementsByClassName(`${carbonPrefix}--search-input`)[0]
+      document.getElementsByClassName(`${carbon.prefix}--search-input`)[0]
     ).toBeDefined();
 
     expect(screen.getByText(/left panel/i)).toHaveClass(
-      `${carbonPrefix}--tooltip-content`
+      `${carbon.prefix}--tooltip-content`
     );
 
     const rowHeightButton = screen.getByLabelText('Row height');

--- a/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.test.js
@@ -8,12 +8,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import userEvent from '@testing-library/user-event';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { EditSidePanel } from '.';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--edit-side-panel`;
 const componentName = EditSidePanel.displayName;
 
@@ -25,7 +24,7 @@ const title = uuidv4();
 const subtitle = uuidv4();
 const formDescription = uuidv4();
 const formTitle = uuidv4();
-const selectorPrimaryFocus = `.${carbonPrefix}--text-input`;
+const selectorPrimaryFocus = `.${carbon.prefix}--text-input`;
 const primaryButtonText = 'Save';
 const secondaryButtonText = 'Cancel';
 const onRequestSubmitFn = jest.fn();

--- a/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.test.js
+++ b/packages/cloud-cognitive/src/components/ExampleComponent/ExampleComponent.test.js
@@ -9,13 +9,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import userEvent from '@testing-library/user-event';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { ExampleComponent } from '.';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--example-component`;
 const componentName = ExampleComponent.displayName;
 
@@ -95,10 +94,10 @@ describe(componentName, () => {
     renderComponent({ primaryKind: 'danger', secondaryKind: 'tertiary' });
     expect(
       screen.getByRole('button', { name: `danger ${primaryButtonLabel}` })
-    ).toHaveClass(`${carbonPrefix}--btn--danger`);
+    ).toHaveClass(`${carbon.prefix}--btn--danger`);
     expect(
       screen.getByRole('button', { name: secondaryButtonLabel })
-    ).toHaveClass(`${carbonPrefix}--btn--tertiary`);
+    ).toHaveClass(`${carbon.prefix}--btn--tertiary`);
   });
 
   it('renders the size property', () => {
@@ -106,7 +105,7 @@ describe(componentName, () => {
     screen
       .getAllByRole('button')
       .forEach((button) =>
-        expect(button).toHaveClass(`${carbonPrefix}--btn--sm`)
+        expect(button).toHaveClass(`${carbon.prefix}--btn--sm`)
       );
   });
 

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.test.js
@@ -8,12 +8,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { carbon } from '../../settings';
 
 import { ExportModal } from '.';
 
 const componentName = ExportModal.displayName;
 
-const carbonPrefix = 'cds';
 const defaultProps = {
   body: 'body content',
   className: 'test-class',
@@ -69,7 +69,7 @@ describe(componentName, () => {
     };
 
     const { container } = render(<ExportModal {...props} />);
-    const textInput = container.querySelector(`.${carbonPrefix}--text-input`);
+    const textInput = container.querySelector(`.${carbon.prefix}--text-input`);
 
     change(textInput, { target: { value: `${props.filename}.pdf` } });
     blur(textInput);
@@ -89,7 +89,9 @@ describe(componentName, () => {
     };
 
     const { container } = render(<ExportModal {...props} />);
-    const submitBtn = container.querySelector(`.${carbonPrefix}--btn--primary`);
+    const submitBtn = container.querySelector(
+      `.${carbon.prefix}--btn--primary`
+    );
 
     click(submitBtn);
     expect(onRequestSubmit).not.toBeCalled();
@@ -108,7 +110,7 @@ describe(componentName, () => {
     };
 
     const { container } = render(<ExportModal {...props} />);
-    const textInput = container.querySelector(`.${carbonPrefix}--text-input`);
+    const textInput = container.querySelector(`.${carbon.prefix}--text-input`);
 
     change(textInput, { target: { value: `${props.filename}` } });
     blur(textInput);
@@ -162,7 +164,7 @@ describe(componentName, () => {
       <ExportModal {...defaultProps} inputType="password" />
     );
     expect(
-      container.querySelector(`.${carbonPrefix}--text-input`)
+      container.querySelector(`.${carbon.prefix}--text-input`)
     ).toHaveAttribute('type', 'password');
   });
 

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.test.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.test.js
@@ -8,6 +8,7 @@
 import { fireEvent, render, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { carbon } from '../../settings';
 
 import { ImportModal } from '.';
 
@@ -19,7 +20,6 @@ global.fetch = jest.fn(() =>
   })
 );
 
-const carbonPrefix = 'cds';
 const componentName = ImportModal.displayName;
 const defaultProps = {
   accept: ['image/jpeg', 'image/png'],
@@ -103,18 +103,18 @@ describe(componentName, () => {
 
     expect(
       getByText(props.inputButtonText).classList.contains(
-        `${carbonPrefix}--btn--disabled`
+        `${carbon.prefix}--btn--disabled`
       )
     ).toBe(true);
     click(getByText(props.primaryButtonText));
     expect(onRequestSubmit).not.toBeCalled();
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.jpeg' },
     });
     expect(
       getByText(props.inputButtonText).classList.contains(
-        `${carbonPrefix}--btn--disabled`
+        `${carbon.prefix}--btn--disabled`
       )
     ).not.toBe(true);
     click(getByText(props.inputButtonText));
@@ -132,7 +132,7 @@ describe(componentName, () => {
     const { click } = userEvent;
     const { getByText, container } = render(<ImportModal {...defaultProps} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.jpeg' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -155,7 +155,7 @@ describe(componentName, () => {
     };
     const { getByText, container } = render(<ImportModal {...props} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.jpeg' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -177,7 +177,7 @@ describe(componentName, () => {
     const { click } = userEvent;
     const { getByText, container } = render(<ImportModal {...defaultProps} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.jpeg' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -201,7 +201,7 @@ describe(componentName, () => {
     const { click } = userEvent;
     const { getByText, container } = render(<ImportModal {...defaultProps} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.pdf' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -230,7 +230,7 @@ describe(componentName, () => {
     };
     const { getByText, container } = render(<ImportModal {...props} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.pdf' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -248,16 +248,16 @@ describe(componentName, () => {
     const { getByText, container } = render(<ImportModal {...defaultProps} />);
     const files = [new File(['foo'], 'foo.jpeg', { type: 'image/jpeg' })];
 
-    change(container.querySelector(`.${carbonPrefix}--file-input`), {
+    change(container.querySelector(`.${carbon.prefix}--file-input`), {
       target: { files },
     });
     expect(getByText('foo.jpeg')).toBeVisible();
     expect(
       screen.getByText(`1 / 1 ${defaultProps.fileUploadLabel}`)
     ).toBeVisible();
-    click(container.querySelector(`.${carbonPrefix}--file-close`));
+    click(container.querySelector(`.${carbon.prefix}--file-close`));
     expect(
-      container.querySelector(`.${carbonPrefix}--file-filename`)
+      container.querySelector(`.${carbon.prefix}--file-filename`)
     ).toBeNull();
   });
 
@@ -270,7 +270,7 @@ describe(componentName, () => {
     };
     const { getByText, container } = render(<ImportModal {...props} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.pdf' },
     });
     click(getByText(defaultProps.inputButtonText));
@@ -293,7 +293,7 @@ describe(componentName, () => {
     };
     const { getByText, container } = render(<ImportModal {...props} />);
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'test.pdf' },
     });
     click(getByText(defaultProps.inputButtonText));

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import { Tab, Tabs, TabList } from '@carbon/react';
 import { Lightning, Bee } from '@carbon/icons-react';
@@ -27,7 +27,6 @@ import { TYPES as tagTypes } from '../TagSet/constants';
 
 const { prefix } = pkg;
 
-const carbonPrefix = 'cds';
 const blockClass = `${prefix}--page-header`;
 
 /* Test properties. */
@@ -125,7 +124,7 @@ jest.mock('../../global/js/utils/uuidv4');
 const initSizes = () => ({
   offsetWidth: {
     [`${blockClass}`]: window.innerWidth,
-    [`${carbonPrefix}--btn`]: 200,
+    [`${carbon.prefix}--btn`]: 200,
     [`${blockClass}__breadcrumb-row`]: window.innerWidth,
     [`${prefix}--breadcrumb-with-overflow`]: window.innerWidth * 0.6,
     [`${prefix}--tag-set`]: window.innerWidth * 0.25,
@@ -133,7 +132,7 @@ const initSizes = () => ({
     [`${prefix}--button-set-with-overflow__button-container`]:
       window.innerWidth * 0.4,
     [`${prefix}--button-set-with-overflow`]: window.innerWidth * 0.4,
-    [`${carbonPrefix}--breadcrumb-item`]: 200,
+    [`${carbon.prefix}--breadcrumb-item`]: 200,
     [`${prefix}--action-bar__displayed-items`]: window.innerWidth * 0.3,
     [`${blockClass}__breadcrumb-title`]: window.innerWidth * 0.2,
     [`${prefix}--button-menu`]: 200,
@@ -143,7 +142,7 @@ const initSizes = () => ({
     [`${blockClass}`]: 300,
     [`${blockClass}__available-row`]: 40,
     [`${blockClass}__breadcrumb-row`]: 40,
-    [`${carbonPrefix}--breadcrumb-item`]: 40,
+    [`${carbon.prefix}--breadcrumb-item`]: 40,
     [`${blockClass}__navigation-row`]: 48,
     [`${blockClass}__subtitle-row`]: 40,
     [`${blockClass}__title-row`]: 64,
@@ -297,10 +296,12 @@ describe('PageHeader', () => {
     expect(
       screen.getAllByText(/Breadcrumb [1-3]/, {
         // selector need to ignore sizing items
-        selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbonPrefix}--link`,
+        selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbon.prefix}--link`,
       })
     ).toHaveLength(3);
-    expect(document.querySelectorAll(`.${carbonPrefix}--tabs`)).toHaveLength(1);
+    expect(document.querySelectorAll(`.${carbon.prefix}--tabs`)).toHaveLength(
+      1
+    );
     expect(screen.getAllByText(/Tab [1-4]/)).toHaveLength(4);
     expect(
       document.querySelectorAll(`.${blockClass}__page-actions`)
@@ -313,7 +314,7 @@ describe('PageHeader', () => {
     expect(
       screen.getAllByText('A tag', {
         // selector need to ignore sizing items
-        selector: `.${prefix}--tag-set__displayed-tag .${carbonPrefix}--tag span`,
+        selector: `.${prefix}--tag-set__displayed-tag .${carbon.prefix}--tag span`,
       }).length
     ).toBeGreaterThan(0);
     expect(document.querySelectorAll(`.${blockClass}__title`)).toHaveLength(1);
@@ -434,7 +435,9 @@ describe('PageHeader', () => {
     const { navigation } = testProps;
     render(<PageHeader {...{ navigation, withoutBackground: true }} />);
 
-    expect(document.querySelectorAll(`.${carbonPrefix}--tabs`)).toHaveLength(1);
+    expect(document.querySelectorAll(`.${carbon.prefix}--tabs`)).toHaveLength(
+      1
+    );
   });
 
   test('Navigation row renders when Tags but no Navigation', () => {
@@ -461,7 +464,7 @@ describe('PageHeader', () => {
     expect(
       screen.getAllByText('A tag', {
         // selector need to ignore sizing items
-        selector: `.${prefix}--tag-set__displayed-tag .${carbonPrefix}--tag span`,
+        selector: `.${prefix}--tag-set__displayed-tag .${carbon.prefix}--tag span`,
       }).length
     ).toBeGreaterThan(0);
   });
@@ -515,7 +518,7 @@ describe('PageHeader', () => {
     expect(
       screen.getAllByText(/Breadcrumb [1-3]/, {
         // selector need to ignore sizing items
-        selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbonPrefix}--link`,
+        selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbon.prefix}--link`,
       })
     ).toHaveLength(3);
   });
@@ -562,7 +565,7 @@ describe('PageHeader', () => {
     screen.getByText(titleUserDefinedStrings.content);
     screen.getByText(titleUserDefinedStrings.breadcrumbContent, {
       // selector need to ignore sizing items
-      selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbonPrefix}--link`,
+      selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbon.prefix}--link`,
     });
 
     const allTitle = screen.getAllByTitle(titleUserDefinedStrings.asText);
@@ -577,7 +580,7 @@ describe('PageHeader', () => {
 
     screen.getByText(titleUserDefinedStrings.content, {
       // selector need to ignore sizing items
-      selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbonPrefix}--link`,
+      selector: `.${prefix}--breadcrumb-with-overflow__breadcrumb-container:not(.${prefix}--breadcrumb-with-overflow__breadcrumb-container--hidden) .${carbon.prefix}--link`,
     });
 
     const allTitle = screen.getAllByTitle(titleUserDefinedStrings.asText);
@@ -635,7 +638,7 @@ describe('PageHeader', () => {
     );
 
     const skeletons = document.querySelectorAll(
-      `.${carbonPrefix}--skeleton__text`
+      `.${carbon.prefix}--skeleton__text`
     );
     expect(skeletons).toHaveLength(3);
   });
@@ -706,9 +709,9 @@ describe('PageHeader', () => {
       <PageHeader data-testid={dataTestId} narrowGrid fullWidthGrid />
     );
 
-    const grid = container.querySelector(`.${carbonPrefix}--grid`);
-    expect(grid).toHaveClass(`${carbonPrefix}--grid--narrow`);
-    expect(grid).toHaveClass(`${carbonPrefix}--grid--full-width`);
+    const grid = container.querySelector(`.${carbon.prefix}--grid`);
+    expect(grid).toHaveClass(`${carbon.prefix}--grid--narrow`);
+    expect(grid).toHaveClass(`${carbon.prefix}--grid--full-width`);
   });
 
   test('PageHeader with custom pageActions', () => {

--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.test.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.test.js
@@ -8,10 +8,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { carbon } from '../../settings';
 
 import { RemoveModal } from '.';
 
-const carbonPrefix = 'cds';
 const componentName = RemoveModal.displayName;
 const resourceName = 'bx1001';
 const defaultProps = {
@@ -56,9 +56,9 @@ describe(componentName, () => {
       <RemoveModal {...defaultProps} textConfirmation />
     );
     screen.getByText(defaultProps.inputLabelText);
-    container.querySelector(`.${carbonPrefix}--text-input`);
+    container.querySelector(`.${carbon.prefix}--text-input`);
     expect(
-      container.querySelector(`.${carbonPrefix}--text-input`)
+      container.querySelector(`.${carbon.prefix}--text-input`)
     ).toHaveAttribute('placeholder', defaultProps.inputPlaceholderText);
   });
 
@@ -97,13 +97,13 @@ describe(componentName, () => {
     click(screen.getByText(props.primaryButtonText));
     expect(onRequestSubmit).not.toBeCalled();
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'bx1002' },
     });
     click(screen.getByText(props.primaryButtonText));
     expect(onRequestSubmit).not.toBeCalled();
 
-    change(container.querySelector(`.${carbonPrefix}--text-input`), {
+    change(container.querySelector(`.${carbon.prefix}--text-input`), {
       target: { value: 'bx1001' },
     });
     click(screen.getByText(props.primaryButtonText));

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 import { TagSet } from '.';
 import { TagSetModal } from './TagSetModal';
 
@@ -23,7 +23,6 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 
 const { prefix } = pkg;
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--tag-set`;
 const blockClassOverflow = `${prefix}--tag-set-overflow`;
 
@@ -98,11 +97,11 @@ describe(TagSet.displayName, () => {
     // first and last should be visible
     screen.getByText(tagLabel(0), {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
     screen.getByText(tagLabel(tags10.length - 1), {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
   });
 
@@ -113,7 +112,7 @@ describe(TagSet.displayName, () => {
 
     const visible = screen.queryAllByText(/Tag [0-9]+/, {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
     expect(visible.length).toEqual(0);
 
@@ -136,12 +135,12 @@ describe(TagSet.displayName, () => {
     // first and last should be visible
     screen.getByText(tagLabel(0), {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
 
     const visible = screen.queryAllByText(/Tag [0-9]+/, {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
     expect(visible.length).toEqual(visibleTags);
 
@@ -199,17 +198,17 @@ describe(TagSet.displayName, () => {
     // first and last should be visible
     screen.getByText(tagLabel(0), {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
     screen.getByText(tagLabel(4), {
       // selector need to ignore sizing items
-      selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+      selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
     });
 
     expect(
       screen.getAllByText(/Tag [0-9]+/, {
         // selector need to ignore sizing items
-        selector: `.${blockClass}__displayed-tag .${carbonPrefix}--tag span`,
+        selector: `.${blockClass}__displayed-tag .${carbon.prefix}--tag span`,
       }).length
     ).toEqual(5);
   });

--- a/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/Tearsheet.test.js
@@ -15,13 +15,12 @@ import {
 } from '../../global/js/utils/test-helper';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import { Button, ButtonSet, Tab, Tabs, TabList } from '@carbon/react';
 import { Tearsheet, TearsheetNarrow } from '.';
 import { CreateTearsheetNarrow } from '../CreateTearsheetNarrow';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--tearsheet`;
 const componentName = Tearsheet.displayName;
 const componentNameNarrow = TearsheetNarrow.displayName;
@@ -93,7 +92,7 @@ let closeIconDescriptionTestedAlready = false;
 const commonTests = (Ts, name, props, testActions) => {
   it(`renders a component ${name}`, () => {
     render(<Ts {...{ ...props, closeIconDescription }} />);
-    expect(document.querySelector(`.${carbonPrefix}--modal`)).toHaveClass(
+    expect(document.querySelector(`.${carbon.prefix}--modal`)).toHaveClass(
       blockClass
     );
   });
@@ -116,7 +115,7 @@ const commonTests = (Ts, name, props, testActions) => {
       expect(document.querySelector(`.${blockClass}__buttons`)).toBeNull();
     }
 
-    expect(document.querySelector(`.${carbonPrefix}--modal`)).not.toHaveClass(
+    expect(document.querySelector(`.${carbon.prefix}--modal`)).not.toHaveClass(
       'is-visible'
     );
   });
@@ -159,7 +158,7 @@ const commonTests = (Ts, name, props, testActions) => {
 
   it('applies className to the root node', () => {
     render(<Ts {...{ ...props, className, closeIconDescription }} />);
-    expect(document.querySelector(`.${carbonPrefix}--modal`)).toHaveClass(
+    expect(document.querySelector(`.${carbon.prefix}--modal`)).toHaveClass(
       className
     );
   });
@@ -208,7 +207,7 @@ const commonTests = (Ts, name, props, testActions) => {
           open
         />
       );
-      const tearsheet = document.querySelector(`.${carbonPrefix}--modal`);
+      const tearsheet = document.querySelector(`.${carbon.prefix}--modal`);
       const closeButton = screen.getByRole('button', {
         name: closeIconDescription,
       });
@@ -227,7 +226,7 @@ const commonTests = (Ts, name, props, testActions) => {
           open
         />
       );
-      const tearsheet = document.querySelector(`.${carbonPrefix}--modal`);
+      const tearsheet = document.querySelector(`.${carbon.prefix}--modal`);
       const closeButton = screen.getByRole('button', {
         name: closeIconDescription,
       });
@@ -241,7 +240,7 @@ const commonTests = (Ts, name, props, testActions) => {
 
   it('is visible when open is true', () => {
     render(<Ts {...props} open />);
-    expect(document.querySelector(`.${carbonPrefix}--modal`)).toHaveClass(
+    expect(document.querySelector(`.${carbon.prefix}--modal`)).toHaveClass(
       'is-visible'
     );
   });
@@ -284,7 +283,7 @@ const commonTests = (Ts, name, props, testActions) => {
         render(<Ts {...props} open />);
         render(<Ts {...props} open />);
         expect(
-          document.querySelectorAll(`.${carbonPrefix}--modal.is-visible`)
+          document.querySelectorAll(`.${carbon.prefix}--modal.is-visible`)
         ).toHaveLength(3);
       }
     ));
@@ -345,7 +344,9 @@ describe(componentName, () => {
     render(
       <Tearsheet open {...{ navigation }} closeIconDescription="Close icon" />
     );
-    expect(document.querySelectorAll(`.${carbonPrefix}--tabs`)).toHaveLength(1);
+    expect(document.querySelectorAll(`.${carbon.prefix}--tabs`)).toHaveLength(
+      1
+    );
     const tabList = screen.getByRole('tablist', { name: 'Tab list' });
     Array.from(tabList).forEach((tab, index) => {
       const tabContent =

--- a/packages/cloud-cognitive/src/components/Toolbar/Toolbar.test.js
+++ b/packages/cloud-cognitive/src/components/Toolbar/Toolbar.test.js
@@ -14,10 +14,10 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { blockClass, componentName } from './Toolbar';
 import { blockClass as toolbarButtonClass } from './ToolbarButton';
+import { carbon } from '../../settings';
 
 const { getByTestId, getByText } = screen;
 const { keyboard, tab } = userEvent;
-const carbonPrefix = 'cds';
 
 function _instance(prop) {
   return `${uuidv4()}--${prop}`;
@@ -220,7 +220,7 @@ describe(toolbarButtonComponentName, () => {
       <ToolbarButton data-testid={dataTestId} />
     );
 
-    const className = `${carbonPrefix}--popover--right`;
+    const className = `${carbon.prefix}--popover--right`;
     expect(getByTestId(dataTestId).parentElement).not.toHaveClass(className, {
       exact: false,
     });

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
@@ -10,12 +10,11 @@ import { render, screen } from '@testing-library/react';
 import { expectError, required } from '../../global/js/utils/test-helper';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 import { UserProfileImage } from '.';
 import { Group } from '@carbon/icons-react';
 
-const carbonPrefix = 'cds';
 const blockClass = `${pkg.prefix}--user-profile-image`;
 const componentName = UserProfileImage.displayName;
 
@@ -104,7 +103,7 @@ describe(componentName, () => {
   it('should render the IconButton component if the tooltipText prop is passed', () => {
     const { container } = renderComponent({ tooltipText: 'Display name' });
     const tooltipElement = container.querySelector(
-      `.${carbonPrefix}--icon-tooltip`
+      `.${carbon.prefix}--icon-tooltip`
     );
     expect(tooltipElement).toBeTruthy();
   });

--- a/packages/cloud-cognitive/src/global/js/utils/__tests__/wrap-focus.test.js
+++ b/packages/cloud-cognitive/src/global/js/utils/__tests__/wrap-focus.test.js
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import wrapFocus from '../wrapFocus';
-
-const carbonPrefix = 'cds';
+import { carbon } from '../../../../settings';
 
 describe('wrapFocus', () => {
   let node;
@@ -23,7 +22,7 @@ describe('wrapFocus', () => {
         id="start-sentinel"
         tabIndex="0"
         role="link"
-        class="${carbonPrefix}--visually-hidden">
+        class="${carbon.prefix}--visually-hidden">
       </span>
       <div id="inner-modal" tabindex="-1">
         <button id="button-0">Button 0</button>
@@ -34,10 +33,10 @@ describe('wrapFocus', () => {
         id="end-sentinel"
         tabIndex="0"
         role="link"
-        class="${carbonPrefix}--visually-hidden">
+        class="${carbon.prefix}--visually-hidden">
       </span>
       <button id="outer-following"></button>
-      <div class="${carbonPrefix}--tooltip" tabindex="0"></div>
+      <div class="${carbon.prefix}--tooltip" tabindex="0"></div>
     `;
     document.body.appendChild(node);
     spyInnerModal = jest.spyOn(node.querySelector('#inner-modal'), 'focus');
@@ -94,7 +93,7 @@ describe('wrapFocus', () => {
       bodyNode: node.querySelector('#inner-modal'),
       startSentinelNode: node.querySelector('#start-sentinel'),
       endSentinelNode: node.querySelector('#end-sentinel'),
-      currentActiveNode: node.querySelector(`.${carbonPrefix}--tooltip`),
+      currentActiveNode: node.querySelector(`.${carbon.prefix}--tooltip`),
       oldActiveNode: node.querySelector('#button-2'),
     });
     expect(spyInnerModal).not.toHaveBeenCalled();

--- a/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
+++ b/packages/cloud-cognitive/src/global/js/utils/wrapFocus.js
@@ -10,8 +10,7 @@ import {
   DOCUMENT_POSITION_BROAD_FOLLOWING,
   selectorTabbable,
 } from './keyboardNavigation';
-
-const carbonPrefix = 'cds';
+import { carbon } from '../../../settings';
 
 /**
  * @param {Node} node A DOM node.
@@ -21,8 +20,8 @@ const carbonPrefix = 'cds';
 function elementOrParentIsFloatingMenu(
   node,
   selectorsFloatingMenus = [
-    `.${carbonPrefix}--overflow-menu-options`,
-    `.${carbonPrefix}--tooltip`,
+    `.${carbon.prefix}--overflow-menu-options`,
+    `.${carbon.prefix}--tooltip`,
     '.flatpickr-calendar',
   ]
 ) {


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2093

Removes hard coded `cds` from tests that needed to check specific cases against the carbon prefix.

#### What did you change?
Test files
#### How did you test and verify your work?
Ran tests to make sure the same number of tests pass as before this change