### PR TITLE
fix(Datagrid): allow sticky column to stick again (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
@@ -44,7 +44,7 @@ export const useMultipleKeyTracking = ({
   }, []);
 
   useEffect(() => {
-    if (containerHasFocus && !isEditing) {
+    if (ref && containerHasFocus && !isEditing) {
       ref.current.onkeydown = ref.current.onkeyup = (event) => {
         // If keydown, we will add the new key to the keysPressedList array
         if (event.type === 'keydown') {
@@ -89,7 +89,7 @@ export const useMultipleKeyTracking = ({
     }
     // Remove handlers if the spreadsheet container loses focus
     // or is currently in edit mode
-    if (!containerHasFocus || isEditing) {
+    if ((ref && !containerHasFocus) || isEditing) {
       ref.current.onkeydown = undefined;
       ref.current.onkeyup = undefined;
       if (!previousState?.isEditing && isEditing) {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -56,8 +56,43 @@ export const DatagridContent = ({ datagridState }) => {
     dispatch({ type: 'REMOVE_GRID_ACTIVE_FOCUS', payload: activeCellId });
   });
 
+  const renderTable = () => {
+    return (
+      <Table
+        {...getTableProps()}
+        className={cx(
+          withVirtualScroll ? '' : `${blockClass}__table-simple`,
+          `${blockClass}__vertical-align-${verticalAlign}`,
+          { [`${blockClass}__variable-row-height`]: variableRowHeight },
+          { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
+          { [`${blockClass}__table-grid-active`]: gridActive },
+          getTableProps()?.className
+        )}
+        role={withInlineEdit && 'grid'}
+        tabIndex={withInlineEdit && 0}
+        onKeyDown={
+          withInlineEdit
+            ? (event) =>
+                handleGridKeyPress({
+                  event,
+                  dispatch,
+                  state,
+                  instance: datagridState,
+                  keysPressedList,
+                  usingMac,
+                })
+            : null
+        }
+        onFocus={withInlineEdit ? () => handleGridFocus(state, dispatch) : null}
+      >
+        <DatagridHead {...datagridState} />
+        <DatagridBody {...datagridState} rows={rows} />
+      </Table>
+    );
+  };
+
   const { keysPressedList, usingMac } = useMultipleKeyTracking({
-    ref: multiKeyTrackingRef,
+    ref: withInlineEdit ? multiKeyTrackingRef : null,
     containerHasFocus: gridActive,
     isEditing: !!editId,
   });
@@ -83,40 +118,11 @@ export const DatagridContent = ({ datagridState }) => {
               {leftPanel.panelContent}
             </div>
           )}
-          <div ref={multiKeyTrackingRef}>
-            <Table
-              {...getTableProps()}
-              className={cx(
-                withVirtualScroll ? '' : `${blockClass}__table-simple`,
-                `${blockClass}__vertical-align-${verticalAlign}`,
-                { [`${blockClass}__variable-row-height`]: variableRowHeight },
-                { [`${blockClass}__table-with-inline-edit`]: withInlineEdit },
-                { [`${blockClass}__table-grid-active`]: gridActive },
-                getTableProps()?.className
-              )}
-              role={withInlineEdit && 'grid'}
-              tabIndex={withInlineEdit && 0}
-              onKeyDown={
-                withInlineEdit
-                  ? (event) =>
-                      handleGridKeyPress({
-                        event,
-                        dispatch,
-                        state,
-                        instance: datagridState,
-                        keysPressedList,
-                        usingMac,
-                      })
-                  : null
-              }
-              onFocus={
-                withInlineEdit ? () => handleGridFocus(state, dispatch) : null
-              }
-            >
-              <DatagridHead {...datagridState} />
-              <DatagridBody {...datagridState} rows={rows} />
-            </Table>
-          </div>
+          {withInlineEdit ? (
+            <div ref={multiKeyTrackingRef}>{renderTable()}</div>
+          ) : (
+            renderTable()
+          )}
         </div>
       </TableContainer>
       {rows?.length > 0 &&


### PR DESCRIPTION
**Corresponding PR for #2281 for v11 branch**

Allows sticky columns to stick again, see #2281 for further detail.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/hooks/useMultipleKeyTracking.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Storybook