### PR TITLE
fix(Datagrid): export useColumnOrder hook

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useColumnOrder } from 'react-table';
+// import { useColumnOrder } from 'react-table';
 import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';
@@ -40,6 +40,7 @@ import {
   useColumnCenterAlign,
   useStickyColumn,
   useActionsColumn,
+  useColumnOrder,
 } from '.';
 
 import {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -7,7 +7,6 @@
  */
 
 import React, { useState, useEffect } from 'react';
-// import { useColumnOrder } from 'react-table';
 import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -29,9 +29,9 @@ import {
   useRowIsMouseOver,
   useStickyColumn,
   useActionsColumn,
+  useColumnOrder,
 } from '.';
 
-import { useColumnOrder } from 'react-table';
 import {
   DataTable,
   Button,

--- a/packages/cloud-cognitive/src/components/Datagrid/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/index.js
@@ -21,3 +21,4 @@ export { default as useActionsColumn } from './useActionsColumn';
 export { default as useCustomizeColumns } from './useCustomizeColumns';
 export { default as useSelectAllWithToggle } from './useSelectAllToggle';
 export { default as useColumnCenterAlign } from './useColumnCenterAlign';
+export { default as useColumnOrder } from './useColumnOrder';

--- a/packages/cloud-cognitive/src/components/Datagrid/useColumnOrder.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useColumnOrder.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useColumnOrder } from 'react-table';
+
+export default useColumnOrder;

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -71,6 +71,7 @@ export {
   useActionsColumn,
   useCustomizeColumns,
   useSelectAllWithToggle,
+  useColumnOrder,
 } from './Datagrid';
 export { EditTearsheet } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';


### PR DESCRIPTION
Contributes to issue brought up over [slack](https://ibm-cloud.slack.com/archives/C013ZTX0N6B/p1661229457777809).

The main issue here is that `useColumnOrder` is coming from `react-table` so in our stories we just import it from that package. However, our consumers shouldn't need to install `react-table` so I created `useColumnOrder` within the Datagrid component and exported that so it is available to import from our package.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
packages/cloud-cognitive/src/components/Datagrid/index.js
packages/cloud-cognitive/src/components/Datagrid/useColumnOrder.js
packages/cloud-cognitive/src/components/index.js
```
#### How did you test and verify your work?
Storybook
Removed `import { useColumnOrder} from 'react-table';`
Added new hook so the following is now possible: `import { useColumnOrder } from '@carbon/ibm-products';`