### PR TITLE
fix(Datagrid): row size drop down alignment

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeRadioGroup.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeRadioGroup.js
@@ -100,10 +100,7 @@ const getDropdownPosition = (buttonEle) => {
   const parent = buttonEle.parentElement;
   if (parent instanceof HTMLElement) {
     const top = buttonEle.offsetTop + buttonEle.offsetHeight;
-    const right =
-      parent.offsetWidth -
-      parent.offsetLeft -
-      (buttonEle.offsetLeft + buttonEle.offsetWidth);
+    const right = parent.offsetWidth - parent.offsetLeft - buttonEle.offsetLeft;
     return {
       top,
       right,


### PR DESCRIPTION
Contributes to #2280 

The row settings menu should be right aligned to the trigger button that opens it.

#### What did you change?

`RowSizeRadioGroup.js`

#### How did you test and verify your work?
Storybook
