### PR TITLE
fix: update generate script to use new sass structure

### DIFF
--- a/packages/cloud-cognitive/scripts/generate/index.js
+++ b/packages/cloud-cognitive/scripts/generate/index.js
@@ -78,6 +78,22 @@ if (name) {
   const componentSCSSIndexData = readFileSync(componentSCSSIndexPath, 'utf-8');
   outputFileSync(
     componentSCSSIndexPath,
-    componentSCSSIndexData + `@use './${substitutions.DISPLAY_NAME}/index';\n`
+    componentSCSSIndexData + `@use './${substitutions.DISPLAY_NAME}';\n`
+  );
+
+  // add new component to end of src/components/_index-with-carbon.scss
+  const componentWithCarbonSCSSIndexPath = join(
+    'src',
+    'components',
+    '_index-with-carbon.scss'
+  );
+  const componentWithCarbonSCSSIndexData = readFileSync(
+    componentWithCarbonSCSSIndexPath,
+    'utf-8'
+  );
+  outputFileSync(
+    componentWithCarbonSCSSIndexPath,
+    componentWithCarbonSCSSIndexData +
+      `@use './${substitutions.DISPLAY_NAME}/index-with-carbon as *';\n`
   );
 }

--- a/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_STYLE_NAME.scss
@@ -14,9 +14,6 @@
 // or
 // TODO: @use '@carbon/react/scss/grid';
 
-// DISPLAY_NAME uses the following Carbon components:
-// TODO: @use(s) of Carbon component styles used by DISPLAY_NAME
-
 // DISPLAY_NAME uses the following Carbon for IBM Products components:
 // TODO: @use(s) of IBM Products component styles used by DISPLAY_NAME
 

--- a/packages/cloud-cognitive/scripts/generate/templates/_carbon-imports.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_carbon-imports.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@use './STYLE_NAME';
+// Import any Carbon component styles used from DISPLAY_NAME in this file.
+// DISPLAY_NAME uses the following Carbon components:

--- a/packages/cloud-cognitive/scripts/generate/templates/_index-with-carbon.scss
+++ b/packages/cloud-cognitive/scripts/generate/templates/_index-with-carbon.scss
@@ -5,4 +5,5 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use './carbon-imports';
 @use './STYLE_NAME';

--- a/packages/cloud-cognitive/src/components/ActionBar/_index.scss
+++ b/packages/cloud-cognitive/src/components/ActionBar/_index.scss
@@ -5,4 +5,4 @@
 // LICENSE file in the root directory of this source tree.
 //
 
-@forward './action-bar';
+@use './action-bar';


### PR DESCRIPTION
Contributes to #2122 

With the refactored component sass structure, the `generate` script needed to be updates so that new components will receive the same structure. I've made sure that the output from this script is what is expected from the generated component files to the exporting of the component styles.

#### What did you change?
`generate` script
#### How did you test and verify your work?
Ran `yarn generate TestComponent` locally and confirmed the correct output