### PR TITLE
fix(SidePanel): style update for title truncation issue

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1041,6 +1041,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   background-color: var(--cds-ui-01, #f4f4f4);
   opacity: var(--c4p--side-panel--subtitle-opacity);
   transform: translateY(var(--c4p--side-panel--title-y-position));
+  word-break: break-word;
 }
 .c4p--side-panel__container .c4p--side-panel__label-text {
   font-size: var(--cds-label-01-font-size, 0.75rem);

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -241,6 +241,7 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       background-color: $ui-01;
       opacity: var(--#{$block-class}--subtitle-opacity);
       transform: translateY(var(--#{$block-class}--title-y-position));
+      word-break: break-word;
     }
     .#{$block-class}__label-text {
       @include carbon--type-style('label-01');


### PR DESCRIPTION
Contributes to #2185

Title truncation does not occur on strings with no spaces

#### What did you change?
- Updated the style for title to resolve the issue
<img width="1489" alt="image" src="https://user-images.githubusercontent.com/40118548/187364823-57b38a87-35e5-4a06-af89-fec67ea8653b.png">


#### How did you test and verify your work?
- Tests & Storybook
