### PR TITLE
fix(ImportModal): empty accepts array and changed extension variable to include period

### DIFF
--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
@@ -76,8 +76,12 @@ export let ImportModal = forwardRef(
       const acceptSet = new Set(accept);
       const name = file.name;
       const mimeType = file.type;
-      const extension = name.split('.').pop();
-      if (acceptSet.has(mimeType) || acceptSet.has(extension)) {
+      const extension = `.${name.split('.').pop()}`;
+      if (
+        acceptSet.has(mimeType) ||
+        acceptSet.has(extension) ||
+        accept.length === 0
+      ) {
         return false;
       }
       return true;


### PR DESCRIPTION
Contributes to #2126 

This PR fixes a bug where the user would pass `accept={[]}` and would always return as an invalid type. Also changed the extension variable to re-add a period in front to align with [HTML's accept attribute standards](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) of having the filetype with a period in front. 

#### What did you change?
packages/cloud-cognitive/src/components/ImportModal/ImportModal.js

1. Added another OR statement to return false when the accept is empty (if the user passes an empty accept array that means that it accepts all file types so isInvalidFileType should return false for this case.
<img width="557" alt="Screen Shot 2022-08-23 at 1 51 42 PM" src="https://user-images.githubusercontent.com/12755042/186229644-f2eee524-8a62-4a97-8e95-11a1f1b11d76.png">

2. Currently the extension doesn't have a period in the front, so I added it back in to align with HTML's accept list.
<img width="487" alt="Screen Shot 2022-08-23 at 1 52 39 PM" src="https://user-images.githubusercontent.com/12755042/186229803-0769306f-cf75-4069-b7ec-5258584df62d.png">




#### How did you test and verify your work?
