### PR TITLE
feat: add release action in v11 branch to run with workflow_dispatch

### DIFF
--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -1,0 +1,41 @@
+name: Releases @carbon/ibm-products with v11 support # Builds and releases v11 supported version of @carbon/ibm-products
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Release_v11:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # https://github.com/actions/checkout/issues/217
+          token: ${{ secrets.GH_TOKEN_LERNA }} # https://github.com/lerna/lerna/issues/1957
+          ref: 'carbon-v11'
+
+      # https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+      - run: |
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name $GITHUB_ACTOR
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2 # https://github.com/actions/setup-node
+        with:
+          node-version: lts/gallium
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+
+      - name: Install
+        run: yarn
+
+      - name: Continuous integration check (includes build)
+        run: yarn ci-check
+
+      # Dry run - `yarn lerna version --no-git-tag-version --no-push`
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn lerna publish premajor --conventional-commits --preid rc --dist-tag next --ignore-changes 'config/**/*' 'packages/security/**/*' 'packages/cdai/**/*' 'packages/core/**/*' --yes # This publish command should ONLY run one time, otherwise it will continue to release the next major version! See https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2163 for series of publish commands

--- a/cspell.json
+++ b/cspell.json
@@ -85,6 +85,8 @@
     "overridable",
     "overscroll",
     "pconsole",
+    "preid",
+    "premajor",
     "Prefs",
     "readme",
     "renderable",


### PR DESCRIPTION
Contributes to #2163 

It appears that if you want to run the action via `workflow_dispatch` it needs to exist on the branch you're running the action against. Because #2167 included these changes on the `main` branch, we are unable to run this action on the `carbon-v11` branch.

#### What did you change?
Same changes as #2167 
#### How did you test and verify your work?
[Sample project](https://github.com/matthewgallo/releases-test)