### PR TITLE
feat(Datagrid): add multi line wrap option

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -154,7 +154,17 @@ const defaultHeader = [
 const { TableBatchAction, TableBatchActions } = DataTable;
 
 export const BasicUsage = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: 'Someone 11',
+        accessor: 'someone11',
+        multiLineWrap: true,
+      },
+    ],
+    []
+  );
   const [data] = useState(makeData(10));
   const datagridState = useDatagrid({
     columns,

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -195,6 +195,13 @@
     white-space: nowrap;
   }
 
+  .#{$block-class}__defaultStringRenderer.#{$block-class}__defaultStringRenderer-multiline {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    white-space: initial;
+  }
+
   .#{$block-class}__expanded-row {
     display: flex;
     overflow: hidden;

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -195,7 +195,7 @@
     white-space: nowrap;
   }
 
-  .#{$block-class}__defaultStringRenderer.#{$block-class}__defaultStringRenderer-multiline {
+  .#{$block-class}__defaultStringRenderer.#{$block-class}__defaultStringRenderer--multiline {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;

--- a/packages/cloud-cognitive/src/components/Datagrid/useDefaultStringRenderer.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useDefaultStringRenderer.js
@@ -15,7 +15,7 @@ const useDefaultStringRenderer = (hooks) => {
   const StringRenderer = (tableProps) => (
     <div
       className={cx(`${blockClass}__defaultStringRenderer`, {
-        [`${blockClass}__defaultStringRenderer-multiline`]:
+        [`${blockClass}__defaultStringRenderer--multiline`]:
           tableProps.column?.multiLineWrap,
       })}
       title={tableProps.value}

--- a/packages/cloud-cognitive/src/components/Datagrid/useDefaultStringRenderer.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useDefaultStringRenderer.js
@@ -6,6 +6,7 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import React from 'react';
+import cx from 'classnames';
 import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
@@ -13,7 +14,10 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const useDefaultStringRenderer = (hooks) => {
   const StringRenderer = (tableProps) => (
     <div
-      className={`${blockClass}__defaultStringRenderer`}
+      className={cx(`${blockClass}__defaultStringRenderer`, {
+        [`${blockClass}__defaultStringRenderer-multiline`]:
+          tableProps.column?.multiLineWrap,
+      })}
       title={tableProps.value}
     >
       {tableProps.value}

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
@@ -46,7 +46,7 @@ const newPerson = () => {
     someone8: namor.generate({ words: 1, numbers: 0 }),
     someone9: namor.generate({ words: 1, numbers: 0 }),
     someone10: namor.generate({ words: 1, numbers: 0 }),
-    someone11: namor.generate({ words: 1, numbers: 0 }),
+    someone11: namor.generate({ words: 4, numbers: 0 }),
     someone12: namor.generate({ words: 1, numbers: 0 }),
     someone13: namor.generate({ words: 1, numbers: 0 }),
     someone14: namor.generate({ words: 1, numbers: 0 }),


### PR DESCRIPTION
Contributes to #2173 

Adds the option to specify `multiLineWrap` on a per column basis. There is an example added to the basic usage story on the last column.
![Screen Shot 2022-08-18 at 3 23 02 PM](https://user-images.githubusercontent.com/10215203/185478325-d1ee718b-22bb-4053-adee-f0ff9ac77b42.png)

#### What did you change?

```
packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
packages/cloud-cognitive/src/components/Datagrid/useDefaultStringRenderer.js
```
#### How did you test and verify your work?
Storybook