### PR TITLE
chore: remove scheduled v11 releases

### DIFF
--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -2,8 +2,6 @@ name: Releases @carbon/ibm-products with v11 support # Builds and releases v11 s
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '30 4 * * TUE' # Release every Tuesday at 4:30am EST
 
 jobs:
   Release_v11:


### PR DESCRIPTION
Best to put the weekly v11 releases on pause until we can better manage upgrading the v11 branch.

#### What did you change?
`release-v11.yml`
#### How did you test and verify your work?
Removing the cron schedule will prevent the action from running weekly.