### PR TITLE
fix: Remove `@carbon/elements` from `@carbon/ibm-cloud-cognitive-cdai`'s peer dependencies

### DIFF
--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -35,7 +35,6 @@
     "upgrade-dependencies": "npm-check-updates -u --dep dev,peer,prod --color --reject '/(carbon|^react$|^react-dom$)/'"
   },
   "peerDependencies": {
-    "@carbon/elements": "^10.55.0",
     "@carbon/grid": "^10.43.1",
     "@carbon/icons-react": "^10.49.0",
     "carbon-components": "^10.57.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1741,7 +1741,6 @@ __metadata:
     sinon: ^14.0.0
     uuid: ^8.3.2
   peerDependencies:
-    "@carbon/elements": ^10.55.0
     "@carbon/grid": ^10.43.1
     "@carbon/icons-react": ^10.49.0
     carbon-components: ^10.57.2


### PR DESCRIPTION
Contributes to #2231

#### What did you change?

See title.

#### How did you test and verify your work?

I'm assuming that CI will bear this out.