### PR TITLE
fix: Require only one of `arial-label` or `aria-labelledby` in `<IdeNavigation>`

### DIFF
--- a/packages/cdai/src/components/IdeNavigation/Navigation/IdeNavigation.js
+++ b/packages/cdai/src/components/IdeNavigation/Navigation/IdeNavigation.js
@@ -101,12 +101,12 @@ IdeNavigation.propTypes = {
   ariaAttributes: PropTypes.oneOfType([
     PropTypes.shape({
       /** aria labelledby markup which is applied to the navigation, referencing the label which describe the nav. Must be provided */
-      'aria-labelledby': PropTypes.string.isRequired
+      'aria-labelledby': PropTypes.string.isRequired,
     }),
     PropTypes.shape({
       /** aria label which is applied to the navigation. Must be provided, and be pre translated */
-      'aria-label': PropTypes.string.isRequired
-    })
+      'aria-label': PropTypes.string.isRequired,
+    }),
   ]),
   /** children. This should be/represent the current page selected by the user */
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.array]),
@@ -134,6 +134,6 @@ IdeNavigation.defaultProps = {
     'Click here to expand or collapse the navigation - change this for a pre translated string!',
   navigationLinks: [],
   ariaAttributes: {
-    'aria-label': 'Example Aria Labeled'
+    'aria-label': 'Example Aria Labeled',
   },
 };

--- a/packages/cdai/src/components/IdeNavigation/Navigation/IdeNavigation.js
+++ b/packages/cdai/src/components/IdeNavigation/Navigation/IdeNavigation.js
@@ -97,13 +97,17 @@ export default class IdeNavigation extends React.Component {
 }
 
 IdeNavigation.propTypes = {
-  /** Required aria attributes. Both must be provided */
-  ariaAttributes: PropTypes.shape({
-    /** aria labelledby markup which is applied to the navigation, referencing the label which describe the nav. Must be provided */
-    'aria-labelledby': PropTypes.string.isRequired,
-    /** aria label which is applied to the navigation. Must be provided, and be pre translated */
-    'aria-label': PropTypes.string.isRequired,
-  }),
+  /** Required aria attributes. One or the other must be provided */
+  ariaAttributes: PropTypes.oneOfType([
+    PropTypes.shape({
+      /** aria labelledby markup which is applied to the navigation, referencing the label which describe the nav. Must be provided */
+      'aria-labelledby': PropTypes.string.isRequired
+    }),
+    PropTypes.shape({
+      /** aria label which is applied to the navigation. Must be provided, and be pre translated */
+      'aria-label': PropTypes.string.isRequired
+    })
+  ]),
   /** children. This should be/represent the current page selected by the user */
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.array]),
   className: PropTypes.string,
@@ -130,7 +134,6 @@ IdeNavigation.defaultProps = {
     'Click here to expand or collapse the navigation - change this for a pre translated string!',
   navigationLinks: [],
   ariaAttributes: {
-    'aria-label': 'Example Aria Labeled',
-    'aria-labelledby': 'Example Aria Labeled by',
+    'aria-label': 'Example Aria Labeled'
   },
 };

--- a/packages/cdai/src/components/IdeNavigation/Navigation/__snapshots__/IdeNavigation.spec.js.snap
+++ b/packages/cdai/src/components/IdeNavigation/Navigation/__snapshots__/IdeNavigation.spec.js.snap
@@ -111,7 +111,6 @@ Array [
       addFocusListeners={false}
       addMouseListeners={false}
       aria-label="Example Aria Labeled"
-      aria-labelledby="Example Aria Labeled by"
       className="ide-navigation--nav-theme ide-navigation--nav-overrides "
       data-ui-id="IdeNavigation--left-nav"
       defaultExpanded={false}


### PR DESCRIPTION
Contributes to #2215

#### What did you change?

Previously, `<IdeNavigation>`'s prop `ariaAttributes` incorrectly required *both* `aria-labelledby` *and* `aria-label` to be specified. Now, only one or the other of `aria-labelledby` and `aria-label` is required. If both are supplied, there is no prop type error, so we will have backwards compatibility. (However, this will still cause the same accessibility issue mentioned in #2215.)

The default `ariaAttributes` prop now only specifies `aria-label`, not `aria-labelledby`. The example value of `aria-labelledby` was `'Example Aria Labeled by'` which was never [a meaningful value for this](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) in any case.

#### How did you test and verify your work?

Manually... also CI will go a long way here I hope.