### PR TITLE
fix(AboutModal): fix spacing issue causing build to break

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -41,7 +41,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--about-modal.c4p--about-modal--with-tabs .cds--modal-content--overflow-indicator {
-  bottom: calc(3rem +2.5rem);
+  bottom: calc(3rem + 2.5rem);
 }
 
 .c4p--about-modal .cds--modal-content--overflow-indicator {

--- a/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
+++ b/packages/cloud-cognitive/src/components/AboutModal/_about-modal.scss
@@ -54,7 +54,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--about-modal;
 
 .#{$block-class}.#{$block-class}--with-tabs
   .#{c4p-settings.$carbon-prefix}--modal-content--overflow-indicator {
-  bottom: calc(#{$spacing-09} +#{$spacing-08});
+  // stylelint-disable-next-line carbon/layout-token-use
+  bottom: calc(#{$spacing-09} + #{$spacing-08});
 }
 
 .#{$block-class}


### PR DESCRIPTION
I was confirming the v2 release worked ok in a sample application and when I imported the styles I was getting an error in the build along the lines of

```
"+" and "-" must be surrounded by whitespace in calculations.
```

which led me to find an issue in the `_about-modal.scss` styles.

#### What did you change?
`_about-modal.scss`
#### How did you test and verify your work?
Adding the whitespace inside of the calc fixes breaking build