### PR TITLE
fix(InlineEdit): fix sass calc issue with carbon token

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -22,7 +22,7 @@
 @mixin input-outline($color: $focus) {
   /* stylelint-disable-next-line carbon/theme-token-use */
   outline: $spacing-01 solid $color;
-  outline-offset: calc(-1 * $spacing-01);
+  outline-offset: calc(-1 * #{$spacing-01});
 
   @media screen and (prefers-contrast) {
     outline-style: dotted;


### PR DESCRIPTION
Issue brought up [over slack](https://ibm-casdesign.slack.com/archives/C013ZTX0N6B/p1659982921891409), Carbon tokens inside of `calc` need to be interpolated in order to compile correctly.

#### What did you change?
`_inline-edit.scss`
#### How did you test and verify your work?
Ensured that sass still compiled and focus outline styling still works