### PR TITLE
fix: update option title truncation issue

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -216,13 +216,15 @@ export let OptionsTile = React.forwardRef(
 
       return (
         <div className={`${blockClass}__heading`}>
-          <h6 id={titleId} className={`${blockClass}__title`}>
+          <h6 id={titleId} className={`${blockClass}__title`} title={title}>
             {title}
           </h6>
           {text && (
             <span className={cx(summaryClasses)} aria-hidden={summaryHidden}>
               {Icon && <Icon />}
-              <span className={`${blockClass}__summary-text`}>{text}</span>
+              <span className={`${blockClass}__summary-text`} title={text}>
+                {text}
+              </span>
             </span>
           )}
         </div>

--- a/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
+++ b/packages/cloud-cognitive/src/components/OptionsTile/_options-tile.scss
@@ -70,13 +70,17 @@
   }
 
   .#{$block-class}__heading {
+    overflow: hidden;
     grid-column: 2;
   }
 
   .#{$block-class}__title {
     @include carbon--type-style('productive-heading-01');
 
+    overflow: hidden;
     color: $text-01;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .#{$block-class}__summary {


### PR DESCRIPTION
Contributes to #2271 

Options tile truncation bug

#### What did you change?
- updated [_options-tile.scss](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/main...punnoosewilson:ibm-cloud-cognitive:%232271?expand=1#diff-42e245e72364e425d798cee3d103d4124ff0bf9b29dd85091ed08f956881004a) for style updates.
- updated [OptionsTile.js](https://github.com/carbon-design-system/ibm-cloud-cognitive/compare/main...punnoosewilson:ibm-cloud-cognitive:%232271?expand=1#diff-1bb9a3a5b36cb4ef9a3b9a80486898a350caeb9cd2db507f03051dda722b1272) for previewing the truncated text on hover.

<img width="805" alt="image" src="https://user-images.githubusercontent.com/40118548/192222717-2fb7fe82-9ac8-45a3-8f93-12e8fb963635.png">
<img width="972" alt="image" src="https://user-images.githubusercontent.com/40118548/192222947-2821bfff-c406-4ace-81ff-397f12afefcf.png">


#### How did you test and verify your work?
- Storybook

