### PR TITLE
chore(Datagrid): add column alignment story extension

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -23,11 +23,9 @@ import {
   useSelectRows,
   useOnRowClick,
   useSortableColumns,
-  useColumnRightAlign,
   useDisableSelectRows,
   useCustomizeColumns,
   useSelectAllWithToggle,
-  useColumnCenterAlign,
   useStickyColumn,
   useActionsColumn,
   useColumnOrder,
@@ -469,66 +467,6 @@ export const SortableColumns = () => {
       data,
     },
     useSortableColumns
-  );
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-export const RightAlignedColumns = () => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader.slice(0, 3),
-      {
-        Header: 'Age',
-        accessor: 'age',
-        rightAlignedColumn: true,
-      },
-      {
-        Header: 'Visits',
-        accessor: 'visits',
-        rightAlignedColumn: true,
-      },
-    ],
-    []
-  );
-  const [data] = useState(makeData(10));
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-    },
-    useColumnRightAlign
-  );
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-export const CenterAlignedColumns = () => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader.slice(0, 3),
-      {
-        Header: 'Age',
-        accessor: 'age',
-        centerAlignedColumn: true,
-      },
-
-      {
-        Header: 'Visit',
-        accessor: 'visits',
-        centerAlignedColumn: true,
-      },
-    ],
-    []
-  );
-
-  const [data] = useState(makeData(10));
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-    },
-    useColumnCenterAlign
   );
 
   return <Datagrid datagridState={{ ...datagridState }} />;

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -9,7 +9,6 @@ import React, { useState, useEffect } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { useDatagrid } from '.';
-import { RightAlignedColumns } from './Datagrid.stories';
 import { makeData } from './utils/makeData';
 
 import { carbon } from '../../settings';
@@ -30,6 +29,7 @@ import {
   useStickyColumn,
   useActionsColumn,
   useColumnOrder,
+  useColumnRightAlign,
 } from '.';
 
 import {
@@ -2036,6 +2036,35 @@ describe(componentName, () => {
       )[2]
     );
   });
+
+  const RightAlignedColumns = () => {
+    const columns = React.useMemo(
+      () => [
+        ...defaultHeader.slice(0, 3),
+        {
+          Header: 'Age',
+          accessor: 'age',
+          rightAlignedColumn: true,
+        },
+        {
+          Header: 'Visits',
+          accessor: 'visits',
+          rightAlignedColumn: true,
+        },
+      ],
+      []
+    );
+    const [data] = useState(makeData(10));
+    const datagridState = useDatagrid(
+      {
+        columns,
+        data,
+      },
+      useColumnRightAlign
+    );
+
+    return <Datagrid datagridState={{ ...datagridState }} />;
+  };
 
   it('Right Aligned Columns', () => {
     render(

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
@@ -1,0 +1,207 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import {
+  Datagrid,
+  useDatagrid,
+  useColumnRightAlign,
+  useColumnCenterAlign,
+} from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { DatagridPagination } from '../../utils/DatagridPagination';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/ColumnAlignment`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 120,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 120,
+  },
+  {
+    Header: 'Bonus',
+    accessor: 'bonus',
+    width: 120,
+    rightAlignedColumn: true,
+  },
+  {
+    Header: 'Status',
+    accessor: 'status_icon',
+    width: 100,
+    centerAlignedColumn: true,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+  expandedContentHeight: 96,
+};
+
+const ColumnAlignment = ({ ...args }) => {
+  const columns = React.useMemo(() => [...defaultHeader], []);
+  const [data] = useState(makeData(10));
+  const rows = React.useMemo(() => data, [data]);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data: rows,
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+      },
+      DatagridActions,
+      DatagridPagination,
+      ...args.defaultGridProps,
+    },
+    useColumnCenterAlign,
+    useColumnRightAlign
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const BasicTemplateWrapper = ({ ...args }) => {
+  return <ColumnAlignment defaultGridProps={{ ...args }} />;
+};
+
+const columnAlignmentControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+};
+const columnAlignmentStoryName = 'With column alignment';
+export const ColumnAlignmentStory = prepareStory(BasicTemplateWrapper, {
+  storyName: columnAlignmentStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+  },
+  args: {
+    ...columnAlignmentControlProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
@@ -7,12 +7,20 @@
 
 import React from 'react';
 import namor from 'namor';
+import { StatusIcon } from '../../StatusIcon';
 import { inlineEditSelectItems } from './getInlineEditColumns';
 
-const getRandomInteger = (min, max) => {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+const getRandomInteger = (min, max, decimalPlaces) => {
+  const roundedMin = Math.ceil(min);
+  const roundedMax = Math.floor(max);
+  const randomNumber = Math.random() * (max - min) + min;
+  if (!decimalPlaces) {
+    return (
+      Math.floor(Math.random() * (roundedMax - roundedMin + 1)) + roundedMin
+    );
+  }
+  const power = Math.pow(10, decimalPlaces);
+  return Math.floor(randomNumber * power) / power;
 };
 
 export const makeData = (...lens) => {
@@ -87,6 +95,30 @@ const newPerson = () => {
         : statusChance > 0.33
         ? yesterdayDate
         : twoDaysAgoDate,
+    bonus: `$\r${getRandomInteger(100, 500, 2)}`,
+    status_icon:
+      statusChance > 0.66 ? (
+        <StatusIcon
+          kind="critical"
+          size="sm"
+          theme="light"
+          iconDescription="Critical"
+        />
+      ) : statusChance > 0.33 ? (
+        <StatusIcon
+          kind="minor-warning"
+          size="sm"
+          theme="light"
+          iconDescription="Minor warning"
+        />
+      ) : (
+        <StatusIcon
+          kind="normal"
+          size="sm"
+          theme="light"
+          iconDescription="Normal"
+        />
+      ),
   };
 };
 

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/makeData.js
@@ -43,6 +43,26 @@ export const range = (len) => {
   return arr;
 };
 
+const renderStatusIcon = (statusChance) => {
+  const iconProps = {
+    size: 'sm',
+    theme: 'light',
+    kind:
+      statusChance > 0.66
+        ? 'critical'
+        : statusChance > 0.33
+        ? 'minor-warning'
+        : 'normal',
+    iconDescription:
+      statusChance > 0.66
+        ? 'Critical'
+        : statusChance > 0.33
+        ? 'Minor warning'
+        : 'Normal',
+  };
+  return <StatusIcon {...iconProps} />;
+};
+
 const newPerson = () => {
   const statusChance = Math.random();
   const initialChartTypeIndex = getRandomInteger(0, 2);
@@ -96,29 +116,7 @@ const newPerson = () => {
         ? yesterdayDate
         : twoDaysAgoDate,
     bonus: `$\r${getRandomInteger(100, 500, 2)}`,
-    status_icon:
-      statusChance > 0.66 ? (
-        <StatusIcon
-          kind="critical"
-          size="sm"
-          theme="light"
-          iconDescription="Critical"
-        />
-      ) : statusChance > 0.33 ? (
-        <StatusIcon
-          kind="minor-warning"
-          size="sm"
-          theme="light"
-          iconDescription="Minor warning"
-        />
-      ) : (
-        <StatusIcon
-          kind="normal"
-          size="sm"
-          theme="light"
-          iconDescription="Normal"
-        />
-      ),
+    status_icon: renderStatusIcon(statusChance),
   };
 };
 

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -50,6 +50,7 @@ const s = [
               'c/Datagrid/Extensions/RowActionButtons',
               'c/Datagrid/Extensions/ExpandableRow',
               'c/Datagrid/Extensions/NestedRows',
+              'c/Datagrid/Extensions/ColumnAlignment',
             ],
           },
         ],


### PR DESCRIPTION
Contributes to #2270 

Adds a new Datagrid extension directory specifically for column alignment. I also added new data to match the usage example for right and center aligned columns from the PAL site, see [here](https://pages.github.ibm.com/cdai-design/pal/components/data-table/column-alignment/usage).
![Screen Shot 2022-09-21 at 11 12 17 AM](https://user-images.githubusercontent.com/10215203/191542756-2fe47411-b389-45b8-9346-fb1da4e1b5db.png)



#### What did you change?
Added new Datagrid extension directory, only storybook presentational change
#### How did you test and verify your work?
Storybook