### PR TITLE
chore: update v2 publish script

### DIFF
--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn lerna publish premajor --conventional-commits --preid rc --dist-tag next --ignore-changes 'config/**/*' 'packages/security/**/*' 'packages/cdai/**/*' 'packages/core/**/*' --yes # This publish command should ONLY run one time, otherwise it will continue to release the next major version! See https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2163 for series of publish commands
+        run: yarn lerna publish --preid rc --dist-tag next --create-release github --yes # This publishes subsequent v2.x.x releases

--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -38,4 +38,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: yarn lerna publish --preid rc --dist-tag next --create-release github --yes # This publishes subsequent v2.x.x releases
+        run: yarn lerna publish --preid rc --dist-tag next --create-release github --ignore-changes 'config/**/*' 'packages/security/**/*' 'packages/cdai/**/*' 'packages/core/**/*' --yes # This publishes subsequent v2.x.x releases

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,7 +1730,7 @@ __metadata:
     cpx: ^1.5.0
     focus-trap-react: ^9.0.2
     jest: ^28.1.3
-    jest-config-ibm-cloud-cognitive: ^0.24.3
+    jest-config-ibm-cloud-cognitive: ^0.24.4
     jest-environment-jsdom: ^28.1.3
     node-sass: ^7.0.1
     npm-check-updates: ^16.0.5
@@ -1784,7 +1784,7 @@ __metadata:
     "@carbon/import-once": 10.7.0
     "@carbon/layout": 10.37.1
     "@carbon/motion": 10.29.0
-    "@carbon/storybook-addon-theme": ^0.22.22
+    "@carbon/storybook-addon-theme": ^0.22.23
     "@carbon/themes": 10.54.0
     "@carbon/type": 10.44.0
     "@storybook/addon-actions": ^6.5.10
@@ -1843,7 +1843,7 @@ __metadata:
     glob: ^8.0.3
     immutability-helper: ^3.1.1
     jest: ^28.1.3
-    jest-config-ibm-cloud-cognitive: ^0.24.3
+    jest-config-ibm-cloud-cognitive: ^0.24.4
     jest-environment-jsdom: ^28.1.3
     namor: ^1.1.2
     npm-check-updates: ^16.0.5
@@ -1905,7 +1905,7 @@ __metadata:
     focus-trap-react: ^9.0.2
     invariant: ^2.2.4
     jest: ^28.1.3
-    jest-config-ibm-cloud-cognitive: ^0.24.3
+    jest-config-ibm-cloud-cognitive: ^0.24.4
     jest-environment-jsdom: ^28.1.3
     npm-check-updates: ^16.0.5
     npm-run-all: ^4.1.5
@@ -1973,7 +1973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/storybook-addon-theme@^0.22.22, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
+"@carbon/storybook-addon-theme@^0.22.23, @carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme":
   version: 0.0.0-use.local
   resolution: "@carbon/storybook-addon-theme@workspace:config/storybook-addon-carbon-theme"
   dependencies:
@@ -16349,7 +16349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-config-ibm-cloud-cognitive@^0.24.3, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
+"jest-config-ibm-cloud-cognitive@^0.24.4, jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive":
   version: 0.0.0-use.local
   resolution: "jest-config-ibm-cloud-cognitive@workspace:config/jest-config-ibm-cloud-cognitive"
   dependencies:


### PR DESCRIPTION
Contributes to #2163 

Initial `2.0.0-rc.0` release has been created, this changes the publish script so that it no longer uses `premajor` (which would cause another major release to be created).

I kept the `--ignore-changes` flag because those other packages will be released from our release action that will continue to run from `main` branch.

#### What did you change?
Removed `premajor` from v11 publish script
#### How did you test and verify your work?
Sample project