### PR TITLE
chore(v11): add weekly release for v11

### DIFF
--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -2,6 +2,8 @@ name: Releases @carbon/ibm-products with v11 support # Builds and releases v11 s
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:
   Release_v11:


### PR DESCRIPTION
Contributes to #2163 

Now that we've made the first release candidate and the first release candidate version bump, I think it makes sense for us to now be able to run this release action on a weekly basis. It will run at the same time as the other version updates (Tues 4:30am).

#### What did you change?
`.github/workflows/release-v11.yml`
#### How did you test and verify your work?
Uses the same cron scheduling as our `main` branch releases