### PR TITLE
feat: Add Row Action Buttons

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -19,6 +19,8 @@ import {
   Download16,
   Filter16,
   Add16,
+  Edit16,
+  TrashCan16,
 } from '@carbon/icons-react';
 import { DataTable, Button, Pagination } from 'carbon-components-react';
 import {
@@ -1155,6 +1157,62 @@ export const StickyActionsColumn = () => {
           id: 'delete',
           itemText: 'Delete',
           hasDivider: true,
+          isDelete: true,
+          onClick: onActionClick,
+        },
+      ],
+    },
+    useStickyColumn,
+    useActionsColumn
+  );
+  return (
+    <Wrapper>
+      <h3>{msg}</h3>
+      <Datagrid datagridState={{ ...datagridState }} />
+      <p>More details documentation check the Notes section below</p>
+    </Wrapper>
+  );
+};
+
+export const RowActionButton = () => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: '',
+        accessor: 'actions',
+        sticky: 'right',
+        width: 90,
+        isAction: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const [msg, setMsg] = useState('click action menu');
+  const onActionClick = (actionId, row) => {
+    const { original } = row;
+    setMsg(
+      `Clicked [${actionId}] on row: <${original.firstName} ${original.lastName}>`
+    );
+  };
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      rowActions: [
+        {
+          id: 'edit',
+          itemText: 'Edit',
+          icon: Edit16,
+          onClick: onActionClick,
+        },
+
+        {
+          id: 'delete',
+          itemText: 'Delete',
+          icon: TrashCan16,
           isDelete: true,
           onClick: onActionClick,
         },

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -2507,7 +2507,7 @@ describe(componentName, () => {
         .getElementsByTagName('tbody')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[16]
-        .getElementsByClassName('c4p--datagrid__actions-column-content')[0]
+        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
         .getElementsByTagName('button')[0]
     );
 
@@ -2532,7 +2532,7 @@ describe(componentName, () => {
         .getElementsByTagName('tbody')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[16]
-        .getElementsByClassName('c4p--datagrid__actions-column-content')[0]
+        .getElementsByClassName('c4p--datagrid__actions-column-contents')[0]
         .getElementsByTagName('button')[0]
     );
     expect(

--- a/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
@@ -13,12 +13,12 @@ import {
   OverflowMenuItem,
 } from 'carbon-components-react';
 import { pkg } from '../../settings';
-
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useActionsColumn = (hooks) => {
   const useAttachActionsOnInstance = (instance) => {
     const { rowActions, isFetching } = instance;
+
     if (rowActions && Array.isArray(rowActions)) {
       const addActionsMenu = (props, cellData) => {
         const { cell } = cellData;
@@ -28,53 +28,85 @@ const useActionsColumn = (hooks) => {
             props,
             {
               children: (
-                <div className={`${blockClass}__actions-column-content`}>
+                <div className={`${blockClass}__actions-column-contents`}>
                   {isFetching && (
                     <IconSkeleton
                       className={`${blockClass}__actions-column-loading`}
                     />
                   )}
-                  {!isFetching && (
-                    <OverflowMenu
-                      size="sm"
-                      light
-                      flipped
-                      onClick={(e) => e.stopPropagation()}
+                  {!isFetching && rowActions.length <= 2 && (
+                    <div
+                      className={`${blockClass}_actions-column`}
+                      style={{ display: 'flex' }}
                     >
                       {rowActions.map((action) => {
-                        const {
-                          id,
-                          onClick,
-                          shouldHideMenuItem,
-                          shouldDisableMenuItem,
-                          disabled,
-                          ...rest
-                        } = action;
-                        const hidden =
-                          typeof shouldHideMenuItem === 'function' &&
-                          shouldHideMenuItem(row);
-                        // shouldDisableMenuItem will override disabled because it's more specific
-                        // if shouldDisableMenuItem doesn't exists, fall back to disabled
-                        const isDisabledByRow =
-                          typeof shouldDisableMenuItem === 'function'
-                            ? shouldDisableMenuItem(row)
-                            : disabled;
-                        if (hidden) {
-                          return null;
-                        }
+                        const { id, itemText, onClick, icon } = action;
                         return (
-                          <OverflowMenuItem
-                            {...rest}
-                            disabled={isDisabledByRow}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onClick(id, row, e);
-                            }}
-                            key={id}
-                          />
+                          <div
+                            className={`${blockClass}__actions-column-button`}
+                            key=""
+                          >
+                            <OverflowMenu
+                              renderIcon={icon}
+                              hasIconOnly
+                              light
+                              iconDescription={itemText}
+                              kind="ghost"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onClick(id, row, e);
+                              }}
+                            ></OverflowMenu>
+                          </div>
                         );
                       })}
-                    </OverflowMenu>
+                    </div>
+                  )}
+                  {!isFetching && rowActions.length > 2 && (
+                    <div>
+                      <OverflowMenu
+                        size="sm"
+                        light
+                        flipped
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        {rowActions.map((action) => {
+                          const {
+                            id,
+                            onClick,
+                            shouldHideMenuItem,
+                            shouldDisableMenuItem,
+                            disabled,
+                            ...rest
+                          } = action;
+                          const hidden =
+                            typeof shouldHideMenuItem === 'function' &&
+                            shouldHideMenuItem(row);
+                          // shouldDisableMenuItem will override disabled because it's more specific
+                          // if shouldDisableMenuItem doesn't exists, fall back to disabled
+                          const isDisabledByRow =
+                            typeof shouldDisableMenuItem === 'function'
+                              ? shouldDisableMenuItem(row)
+                              : disabled;
+                          if (hidden) {
+                            return null;
+                          }
+                          return (
+                            <OverflowMenuItem
+                              {...rest}
+                              disabled={isDisabledByRow}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onClick(id, row, e);
+                              }}
+                              key={id}
+                            />
+                          );
+                        })}
+                      </OverflowMenu>
+                    </div>
                   )}
                 </div>
               ),

--- a/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
@@ -90,6 +90,7 @@ const useStickyColumn = (hooks) => {
     const newColumns = instance.visibleColumns;
     let spacerIdx = newColumns.findIndex((col) => col.id === 'spacer');
     let stickyIdx = newColumns.findIndex((col) => col.sticky === 'right');
+    // let stickyIdx = newColumns.findIndex((col) => false);
     if (spacerIdx >= 0 && stickyIdx >= 0 && stickyIdx < spacerIdx) {
       const temp = newColumns[spacerIdx];
       newColumns[spacerIdx] = newColumns[stickyIdx];
@@ -98,9 +99,14 @@ const useStickyColumn = (hooks) => {
     const newHeaders = instance.headers;
     spacerIdx = newHeaders.findIndex((col) => col.id === 'spacer');
     stickyIdx = newHeaders.findIndex((col) => col.sticky === 'right');
+    // stickyIdx = newHeaders.findIndex((col) => false);
+
     if (spacerIdx >= 0 && stickyIdx >= 0 && stickyIdx < spacerIdx) {
       const temp = newHeaders[spacerIdx];
       newHeaders[spacerIdx] = newHeaders[stickyIdx];
+      newHeaders[spacerIdx].canResize = false;
+      newHeaders[spacerIdx].disableResizing = true;
+      delete newHeaders[spacerIdx].getResizerProps;
       newHeaders[stickyIdx] = temp;
     }
   });
@@ -120,7 +126,7 @@ const changeProps = (elementName, headerCellRef, props, data) => {
       props,
       {
         className: cx({
-          [`${styleClassPrefix}-${elementName}`]: true, // apply sticky styles
+          [`${styleClassPrefix}-${elementName}`]: true,
           [`${blockClass}__resizableColumn`]: false,
           [`${blockClass}__sortableColumn`]: false,
         }),

--- a/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
@@ -90,7 +90,6 @@ const useStickyColumn = (hooks) => {
     const newColumns = instance.visibleColumns;
     let spacerIdx = newColumns.findIndex((col) => col.id === 'spacer');
     let stickyIdx = newColumns.findIndex((col) => col.sticky === 'right');
-    // let stickyIdx = newColumns.findIndex((col) => false);
     if (spacerIdx >= 0 && stickyIdx >= 0 && stickyIdx < spacerIdx) {
       const temp = newColumns[spacerIdx];
       newColumns[spacerIdx] = newColumns[stickyIdx];
@@ -99,7 +98,6 @@ const useStickyColumn = (hooks) => {
     const newHeaders = instance.headers;
     spacerIdx = newHeaders.findIndex((col) => col.id === 'spacer');
     stickyIdx = newHeaders.findIndex((col) => col.sticky === 'right');
-    // stickyIdx = newHeaders.findIndex((col) => false);
 
     if (spacerIdx >= 0 && stickyIdx >= 0 && stickyIdx < spacerIdx) {
       const temp = newHeaders[spacerIdx];


### PR DESCRIPTION
Contributes to #
1609

Implements actions buttons extensions for Datagrid component

What did you change?
`useActionsColumn.js` - added logic that shows individual buttons when number of actions are less than 3
`useStickyColumn.js` - added logic that removes the datagrid resizer element found in the sticky column. This also affects the Sticky Action Columns story, see https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1783
`Datagrid.stories.js` - added RowActionButton story

How did you test and verify your work?
storybook