### PR TITLE
chore(Datagrid): start storybook reorganization for Datagrid

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -17,12 +17,57 @@ import { Datagrid } from '.';
 
 <!-- TODO: Overview. -->
 
+The Datagrid component is an extension of Carbon's DataTable component. At the
+most basic level, the Datagrid component takes in columns and rows and renders a
+data table. There is a set of data table extensions which this component
+provides support for, these can be found
+[here](https://pages.github.ibm.com/cdai-design/pal/components/data-table/overview/).
+This component is data driven and allows you to choose what pieces will be
+included based on the hooks/plugins that are provided.
+
 ## Example usage
 
 <!-- TODO: One example per designed use case. -->
 
+Here is a basic usage example. The following component will render the datagrid
+seen below, with pagination and some toolbar actions. One of the key pieces to
+building the datagrid is the `useDatagrid` hook, this will give you all of the
+state/props required to render a Datagrid.
+
+```jsx
+import { Datagrid, useDatagrid } from '@carbon/ibm-products';
+...
+...
+const App = () => {
+  const columns = React.useMemo(() => defaultHeader, []);
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid({
+    columns,
+    data: rows,
+    gridTitle: 'Data table title',
+    gridDescription: 'Additional information if needed'
+    initialState: {
+      pageSize: 10,
+      pageSizes: [5, 10, 25, 50],
+    },
+    DatagridActions,
+    DatagridPagination,
+  });
+
+  return <Datagrid datagridState={datagridState} />;
+};
+```
+
 <Canvas>
-  <Story id={getStoryId(Datagrid.displayName, 'basic-usage')} />
+  <Story
+    id={getStoryId(
+      Datagrid.displayName,
+      'header-basic-usage-story',
+      '/Extensions/Header'
+    )}
+  />
 </Canvas>
 
 ## Code sample

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -13,16 +13,8 @@ import { getInlineEditColumns } from './utils/getInlineEditColumns';
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 
 import { action } from '@storybook/addon-actions';
-import {
-  Activity16,
-  Restart16,
-  Download16,
-  Filter16,
-  Add16,
-  Edit16,
-  TrashCan16,
-} from '@carbon/icons-react';
-import { DataTable, Button, Pagination } from 'carbon-components-react';
+import { Activity16, Add16 } from '@carbon/icons-react';
+import { DataTable } from 'carbon-components-react';
 import {
   Datagrid,
   useDatagrid,
@@ -57,7 +49,9 @@ import cx from 'classnames';
 
 import styles from './_storybook-styles.scss';
 import { SidePanel } from '../SidePanel';
-import { ButtonMenu, ButtonMenuItem } from '../ButtonMenu';
+import { DatagridActions } from './utils/DatagridActions';
+import { DatagridPagination } from './utils/DatagridPagination';
+import { Wrapper } from './utils/Wrapper';
 
 export default {
   title: getStoryTitle(Datagrid.displayName),
@@ -69,22 +63,7 @@ export default {
     },
   },
 };
-
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const Wrapper = ({ children }) => (
-  <div
-    style={{
-      height: '100vh',
-      width: '100%',
-      padding: '1rem',
-      margin: '0',
-      zIndex: '0',
-    }}
-  >
-    {children}
-  </div>
-);
 
 const defaultHeader = [
   {
@@ -168,12 +147,14 @@ export const BasicUsage = () => {
     []
   );
   const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
   const datagridState = useDatagrid({
     columns,
-    data,
+    data: rows,
   });
 
-  return <Datagrid datagridState={{ ...datagridState }} />;
+  return <Datagrid datagridState={datagridState} />;
 };
 
 export const EmptyState = () => {
@@ -227,49 +208,6 @@ export const InitialLoad = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const WithHeader = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
-  const [data] = useState(makeData(11));
-  const gridTitle = 'Data table title';
-  const gridDescription = 'Additional information if needed';
-  const datagridState = useDatagrid({
-    columns,
-    data,
-    gridTitle,
-    gridDescription,
-    initialState: {
-      pageSize: 10,
-      pageSizes: [5, 10, 25, 50],
-    },
-    DatagridActions,
-    DatagridPagination,
-  });
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-export const WithDenseHeader = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
-  const [data] = useState(makeData(11));
-  const gridTitle = 'Data table title';
-  const gridDescription = 'Additional information if needed';
-  const datagridState = useDatagrid({
-    columns,
-    data,
-    gridTitle,
-    gridDescription,
-    initialState: {
-      pageSize: 10,
-      pageSizes: [5, 10, 25, 50],
-    },
-    useDenseHeader: true,
-    DatagridActions,
-    DatagridPagination,
-  });
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
 export const InfiniteScroll = () => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data, setData] = useState(makeData(0));
@@ -317,24 +255,6 @@ export const TenThousandEntries = () => {
   );
 
   return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-const DatagridPagination = ({ state, setPageSize, gotoPage, rows }) => {
-  const updatePagination = ({ page, pageSize }) => {
-    console.log(state);
-    setPageSize(pageSize);
-    gotoPage(page - 1); // Carbon is non-zero-based
-  };
-
-  return (
-    <Pagination
-      page={state.pageIndex + 1} // react-table is zero-based
-      pageSize={state.pageSize}
-      pageSizes={state.pageSizes || [10, 20, 30, 40, 50]}
-      totalItems={rows.length}
-      onChange={updatePagination}
-    />
-  );
 };
 
 export const WithPagination = () => {
@@ -678,135 +598,6 @@ export const CenterAlignedColumns = () => {
   );
 
   return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-const DatagridActions = (datagridState) => {
-  const {
-    selectedFlatRows,
-    setGlobalFilter,
-    CustomizeColumnsButton,
-    RowSizeDropdown,
-    rowSizeDropdownProps,
-    useDenseHeader,
-  } = datagridState;
-  const downloadCsv = () => {
-    alert('Downloading...');
-  };
-  const { TableToolbarContent, TableToolbarSearch } = DataTable;
-
-  const refreshColumns = () => {
-    alert('refreshing...');
-  };
-  const leftPanelClick = () => {
-    alert('open/close left panel...');
-  };
-  const searchForAColumn = 'Search';
-  const isNothingSelected = selectedFlatRows.length === 0;
-  const style = {
-    'button:nth-child(1) > span:nth-child(1)': {
-      bottom: '-37px',
-    },
-  };
-
-  return (
-    isNothingSelected &&
-    (useDenseHeader && useDenseHeader ? (
-      <TableToolbarContent size="sm">
-        <div style={style}>
-          <Button
-            kind="ghost"
-            hasIconOnly
-            tooltipPosition="bottom"
-            renderIcon={Download16}
-            iconDescription={'Download CSV'}
-            onClick={downloadCsv}
-          />
-        </div>
-        <div style={style}>
-          <Button
-            kind="ghost"
-            hasIconOnly
-            tooltipPosition="bottom"
-            renderIcon={Filter16}
-            iconDescription={'Left panel'}
-            onClick={leftPanelClick}
-          />
-        </div>
-        <RowSizeDropdown {...rowSizeDropdownProps} />
-        <div style={style} className={`${blockClass}__toolbar-divider`}>
-          <Button kind="ghost" renderIcon={Add16} iconDescription={'Action'}>
-            Ghost button
-          </Button>
-        </div>
-
-        {CustomizeColumnsButton && (
-          <div style={style}>
-            <CustomizeColumnsButton />
-          </div>
-        )}
-      </TableToolbarContent>
-    ) : (
-      <>
-        <Button
-          kind="ghost"
-          hasIconOnly
-          tooltipPosition="bottom"
-          renderIcon={Filter16}
-          iconDescription={'Left panel'}
-          onClick={leftPanelClick}
-        />
-        <TableToolbarContent>
-          <TableToolbarSearch
-            size="xl"
-            id="columnSearch"
-            persistent
-            placeHolderText={searchForAColumn}
-            onChange={(e) => setGlobalFilter(e.target.value)}
-          />
-          <RowSizeDropdown {...rowSizeDropdownProps} />
-          <div style={style}>
-            <Button
-              kind="ghost"
-              hasIconOnly
-              tooltipPosition="bottom"
-              renderIcon={Restart16}
-              iconDescription={'Refresh'}
-              onClick={refreshColumns}
-            />
-          </div>
-          <div style={style}>
-            <Button
-              kind="ghost"
-              hasIconOnly
-              tooltipPosition="bottom"
-              renderIcon={Download16}
-              iconDescription={'Download CSV'}
-              onClick={downloadCsv}
-            />
-          </div>
-          {CustomizeColumnsButton && (
-            <div style={style}>
-              <CustomizeColumnsButton />
-            </div>
-          )}
-          <ButtonMenu label="Primary button" renderIcon={Add16}>
-            <ButtonMenuItem
-              itemText="Option 1"
-              onClick={action(`Click on ButtonMenu Option 1`)}
-            />
-            <ButtonMenuItem
-              itemText="Option 2"
-              onClick={action(`Click on ButtonMenu Option 2`)}
-            />
-            <ButtonMenuItem
-              itemText="Option 3"
-              onClick={action(`Click on ButtonMenu Option 3`)}
-            />
-          </ButtonMenu>
-        </TableToolbarContent>
-      </>
-    ))
-  );
 };
 
 export const DatagridActionsToolbar = () => {
@@ -1243,63 +1034,6 @@ export const StickyActionsColumn = () => {
     useActionsColumn,
     useSelectRows,
     useSelectAllWithToggle
-  );
-  return (
-    <Wrapper>
-      <h3>{msg}</h3>
-      <Datagrid datagridState={{ ...datagridState }} />
-      <p>More details documentation check the Notes section below</p>
-    </Wrapper>
-  );
-};
-
-export const RowActionButton = () => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader,
-      {
-        Header: '',
-        accessor: 'actions',
-        sticky: 'right',
-        width: 90,
-        isAction: true,
-      },
-    ],
-    []
-  );
-  const [data] = useState(makeData(10));
-  const [msg, setMsg] = useState('click action menu');
-  const onActionClick = (actionId, row) => {
-    console.log(onActionClick);
-    const { original } = row;
-    setMsg(
-      `Clicked [${actionId}] on row: <${original.firstName} ${original.lastName}>`
-    );
-  };
-
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      rowActions: [
-        {
-          id: 'edit',
-          itemText: 'Edit',
-          icon: Edit16,
-          onClick: onActionClick,
-        },
-
-        {
-          id: 'delete',
-          itemText: 'Delete',
-          icon: TrashCan16,
-          isDelete: true,
-          onClick: onActionClick,
-        },
-      ],
-    },
-    useStickyColumn,
-    useActionsColumn
   );
   return (
     <Wrapper>

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -117,7 +117,10 @@ DatagridContent.propTypes = {
   datagridState: PropTypes.shape({
     getTableProps: PropTypes.func,
     withVirtualScroll: PropTypes.bool,
-    DatagridPagination: PropTypes.element,
+    DatagridPagination: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+    ]),
     CustomizeColumnsModal: PropTypes.element,
     isFetching: PropTypes.bool,
     leftPanel: PropTypes.object,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
@@ -8,6 +8,7 @@
 // @flow
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import {
   OverflowMenu,
   OverflowMenuItem,
@@ -31,6 +32,8 @@ const SelectAllWithToggle = ({
   getToggleAllRowsSelectedProps,
   allPageRowsLabel = 'Select all on page',
   allRowsLabel = 'Select all',
+  columns,
+  withStickyColumn,
 }) => {
   const [selectAllMode, setSelectAllMode] = useState(SELECT_ALL_PAGE_ROWS);
   useEffect(() => {
@@ -50,11 +53,15 @@ const SelectAllWithToggle = ({
       : getToggleAllRowsSelectedProps;
   const { onChange, ...selectProps } = getProps();
   const disabled = isFetching || selectProps.disabled;
+  const isFirstColumnStickyLeft =
+    columns[0]?.sticky === 'left' && withStickyColumn;
   return (
     <th
       role="columnheader"
       scope="col"
-      className={`${blockClass}__select-all-toggle-on`}
+      className={cx(`${blockClass}__select-all-toggle-on`, {
+        [`${blockClass}__select-all-sticky-left`]: isFirstColumnStickyLeft,
+      })}
     >
       <span>
         <Checkbox
@@ -103,12 +110,14 @@ const SelectAllWithToggle = ({
 SelectAllWithToggle.propTypes = {
   allPageRowsLabel: PropTypes.string,
   allRowsLabel: PropTypes.string,
+  columns: PropTypes.arrayOf(PropTypes.object),
   getToggleAllPageRowsSelectedProps: PropTypes.func.isRequired,
   getToggleAllRowsSelectedProps: PropTypes.func.isRequired,
   isAllRowsSelected: PropTypes.bool.isRequired,
   isFetching: PropTypes.bool,
   selectAllToggle: PropTypes.object,
   tableId: PropTypes.string.isRequired,
+  withStickyColumn: PropTypes.bool,
 };
 
 export default SelectAllWithToggle;

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
@@ -1,0 +1,197 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { DatagridPagination } from '../../utils/DatagridPagination';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Header`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 60,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const BasicUsage = ({ ...args }) => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: 'Someone 11',
+        accessor: 'someone11',
+        multiLineWrap: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid({
+    columns,
+    data: rows,
+    initialState: {
+      pageSize: 10,
+      pageSizes: [5, 10, 25, 50],
+    },
+    DatagridActions,
+    DatagridPagination,
+    ...args.defaultGridProps,
+  });
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const BasicTemplateWrapper = ({ ...args }) => {
+  return <BasicUsage defaultGridProps={{ ...args }} />;
+};
+
+const basicUsageControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+};
+const basicUsageStoryName = 'With header';
+export const HeaderBasicUsageStory = prepareStory(BasicTemplateWrapper, {
+  storyName: basicUsageStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+  },
+  args: {
+    ...basicUsageControlProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -1,0 +1,365 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Add16, Edit16, TrashCan16, Checkmark16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import {
+  Datagrid,
+  useDatagrid,
+  useStickyColumn,
+  useActionsColumn,
+  useSelectRows,
+  useSelectAllWithToggle,
+} from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { DatagridPagination } from '../../utils/DatagridPagination';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/RowActionButtons`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 60,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const RowActionButtons = ({ ...args }) => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: '',
+        accessor: 'actions',
+        sticky: 'right',
+        width: 96,
+        isAction: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data: rows,
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+      },
+      DatagridActions,
+      DatagridPagination,
+      ...args.defaultGridProps,
+    },
+    useStickyColumn,
+    useActionsColumn
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const RowActionButtonTemplateWrapper = ({ ...args }) => {
+  return <RowActionButtons defaultGridProps={{ ...args }} />;
+};
+
+const rowActionButtonsProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  rowActions: sharedDatagridProps.rowActions,
+};
+const basicUsageStoryName = 'With row action buttons';
+export const RowActionButtonsUsageStory = prepareStory(
+  RowActionButtonTemplateWrapper,
+  {
+    storyName: basicUsageStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      rowActions: ARG_TYPES.rowActions,
+    },
+    args: {
+      ...rowActionButtonsProps,
+    },
+  }
+);
+
+const manyRowActionButtonsProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+    {
+      id: 'approve',
+      itemText: 'Approve',
+      icon: Checkmark16,
+      onClick: action('Clicked row action: approve'),
+    },
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      hasDivider: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+const manyRowActionButtonsStoryName = 'With many row action buttons';
+export const ManyRowActionButtonsUsageStory = prepareStory(
+  RowActionButtonTemplateWrapper,
+  {
+    storyName: manyRowActionButtonsStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      rowActions: ARG_TYPES.rowActions,
+    },
+    args: {
+      ...manyRowActionButtonsProps,
+    },
+  }
+);
+
+const RowActionButtonsBatchActions = ({ ...args }) => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: '',
+        accessor: 'actions',
+        sticky: 'right',
+        width: 96,
+        isAction: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data: rows,
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+      },
+      DatagridActions,
+      DatagridPagination,
+      ...args.defaultGridProps,
+    },
+    useStickyColumn,
+    useActionsColumn,
+    useSelectRows,
+    useSelectAllWithToggle
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const getBatchActions = () => {
+  return [
+    {
+      label: 'Duplicate',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Add',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Select all',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+      type: 'select_all',
+    },
+    {
+      label: 'Publish to catalog',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Download',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Delete',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+      hasDivider: true,
+      kind: 'danger',
+    },
+  ];
+};
+
+const RowActionButtonBatchTemplateWrapper = ({ ...args }) => {
+  return <RowActionButtonsBatchActions defaultGridProps={{ ...args }} />;
+};
+
+const rowActionButtonsBatchActionsProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  rowActions: sharedDatagridProps.rowActions,
+  toolbarBatchActions: getBatchActions(),
+  batchActions: true,
+};
+const rowActionButtonsBatchActionsStoryName =
+  'With row action buttons and batch actions';
+export const RowActionButtonsBatchActionsUsageStory = prepareStory(
+  RowActionButtonBatchTemplateWrapper,
+  {
+    storyName: rowActionButtonsBatchActionsStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      rowActions: ARG_TYPES.rowActions,
+      batchActions: ARG_TYPES.batchActions,
+    },
+    args: {
+      ...rowActionButtonsBatchActionsProps,
+    },
+  }
+);

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/Settings/Settings.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/Settings/Settings.stories.js
@@ -1,0 +1,203 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { DatagridPagination } from '../../utils/DatagridPagination';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Settings`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 60,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const BasicUsage = ({ ...args }) => {
+  const columns = React.useMemo(
+    () => [
+      ...defaultHeader,
+      {
+        Header: 'Someone 11',
+        accessor: 'someone11',
+        multiLineWrap: true,
+      },
+    ],
+    []
+  );
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid({
+    columns,
+    data: rows,
+    initialState: {
+      pageSize: 10,
+      pageSizes: [5, 10, 25, 50],
+    },
+    DatagridActions,
+    DatagridPagination,
+    ...args.defaultGridProps,
+  });
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const BasicTemplateWrapper = ({ ...args }) => {
+  return <BasicUsage defaultGridProps={{ ...args }} />;
+};
+
+const basicUsageControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  rowSize: sharedDatagridProps.rowSize,
+  rowSizes: sharedDatagridProps.rowSizes,
+  onRowSizeChange: sharedDatagridProps.onRowSizeChange,
+};
+const basicUsageStoryName = 'With default row height settings';
+export const DefaultSettingsUsageStory = prepareStory(BasicTemplateWrapper, {
+  storyName: basicUsageStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+    rowSize: ARG_TYPES.rowSize,
+    rowSizes: ARG_TYPES.rowSizes,
+    onRowSizeChange: ARG_TYPES.onRowSizeChange,
+  },
+  args: {
+    ...basicUsageControlProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useActionsColumn.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useActionsColumn.scss
@@ -22,3 +22,15 @@
 .#{$block-class}__actions-column-loading {
   margin-bottom: $spacing-03;
 }
+
+.#{$block-class} .#{$block-class}__disabled-row-action-button {
+  cursor: not-allowed;
+}
+
+.#{$block-class} .#{$block-class}__disabled-row-action {
+  pointer-events: none;
+}
+
+.#{$block-class} .#{$block-class}__disabled-row-action svg {
+  fill: $disabled-03;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useStickyColumn.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useStickyColumn.scss
@@ -58,3 +58,9 @@
   /* stylelint-disable-next-line */
   right: 6px !important; // offset the vertical scroll bar in the table body
 }
+
+.#{$block-class}__select-all-toggle-on.#{$block-class}__select-all-sticky-left {
+  position: sticky;
+  z-index: 1;
+  left: 0;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
@@ -17,7 +17,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 
 const useActionsColumn = (hooks) => {
   const useAttachActionsOnInstance = (instance) => {
-    const { rowActions, isFetching } = instance;
+    const { rowActions, isFetching, selectedFlatRows } = instance;
 
     if (rowActions && Array.isArray(rowActions)) {
       const addActionsMenu = (props, cellData) => {
@@ -39,20 +39,49 @@ const useActionsColumn = (hooks) => {
                       className={`${blockClass}_actions-column`}
                       style={{ display: 'flex' }}
                     >
-                      {rowActions.map((action) => {
-                        const { id, itemText, onClick, icon } = action;
+                      {rowActions.map((action, index) => {
+                        const { id, itemText, onClick, icon, ...rest } = action;
+                        const selectedRowId = selectedFlatRows?.filter((item) =>
+                          item.id === row.id ? item.id : null
+                        );
                         return (
                           <div
-                            className={`${blockClass}__actions-column-button`}
-                            key=""
+                            className={cx(
+                              `${blockClass}__actions-column-button`,
+                              {
+                                [`${blockClass}__disabled-row-action-button`]:
+                                  selectedFlatRows &&
+                                  selectedFlatRows.length &&
+                                  selectedRowId &&
+                                  selectedRowId.length,
+                              }
+                            )}
+                            key={`${itemText}__${index}`}
                           >
                             <OverflowMenu
+                              {...rest}
                               renderIcon={icon}
                               hasIconOnly
                               light
                               iconDescription={itemText}
                               kind="ghost"
+                              className={cx({
+                                [`${blockClass}__disabled-row-action`]:
+                                  selectedFlatRows &&
+                                  selectedFlatRows.length &&
+                                  selectedRowId &&
+                                  selectedRowId.length,
+                              })}
                               onClick={(e) => {
+                                if (
+                                  selectedFlatRows &&
+                                  selectedFlatRows.length &&
+                                  selectedRowId &&
+                                  selectedRowId.length
+                                ) {
+                                  // Row actions should be disabled if row is selected and batchActions toolbar is active
+                                  return;
+                                }
                                 e.stopPropagation();
                                 onClick(id, row, e);
                               }}
@@ -114,6 +143,9 @@ const useActionsColumn = (hooks) => {
                 [`${blockClass}__actions-column-cell`]: true,
                 [`${blockClass}__cell`]: true,
               }),
+              style: {
+                width: 96,
+              },
             },
           ];
         }

--- a/packages/cloud-cognitive/src/components/Datagrid/useSelectAllToggle.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSelectAllToggle.js
@@ -7,6 +7,7 @@
  */
 // @flow
 import React from 'react';
+import cx from 'classnames';
 import { selectionColumnId } from './common-column-ids';
 import SelectAllWithToggle from './Datagrid/DatagridSelectAllWithToggle';
 import { pkg } from '../../settings';
@@ -37,12 +38,16 @@ const useSelectAllWithToggleComponent = (hooks) => {
 const useAddClassNameToSelectRow = (hooks) => {
   hooks.getCellProps.push((props, data) => {
     const { column } = data.cell;
-    const { DatagridPagination } = data.instance;
+    const { DatagridPagination, columns, withStickyColumn } = data.instance;
+    const isFirstColumnStickyLeft =
+      columns[0]?.sticky === 'left' && withStickyColumn;
     if (column.id === selectionColumnId && DatagridPagination) {
       return [
         props,
         {
-          className: `${blockClass}__select-all-toggle-on`,
+          className: cx(`${blockClass}__select-all-toggle-on`, {
+            [`${blockClass}__select-all-sticky-left`]: isFirstColumnStickyLeft,
+          }),
         },
       ];
     }
@@ -58,6 +63,8 @@ const Header = (gridState) => {
     getToggleAllPageRowsSelectedProps,
     getToggleAllRowsSelectedProps,
     isAllRowsSelected,
+    withStickyColumn,
+    columns,
   } = gridState;
   const props = {
     tableId,
@@ -66,6 +73,8 @@ const Header = (gridState) => {
     getToggleAllPageRowsSelectedProps,
     getToggleAllRowsSelectedProps,
     isAllRowsSelected,
+    withStickyColumn,
+    columns,
   };
   return <SelectAllWithToggle {...props} />;
 };

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { DataTable, Button } from 'carbon-components-react';
+import { Download16, Filter16, Add16, Restart16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import { pkg } from '../../../settings';
+import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
+
+const blockClass = `${pkg.prefix}--datagrid`;
+export const DatagridActions = (datagridState) => {
+  const {
+    selectedFlatRows,
+    setGlobalFilter,
+    CustomizeColumnsButton,
+    RowSizeDropdown,
+    rowSizeDropdownProps,
+    useDenseHeader,
+  } = datagridState;
+  const downloadCsv = () => {
+    alert('Downloading...');
+  };
+  const { TableToolbarContent, TableToolbarSearch } = DataTable;
+
+  const refreshColumns = () => {
+    alert('refreshing...');
+  };
+  const leftPanelClick = () => {
+    alert('open/close left panel...');
+  };
+  const searchForAColumn = 'Search';
+  const isNothingSelected = selectedFlatRows.length === 0;
+  const style = {
+    'button:nth-child(1) > span:nth-child(1)': {
+      bottom: '-37px',
+    },
+  };
+
+  return (
+    isNothingSelected &&
+    (useDenseHeader && useDenseHeader ? (
+      <TableToolbarContent size="sm">
+        <div style={style}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            tooltipPosition="bottom"
+            renderIcon={Download16}
+            iconDescription={'Download CSV'}
+            onClick={downloadCsv}
+          />
+        </div>
+        <div style={style}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            tooltipPosition="bottom"
+            renderIcon={Filter16}
+            iconDescription={'Left panel'}
+            onClick={leftPanelClick}
+          />
+        </div>
+        <RowSizeDropdown {...rowSizeDropdownProps} />
+        <div style={style} className={`${blockClass}__toolbar-divider`}>
+          <Button kind="ghost" renderIcon={Add16} iconDescription={'Action'}>
+            Ghost button
+          </Button>
+        </div>
+
+        {CustomizeColumnsButton && (
+          <div style={style}>
+            <CustomizeColumnsButton />
+          </div>
+        )}
+      </TableToolbarContent>
+    ) : (
+      <>
+        <Button
+          kind="ghost"
+          hasIconOnly
+          tooltipPosition="bottom"
+          renderIcon={Filter16}
+          iconDescription={'Left panel'}
+          onClick={leftPanelClick}
+        />
+        <TableToolbarContent>
+          <TableToolbarSearch
+            size="xl"
+            id="columnSearch"
+            persistent
+            placeHolderText={searchForAColumn}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+          />
+          <RowSizeDropdown {...rowSizeDropdownProps} />
+          <div style={style}>
+            <Button
+              kind="ghost"
+              hasIconOnly
+              tooltipPosition="bottom"
+              renderIcon={Restart16}
+              iconDescription={'Refresh'}
+              onClick={refreshColumns}
+            />
+          </div>
+          <div style={style}>
+            <Button
+              kind="ghost"
+              hasIconOnly
+              tooltipPosition="bottom"
+              renderIcon={Download16}
+              iconDescription={'Download CSV'}
+              onClick={downloadCsv}
+            />
+          </div>
+          {CustomizeColumnsButton && (
+            <div style={style}>
+              <CustomizeColumnsButton />
+            </div>
+          )}
+          <ButtonMenu label="Primary button" renderIcon={Add16}>
+            <ButtonMenuItem
+              itemText="Option 1"
+              onClick={action(`Click on ButtonMenu Option 1`)}
+            />
+            <ButtonMenuItem
+              itemText="Option 2"
+              onClick={action(`Click on ButtonMenu Option 2`)}
+            />
+            <ButtonMenuItem
+              itemText="Option 3"
+              onClick={action(`Click on ButtonMenu Option 3`)}
+            />
+          </ButtonMenu>
+        </TableToolbarContent>
+      </>
+    ))
+  );
+};

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridPagination.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridPagination.js
@@ -1,0 +1,28 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { Pagination } from 'carbon-components-react';
+
+export const DatagridPagination = ({ state, setPageSize, gotoPage, rows }) => {
+  const updatePagination = ({ page, pageSize }) => {
+    console.log(state);
+    setPageSize(pageSize);
+    gotoPage(page - 1); // Carbon is non-zero-based
+  };
+
+  return (
+    <Pagination
+      page={state.pageIndex + 1} // react-table is zero-based
+      pageSize={state.pageSize}
+      pageSizes={state.pageSizes || [10, 20, 30, 40, 50]}
+      totalItems={rows.length}
+      onChange={updatePagination}
+    />
+  );
+};

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/Wrapper.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/Wrapper.js
@@ -1,0 +1,23 @@
+/* eslint-disable react/prop-types */
+/**
+ * Copyright IBM Corp. 2020, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+export const Wrapper = ({ children }) => (
+  <div
+    style={{
+      height: '100vh',
+      width: '100%',
+      padding: '1rem',
+      margin: '0',
+      zIndex: '0',
+    }}
+  >
+    {children}
+  </div>
+);

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const ARG_TYPES = {
+  gridTitle: {
+    name: 'gridTitle',
+    control: 'text',
+    description:
+      'This sets the title text for the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+    type: { name: 'string', required: false },
+  },
+  gridDescription: {
+    name: 'gridDescription',
+    control: 'text',
+    description:
+      'This sets the description text for the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+    type: { name: 'string', required: false },
+  },
+  emptyStateTitle: {
+    name: 'emptyStateTitle',
+    control: 'text',
+    description:
+      'This sets the empty state title text for the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+    type: { name: 'string', required: false },
+  },
+  emptyStateDescription: {
+    name: 'emptyStateDescription',
+    control: 'text',
+    description:
+      'This sets the empty state description text for the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+    type: { name: 'string', required: false },
+  },
+  emptyStateSize: { control: 'select', options: ['sm', 'lg'] },
+  useDenseHeader: {
+    control: { type: 'radio' },
+    options: [true, false],
+    description:
+      'This sets the dense header option for the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+  },
+  rowSize: {
+    control: 'select',
+    options: ['xs', 'sm', 'md', 'lg', 'xl'],
+    description:
+      'This sets the height for each row of the Datagrid component. _This value is set/passed inside of the `datagridState` object._',
+  },
+  rowSizes: {
+    control: 'object',
+    description:
+      'This array of objects specifies the different row size options that will render from the settings icon in the table actions. _This value is set/passed inside of the `datagridState` object._',
+  },
+  onRowSizeChange: {
+    description:
+      'Callback function that is called on row size changes. _This value is set/passed inside of the `datagridState` object._',
+  },
+  rowActions: {
+    control: 'object',
+    description:
+      'This array of objects renders the action buttons for each row in the Datagrid. _This value is set/passed inside of the `datagridState` object._',
+    action: 'Row action onClick',
+  },
+  batchActions: {
+    control: { type: 'radio' },
+    options: [true, false],
+    description:
+      'This will allow the Datagrid component to use batch actions. _This value is set/passed inside of the `datagridState` object._',
+  },
+};

--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -36,8 +36,14 @@ export const getStoryTitle = (componentName) => {
  * @param {string} scenario The scenario name, also as a slug.
  * @returns The story id.
  */
-export const getStoryId = (componentName, scenario) =>
-  `${sanitize(getStoryTitle(componentName))}--${scenario}`;
+export const getStoryId = (componentName, scenario, subdirectory) => {
+  if (subdirectory) {
+    return `${sanitize(getStoryTitle(componentName))}-${sanitize(
+      subdirectory
+    )}--${scenario}`;
+  }
+  return `${sanitize(getStoryTitle(componentName))}--${scenario}`;
+};
 
 /**
  * A helper function to prepare storybook stories for export. This function

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -41,7 +41,15 @@ const s = [
           { n: 'Side panel', s: ['c/SidePanel'] },
           { n: 'Tearsheet', s: ['c/Tearsheet', 'c/TearsheetNarrow'] },
           { n: 'DataSpreadsheet', s: ['c/DataSpreadsheet'] },
-          { n: 'Datagrid', s: ['c/Datagrid'] },
+          {
+            n: 'Datagrid',
+            s: [
+              'c/Datagrid',
+              'c/Datagrid/Extensions/Header',
+              'c/Datagrid/Extensions/Settings',
+              'c/Datagrid/Extensions/RowActionButtons',
+            ],
+          },
         ],
       },
       {


### PR DESCRIPTION
Contributes to #2270 

This adds a folder structure to some of the Datagrid stories, with the purpose of organizing Datagrid stories based on the Data table extensions found on the [PAL site](https://pages.github.ibm.com/cdai-design/pal/components/data-table/overview/).

See below:
![Screen Shot 2022-09-14 at 2 45 26 PM](https://user-images.githubusercontent.com/10215203/190237541-f9309da8-a42b-43a2-97b3-6e908e6bfd55.png)

I also setup the stories that are inside of `Datagrid/Extensions/` such that there are some controls that you can now use to change the component. This was not originally done for the other Datagrid stories. I have only done three extensions (Header, Row action buttons, Settings) to start off, to reduce the amount of changes being reviewed. Also, started on some documentation in the `mdx` file. The majority of these changes involved adding new stories files and creating shared components that are used across datagrid  stories.

Updated mdx docs page:
![image](https://user-images.githubusercontent.com/10215203/190238626-50155e6c-4ba9-4c61-9779-908860d55a9e.png)



#### What did you change?
Datagrid stories setup
#### How did you test and verify your work?
Storybook