### PR TITLE
fix(removeModal): Edit small inconsistencies from pal

### DIFF
--- a/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
+++ b/packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
@@ -32,7 +32,7 @@ const defaultProps = {
   body: `Deleting ${resourceName} will permanently delete the configuration. This action cannot be undone.`,
   className: 'remove-modal-test',
   title: 'Confirm delete',
-  iconDescription: 'close',
+  iconDescription: 'Close',
   inputInvalidText: 'A valid value is required',
   inputLabelText: `Type ${resourceName} to confirm`,
   inputPlaceholderText: 'Name of resourceName',
@@ -40,7 +40,7 @@ const defaultProps = {
   open: true,
   primaryButtonText: 'Delete',
   resourceName,
-  secondaryButtonText: 'Close',
+  secondaryButtonText: 'Cancel',
   label: `Delete ${resourceName}`,
   preventCloseOnClickOutside: true,
 };

--- a/packages/cloud-cognitive/src/components/RemoveModal/_remove-modal.scss
+++ b/packages/cloud-cognitive/src/components/RemoveModal/_remove-modal.scss
@@ -25,10 +25,6 @@
     padding-right: $spacing-05;
   }
 
-  .#{$block-class} .#{$carbon-prefix}--modal-close {
-    display: none;
-  }
-
   .#{$block-class}__body {
     padding-right: 20%;
     margin-bottom: $spacing-05;


### PR DESCRIPTION
Contributes to #2190

- Changed secondary button text to represent the guidance from PAL from 'Close' to 'Cancel'
- Added the 'X' icon on all instances to close model

#### What did you change?
`
packages/cloud-cognitive/src/components/RemoveModal/_remove-modal.scss
packages/cloud-cognitive/src/components/RemoveModal/RemoveModal.stories.js
`

#### How did you test and verify your work?
Storybook