### PR TITLE
chore: remove version number from storybook brand title until one exists

### DIFF
--- a/packages/core/.storybook/manager.js
+++ b/packages/core/.storybook/manager.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2022
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,11 +12,11 @@ import React from 'react';
 
 import packageInfo from '../../cloud-cognitive/package.json';
 
-const { description, version } = packageInfo;
+const { description } = packageInfo;
 
 addons.setConfig({
   theme: create({
-    brandTitle: `${description} v${version}`,
+    brandTitle: `${description} (v11 preview)`,
   }),
 
   sidebar: {


### PR DESCRIPTION
To prevent any confusion now that we have a v11 storybook site, I removed the version from the `brandTitle` until we have created our first release candidate supporting Carbon v11.

#### What did you change?
```
packages/core/.storybook/manager.js
```
#### How did you test and verify your work?
Ran storybook locally and confirmed that the brand title was updated

![image](https://user-images.githubusercontent.com/10215203/182450208-016f807b-e2aa-4c9f-8de1-0bfc9cc5498a.png)
