### PR TITLE
fix(Data Grid): review feedback fix (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -6,11 +6,13 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 // @flow
-import React from 'react';
+import React, { useContext } from 'react';
 import { DataTable, SkeletonText } from '@carbon/react';
 import { selectionColumnId } from '../common-column-ids';
 import cx from 'classnames';
 import { pkg, carbon } from '../../../settings';
+import { InlineEditContext } from './addons/InlineEdit/InlineEditContext/InlineEditContext';
+import { getCellIdAsObject } from './addons/InlineEdit/InlineEditContext/getCellIdAsObject';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -19,11 +21,16 @@ const { TableRow, TableCell } = DataTable;
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
   const { row } = datagridState;
+  const { state } = useContext(InlineEditContext);
+  const { activeCellId } = state;
+  const activeCellObject = activeCellId && getCellIdAsObject(activeCellId);
   return (
     <TableRow
       className={cx(`${blockClass}__carbon-row`, {
         [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
         [`${carbon.prefix}--data-table--selected`]: row.isSelected,
+        [`${blockClass}__carbon-row-hover-active`]:
+          activeCellObject && row.index === activeCellObject.row,
       })}
       {...row.getRowProps()}
       key={row.id}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -94,6 +94,7 @@ $row-heights: (
   cursor: pointer;
   outline: 0; // handled by active class
   .#{variables.$block-class}__label-icon {
+    height: $spacing-05;
     padding-right: $spacing-05;
   }
   &.#{variables.$block-class}__inline-edit-button--non-edit {
@@ -227,4 +228,12 @@ $row-heights: (
   padding-right: $spacing-07;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.#{variables.$block-class}
+  .#{c4p-settings.$carbon-prefix}--data-table
+  .#{variables.$block-class}__carbon-row-hover-active
+  td {
+  border-top-color: $layer-hover;
+  background-color: $layer-hover;
 }


### PR DESCRIPTION
_Includes @Ratheeshrajan's review feedback fixes for `carbon-v11` branch_

Contributes to #1924

- The row should also receive its hover effect (light gray background) when using keyboard navigation.
![image](https://user-images.githubusercontent.com/305492/190655172-67380a9f-a8be-47ee-a12a-965236e1868e.png)
- The row should still have its hover effect (light gray background) when a cell is in editing mode
![image](https://user-images.githubusercontent.com/305492/190655283-fb3e0ec5-6644-4ff8-8939-6f75847eef3c.png)
- The dropdown icons are baseline-aligned, should be center-aligned
![image](https://user-images.githubusercontent.com/305492/190655359-bde9eb8c-423a-44de-b12d-8422c749caba.png)

#### What did you change?
`DatagridRow.js`
`_useInlineEdit.scss`
#### How did you test and verify your work?
Storybook