### PR TITLE
fix: inline edit newline fix

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -72,7 +72,7 @@ export let InlineEdit = React.forwardRef(
     },
     refIn
   ) => {
-    const refInput = useRef({ innerText: value });
+    const refInput = useRef({ textContent: value });
     const localRef = useRef(null);
     const ref = refIn || localRef;
     const [editing, setEditing] = useState(false);
@@ -146,15 +146,15 @@ export let InlineEdit = React.forwardRef(
       document.getSelection().removeAllRanges();
 
       if (onSave) {
-        onSave(refInput.current.innerText);
+        onSave(refInput.current.textContent);
       }
     };
 
     const handleInput = () => {
-      setInternalValue(refInput.current.innerText);
+      setInternalValue(refInput.current.textContent);
 
       if (onChange) {
-        onChange(refInput.current.innerText);
+        onChange(refInput.current.textContent);
       }
     };
 
@@ -194,7 +194,7 @@ export let InlineEdit = React.forwardRef(
       }
     };
     const handleCancel = () => {
-      refInput.current.innerText = value;
+      refInput.current.textContent = value;
       handleInput(value);
       doSetEditing(false);
       document.getSelection().removeAllRanges();
@@ -278,7 +278,7 @@ export let InlineEdit = React.forwardRef(
           {...{ id, size }}
           className={cx(`${blockClass}__input`, {
             [`${blockClass}__input--empty`]:
-              refInput.current?.innerText?.length === 0,
+              refInput.current?.textContent?.length === 0,
           })}
           contentEditable
           aria-label={labelText}

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.test.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.test.js
@@ -271,8 +271,8 @@ describe(componentName, () => {
     // click cancel check result reverts
     userEvent.click(controls[0]);
     expect(component).not.toHaveClass(`${blockClass}--editing`);
-    // JSDom does not implement innerText, so cannot check toHaveTextContent
-    expect(input.innerText).toEqual(startingValue);
+    // JSDom does not implement textContent, so cannot check toHaveTextContent
+    expect(input.textContent).toEqual(startingValue);
 
     expect(handleChange).toBeCalledTimes(4); // 3 for ABC and once for cancel
     expect(handleSave).not.toBeCalled();


### PR DESCRIPTION
Contributes to #2030 

I was able to fix this by using `textContent` instead of `innerText`. i have been unable to find a reason as to why this interaction occurs in firefox, which is unfortunate because i think it's beneficial to understand these limitations. either way this seems to work better.
