### PR TITLE
fix(Datagrid): add withSelectColumns when using useSelectRows

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
@@ -23,6 +23,11 @@ const useSelectRows = (hooks) => {
     Object.assign(instance, { rows: rowsWithSelect });
   };
   hooks.useInstance.push(useInstance);
+  hooks.useInstance.push((instance) => {
+    Object.assign(instance, {
+      withSelectRows: true,
+    });
+  });
   hooks.visibleColumns.push((columns) => [
     {
       id: selectionColumnId,

--- a/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
@@ -142,7 +142,7 @@ const changeProps = (elementName, headerCellRef, props, data) => {
         className: cx({
           [`${leftStickyStyleClassPrefix}-${elementName}`]: true,
           [`${leftStickyStyleClassPrefix}-${elementName}--with-extra-select-column`]:
-            data?.instance?.withStickyColumn,
+            data?.instance?.withSelectRows,
         }),
         ...(headerCellRef && {
           ref: headerCellRef,


### PR DESCRIPTION
Contributes to #2240 

We needed to check against a value in `datagridState` to know when to change the `left` position value. I added it to `useSelectRows` and then was able to check for `withSelectRows` in `useStickyColumns`.

Before
https://user-images.githubusercontent.com/10215203/187460664-05dd72b5-f441-4e67-b8a6-422398b47195.mov

After
https://user-images.githubusercontent.com/10215203/187460698-26bae5b0-8326-4915-9c0d-80c60c4ca2af.mov


#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
packages/cloud-cognitive/src/components/Datagrid/useStickyColumn.js
```
#### How did you test and verify your work?
Storybook