### PR TITLE
fix: Inline edit 2107

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -72,7 +72,7 @@ export let InlineEdit = React.forwardRef(
     },
     refIn
   ) => {
-    const refInput = useRef(null);
+    const refInput = useRef({ innerText: value });
     const localRef = useRef(null);
     const ref = refIn || localRef;
     const [editing, setEditing] = useState(false);
@@ -277,7 +277,8 @@ export let InlineEdit = React.forwardRef(
           {...getDevtoolsProps(componentName)}
           {...{ id, size }}
           className={cx(`${blockClass}__input`, {
-            [`${blockClass}__input--empty`]: !value,
+            [`${blockClass}__input--empty`]:
+              refInput.current?.innerText?.length === 0,
           })}
           contentEditable
           aria-label={labelText}

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -289,7 +289,7 @@ export let InlineEdit = React.forwardRef(
           onPaste={handlePaste}
           suppressContentEditableWarning={true}
           ref={refInput}
-          data-placeholder={placeholder ?? labelText}
+          data-placeholder={placeholder}
         >
           {value}
         </div>

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -277,8 +277,7 @@ export let InlineEdit = React.forwardRef(
           {...getDevtoolsProps(componentName)}
           {...{ id, size }}
           className={cx(`${blockClass}__input`, {
-            [`${blockClass}__input--empty`]:
-              refInput.current?.innerText?.length === 0,
+            [`${blockClass}__input--empty`]: !value,
           })}
           contentEditable
           aria-label={labelText}

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.stories.js
@@ -226,5 +226,6 @@ export const inlineEdit = prepareStory(Template, {
     cancelDescription: 'Cancel',
     saveDescription: 'Save',
     value: 'hello, world',
+    placeholder: 'placeholder text',
   },
 });


### PR DESCRIPTION
Contributes to #2107 

fixes an issue where if no value was supplied to inline edit it causes the placeholder text to not show.

i'll be honest, i'm not as familiar with the need for so much need of `ref`'s in this component. the problem appeared to be related to the fact that `refInput` wasn't being set until the user clicked inside the input when no value prop was supplied. this fix changes that check to use `value` instead of `refInput`. @lee-chase i know you have a lot of experience with this component. perhaps you should review this change and let me know if this works or not since it appears to be a different approach.

you can verify this behavior by going to `InlineEdit.stories.js` and in the template props setting `value: ''` and adding a `placeholder` prop (assuming you're on the main branch and not this one).

also, i noticed this on line 292 `data-placeholder={placeholder ?? labelText}` i don't think this is necessary. the user either wants a placeholder or not.