### PR TITLE
fix(SidePanel): motion refactor using framer motion (v11)

### DIFF
--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
@@ -19,7 +19,7 @@ global.__DEV__ = true;
 global.requestAnimationFrame = function requestAnimationFrame(callback) {
   // TODO: replace with async version
   // setTimeout(callback);
-  callback();
+  // callback();
 };
 
 const enzyme = jest.requireActual('enzyme');

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
@@ -19,8 +19,8 @@ global.__DEV__ = true;
 const enzyme = jest.requireActual('enzyme');
 const Adapter = jest.requireActual('@wojtekmaj/enzyme-adapter-react-17');
 
-global.requestAnimationFrame = function (callback) {
-  setTimeout(callback, 0);
+global.requestAnimationFrame = (callback) => {
+  return setTimeout(callback, 0);
 };
 
 enzyme.configure({ adapter: new Adapter() });

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
@@ -16,12 +16,6 @@ setAllComponents(true);
 
 global.__DEV__ = true;
 
-global.requestAnimationFrame = function requestAnimationFrame(callback) {
-  // TODO: replace with async version
-  // setTimeout(callback);
-  // callback();
-};
-
 const enzyme = jest.requireActual('enzyme');
 const Adapter = jest.requireActual('@wojtekmaj/enzyme-adapter-react-17');
 

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
@@ -19,6 +19,10 @@ global.__DEV__ = true;
 const enzyme = jest.requireActual('enzyme');
 const Adapter = jest.requireActual('@wojtekmaj/enzyme-adapter-react-17');
 
+global.requestAnimationFrame = function (callback) {
+  setTimeout(callback, 0);
+};
+
 enzyme.configure({ adapter: new Adapter() });
 
 if (global.HTMLElement) {

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -75,13 +75,3 @@ const oldConsole = {};
 global.afterEach(() => {
   jest.clearAllMocks();
 });
-
-global.beforeAll(() => {
-  jest
-    .spyOn(window, 'requestAnimationFrame')
-    .mockImplementation((callback) => callback());
-});
-
-global.afterAll(() => {
-  jest.clearAllMocks();
-});

--- a/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
+++ b/config/jest-config-ibm-cloud-cognitive/setup/setupFilesAfterEnv.js
@@ -75,3 +75,13 @@ const oldConsole = {};
 global.afterEach(() => {
   jest.clearAllMocks();
 });
+
+global.beforeAll(() => {
+  jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((callback) => callback());
+});
+
+global.afterAll(() => {
+  jest.clearAllMocks();
+});

--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -81,6 +81,7 @@
     "@carbon/telemetry": "^0.1.0",
     "@carbon/themes": "^11.4.0",
     "@carbon/type": "^11.4.0",
+    "framer-motion": "^6.5.1",
     "immutability-helper": "^3.1.1",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2136,26 +2136,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   white-space: nowrap;
 }
 
-@keyframes side-panel-exit-left {
-  0% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateX(calc(-1 * 30rem));
-  }
-}
-@keyframes side-panel-exit-right {
-  0% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateX(30rem);
-  }
-}
 .c4p--side-panel__container {
   --c4p--side-panel--subtitle-opacity: 1;
   --c4p--side-panel--title-container-height: 0;
@@ -2175,7 +2155,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   box-sizing: border-box;
   background-color: var(--cds-layer-01, #f4f4f4);
   color: var(--cds-text-primary, #161616);
-  transition: transform 240ms cubic-bezier(0.2, 0, 0.38, 0.9);
 }
 .c4p--side-panel__container.c4p--side-panel__container--xs {
   width: 16rem;
@@ -2189,36 +2168,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement.c4p--side-panel__container--xs {
-  width: 16rem;
-  max-width: 100%;
   right: 0;
   border-left: 1px solid var(--cds-border-subtle-02, #e0e0e0);
 }
-@keyframes side-panel-entrance-right {
-  0% {
-    opacity: 0;
-    transform: translateX(16rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--xs {
-  width: 16rem;
-  max-width: 100%;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle-02, #e0e0e0);
-}
-@keyframes side-panel-entrance-left {
-  0% {
-    opacity: 0;
-    transform: translateX(-16rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
 }
 .c4p--side-panel__container.c4p--side-panel__container--sm {
   width: 20rem;
@@ -2232,36 +2187,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement.c4p--side-panel__container--sm {
-  width: 20rem;
-  max-width: 100%;
   right: 0;
   border-left: 1px solid var(--cds-border-subtle-02, #e0e0e0);
 }
-@keyframes side-panel-entrance-right {
-  0% {
-    opacity: 0;
-    transform: translateX(20rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--sm {
-  width: 20rem;
-  max-width: 100%;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle-02, #e0e0e0);
-}
-@keyframes side-panel-entrance-left {
-  0% {
-    opacity: 0;
-    transform: translateX(-20rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
 }
 .c4p--side-panel__container.c4p--side-panel__container--md {
   width: 30rem;
@@ -2275,36 +2206,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement.c4p--side-panel__container--md {
-  width: 30rem;
-  max-width: 100%;
   right: 0;
   border-left: 1px solid var(--cds-border-subtle-02, #e0e0e0);
 }
-@keyframes side-panel-entrance-right {
-  0% {
-    opacity: 0;
-    transform: translateX(30rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--md {
-  width: 30rem;
-  max-width: 100%;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle-02, #e0e0e0);
-}
-@keyframes side-panel-entrance-left {
-  0% {
-    opacity: 0;
-    transform: translateX(-30rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
 }
 .c4p--side-panel__container.c4p--side-panel__container--lg {
   width: 40rem;
@@ -2318,36 +2225,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement.c4p--side-panel__container--lg {
-  width: 40rem;
-  max-width: 100%;
   right: 0;
   border-left: 1px solid var(--cds-border-subtle-02, #e0e0e0);
 }
-@keyframes side-panel-entrance-right {
-  0% {
-    opacity: 0;
-    transform: translateX(40rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--lg {
-  width: 40rem;
-  max-width: 100%;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle-02, #e0e0e0);
-}
-@keyframes side-panel-entrance-left {
-  0% {
-    opacity: 0;
-    transform: translateX(-40rem);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
 }
 .c4p--side-panel__container.c4p--side-panel__container--2xl {
   width: 75%;
@@ -2361,36 +2244,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   max-width: 100%;
 }
 .c4p--side-panel__container.c4p--side-panel__container-right-placement.c4p--side-panel__container--2xl {
-  width: 75%;
-  max-width: 100%;
   right: 0;
   border-left: 1px solid var(--cds-border-subtle-02, #e0e0e0);
 }
-@keyframes side-panel-entrance-right {
-  0% {
-    opacity: 0;
-    transform: translateX(75%);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
 .c4p--side-panel__container.c4p--side-panel__container-left-placement.c4p--side-panel__container--2xl {
-  width: 75%;
-  max-width: 100%;
   left: 0;
   border-right: 1px solid var(--cds-border-subtle-02, #e0e0e0);
-}
-@keyframes side-panel-entrance-left {
-  0% {
-    opacity: 0;
-    transform: translateX(-75%);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(0);
-  }
 }
 .c4p--side-panel__container.c4p--side-panel__container-with-action-toolbar.c4p--side-panel__with-condensed-header .c4p--side-panel__title-container {
   /* stylelint-disable-next-line max-nesting-depth */
@@ -2722,7 +2581,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   width: 100%;
   height: 100%;
   background-color: var(--cds-overlay, rgba(22, 22, 22, 0.5));
-  transition: background-color 240ms cubic-bezier(0.2, 0, 0.38, 0.9);
 }
 
 .c4p--create-side-panel.c4p--side-panel__container .c4p--create-side-panel__content-text {

--- a/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/CreateSidePanel/CreateSidePanel.test.js
@@ -13,6 +13,7 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg, carbon } from '../../settings';
 
 import { CreateSidePanel } from '.';
+import { act } from 'react-dom/test-utils';
 
 const componentName = CreateSidePanel.displayName;
 
@@ -122,8 +123,10 @@ describe(componentName, () => {
 
   it('has no accessibility violations', async () => {
     const { container } = renderComponent();
-    await expect(container).toBeAccessible(componentName);
-    await expect(container).toHaveNoAxeViolations();
+    await act(async () => {
+      await expect(container).toBeAccessible(componentName);
+      await expect(container).toHaveNoAxeViolations();
+    });
   });
 
   it('applies className to the containing node', () => {

--- a/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.test.js
@@ -12,6 +12,7 @@ import { pkg, carbon } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 
 import { EditSidePanel } from '.';
+import { act } from 'react-dom/test-utils';
 
 const blockClass = `${pkg.prefix}--edit-side-panel`;
 const componentName = EditSidePanel.displayName;
@@ -74,8 +75,10 @@ describe(componentName, () => {
 
   it('has no accessibility violations', async () => {
     const { container } = renderEditPanel();
-    await expect(container).toBeAccessible(componentName);
-    await expect(container).toHaveNoAxeViolations();
+    await act(async () => {
+      await expect(container).toBeAccessible(componentName);
+      await expect(container).toHaveNoAxeViolations();
+    });
   });
 
   it(`renders children`, () => {

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -370,7 +370,7 @@ const renderDataTable = () => {
 const renderUIShellHeader = () => (
   <HeaderContainer
     render={() => (
-      <Header aria-label="IBM Cloud Pak">
+      <Header aria-label="IBM Cloud Pak" className={`${prefix}header`}>
         <HeaderName href="/" prefix="IBM">
           Cloud Pak
         </HeaderName>

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -26,49 +26,6 @@
 $block-class: #{c4p-settings.$pkg-prefix}--side-panel;
 $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 
-@mixin sidePanelEntranceRight($size: map-get($side-panel-sizes, md)) {
-  @keyframes side-panel-entrance-right {
-    0% {
-      opacity: 0;
-      // stylelint-disable-next-line carbon/layout-token-use
-      transform: translateX(#{$size}); // the size width of the side panel
-    }
-
-    100% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
-}
-
-@mixin sidePanelEntranceLeft($size: map-get($side-panel-sizes, md)) {
-  @keyframes side-panel-entrance-left {
-    0% {
-      opacity: 0;
-      // stylelint-disable-next-line carbon/layout-token-use
-      transform: translateX(-#{$size}); // the size width of the side panel
-    }
-
-    100% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
-}
-
-@mixin sidePanelEntrance(
-  $placement: 'right',
-  $size: map-get($side-panel-sizes, md)
-) {
-  width: $size;
-  max-width: 100%;
-  @if $placement == right {
-    @include sidePanelEntranceRight($size);
-  } @else {
-    @include sidePanelEntranceLeft($size);
-  }
-}
-
 @mixin setPanelSize($size: map-get($side-panel-sizes, md)) {
   width: $size;
   max-width: 100%;
@@ -93,32 +50,6 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   -webkit-line-clamp: 2;
 }
 
-@keyframes side-panel-exit-left {
-  0% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-
-  100% {
-    opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
-    transform: translateX(calc(-1 * #{map-get($side-panel-sizes, md)}));
-  }
-}
-
-@keyframes side-panel-exit-right {
-  0% {
-    opacity: 1;
-    transform: translateX(0);
-  }
-
-  100% {
-    opacity: 0;
-    // stylelint-disable-next-line carbon/layout-token-use
-    transform: translateX(map-get($side-panel-sizes, md));
-  }
-}
-
 .#{$block-class}__container {
   --#{$block-class}--subtitle-opacity: 1;
   --#{$block-class}--title-container-height: 0;
@@ -140,7 +71,6 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   box-sizing: border-box;
   background-color: $layer-01;
   color: $text-primary;
-  transition: transform $duration-moderate-02 motion(standard);
   @each $size, $size_value in $side-panel-sizes {
     &.#{$block-class}__container--#{$size} {
       @include setPanelSize($size_value);
@@ -152,14 +82,10 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
       }
     }
     &.#{$block-class}__container-right-placement.#{$block-class}__container--#{$size} {
-      @include sidePanelEntrance(right, $size_value);
-
       right: 0;
       border-left: 1px solid $border-subtle-02;
     }
     &.#{$block-class}__container-left-placement.#{$block-class}__container--#{$size} {
-      @include sidePanelEntrance(left, $size_value);
-
       left: 0;
       border-right: 1px solid $border-subtle-02;
     }
@@ -533,5 +459,4 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
   width: 100%;
   height: 100%;
   background-color: $overlay;
-  transition: background-color $duration-moderate-02 motion(standard);
 }

--- a/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_storybook-styles.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2022
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -7,6 +7,7 @@
 
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/themes/scss/themes';
 @use '@carbon/styles/scss/type';
 
 $story-prefix: side-panel-stories__;
@@ -37,4 +38,8 @@ $story-prefix: side-panel-stories__;
   .#{$story-prefix}content-subtitle {
     margin: $spacing-05 0 $spacing-04;
   }
+}
+
+.#{$story-prefix}header {
+  @include theme(themes.$g100);
 }

--- a/packages/cloud-cognitive/src/components/SidePanel/motion/variants.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/motion/variants.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { DURATIONS, EASINGS } from '../../../global/js/utils/motionConstants';
+
+export const overlayVariants = {
+  visible: {
+    opacity: 1,
+    transition: {
+      duration: DURATIONS.moderate02,
+      ease: EASINGS.productive.standard,
+    },
+  },
+  hidden: {
+    opacity: 0,
+  },
+  exit: {
+    opacity: 0,
+  },
+};
+
+export const panelVariants = {
+  visible: {
+    x: 0,
+    transition: {
+      duration: DURATIONS.moderate02,
+      ease: EASINGS.productive.standard,
+    },
+  },
+  hidden: (placement) => ({
+    x: placement === 'right' ? '100%' : -320,
+  }),
+  exit: (placement) => ({
+    x: placement === 'right' ? '100%' : -320,
+    transition: {
+      duration: DURATIONS.moderate01,
+      ease: EASINGS.productive.exit,
+    },
+  }),
+};

--- a/packages/cloud-cognitive/src/global/js/utils/getBezierValues.js
+++ b/packages/cloud-cognitive/src/global/js/utils/getBezierValues.js
@@ -1,0 +1,22 @@
+import { motion } from '@carbon/motion';
+
+/**
+ * This function turns a cubic-bezier() string to an
+ * array of values that we can use with framer-motion
+ * @param {string} type - The carbon motion type, either 'standard', 'entrance', or 'exit'
+ * @param {string} mode - The carbon motion mode, either 'productive', or 'expressive'
+ */
+
+export const getBezierValues = (type, mode) => {
+  const cubicBezier = motion(type, mode);
+  const extractStringFromParens = /\(([^)]+)\)/;
+  const desiredBezierStrings = extractStringFromParens.exec(cubicBezier)[1];
+  const formattedDesiredBezierStrings = desiredBezierStrings
+    .trim()
+    .split(',')
+    .map(Number);
+  if (Array.isArray(formattedDesiredBezierStrings)) {
+    return formattedDesiredBezierStrings;
+  }
+  return [];
+};

--- a/packages/cloud-cognitive/src/global/js/utils/motionConstants.js
+++ b/packages/cloud-cognitive/src/global/js/utils/motionConstants.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getBezierValues } from './getBezierValues';
+import {
+  fast01,
+  fast02,
+  moderate01,
+  moderate02,
+  slow01,
+  slow02,
+} from '@carbon/motion';
+
+const cleanMotionValue = (val) => parseInt(val) / 1000;
+
+export const DURATIONS = {
+  // Micro-interactions such as button and toggle
+  fast01: cleanMotionValue(fast01), // '70ms'
+  // Micro-interactions such as fade
+  fast02: cleanMotionValue(fast02), // '110ms'
+  // Micro-interactions, small expansion, short distance movements
+  moderate01: cleanMotionValue(moderate01), // '150ms'
+  // Expansion, system communication, toast
+  moderate02: cleanMotionValue(moderate02), // '240ms'
+  // Large expansion, important system notifications
+  slow01: cleanMotionValue(slow01), // '400ms'
+  //  Background dimming
+  slow02: cleanMotionValue(slow02), // '700ms'
+};
+
+export const EASINGS = {
+  productive: {
+    entrance: getBezierValues('entrance', 'productive'),
+    standard: getBezierValues('standard', 'productive'),
+    exit: getBezierValues('exit', 'productive'),
+  },
+  expressive: {
+    entrance: getBezierValues('entrance', 'expressive'),
+    standard: getBezierValues('standard', 'expressive'),
+    exit: getBezierValues('exit', 'expressive'),
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,6 +1868,7 @@ __metadata:
     change-case: ^4.1.2
     copyfiles: ^2.4.1
     cross-env: ^7.0.3
+    framer-motion: ^6.5.1
     fs-extra: ^10.1.0
     glob: ^8.0.3
     immutability-helper: ^3.1.1
@@ -2874,7 +2875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:0.8.8":
+"@emotion/is-prop-valid@npm:0.8.8, @emotion/is-prop-valid@npm:^0.8.2":
   version: 0.8.8
   resolution: "@emotion/is-prop-valid@npm:0.8.8"
   dependencies:
@@ -4350,6 +4351,71 @@ __metadata:
   version: 1.6.22
   resolution: "@mdx-js/util@npm:1.6.22"
   checksum: 4b393907e39a1a75214f0314bf72a0adfa5e5adffd050dd5efe9c055b8549481a3cfc9f308c16dfb33311daf3ff63added7d5fd1fe52db614c004f886e0e559a
+  languageName: node
+  linkType: hard
+
+"@motionone/animation@npm:^10.12.0":
+  version: 10.14.0
+  resolution: "@motionone/animation@npm:10.14.0"
+  dependencies:
+    "@motionone/easing": ^10.14.0
+    "@motionone/types": ^10.14.0
+    "@motionone/utils": ^10.14.0
+    tslib: ^2.3.1
+  checksum: 664f7f036418e3604bdcb267636ed21057a2036a21cdff90f9fa49b62e788cdfc3149f6f9a27e9530ebfbee3a39d6e7dcd73adaa95d16af25bfcf1e01bd95cbb
+  languageName: node
+  linkType: hard
+
+"@motionone/dom@npm:10.12.0":
+  version: 10.12.0
+  resolution: "@motionone/dom@npm:10.12.0"
+  dependencies:
+    "@motionone/animation": ^10.12.0
+    "@motionone/generators": ^10.12.0
+    "@motionone/types": ^10.12.0
+    "@motionone/utils": ^10.12.0
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: 123356f28e44362c4f081aae3df22e576f46bfcb07e01257b2ac64a115668448f29b8de67e4b6e692c5407cffb78ffe7cf9fa1bc064007482bab5dd23a69d380
+  languageName: node
+  linkType: hard
+
+"@motionone/easing@npm:^10.14.0":
+  version: 10.14.0
+  resolution: "@motionone/easing@npm:10.14.0"
+  dependencies:
+    "@motionone/utils": ^10.14.0
+    tslib: ^2.3.1
+  checksum: c845b7a445d6dbfb6d9d830fe8c88050345988fb6e423e63c1962506995e99efe899d6e7b14a8960b7df27aa279dfdfb02202a20de01bc65dcbd416ec2315d37
+  languageName: node
+  linkType: hard
+
+"@motionone/generators@npm:^10.12.0":
+  version: 10.14.0
+  resolution: "@motionone/generators@npm:10.14.0"
+  dependencies:
+    "@motionone/types": ^10.14.0
+    "@motionone/utils": ^10.14.0
+    tslib: ^2.3.1
+  checksum: 14cb500441f7b19dd84672c00ebeda0380fa151922118ac7e1bd13bf7b7b6bd87f876454863f3acf0849bb9c7b83a496eb0fba8f7b4d720f99bf5fa2121f056f
+  languageName: node
+  linkType: hard
+
+"@motionone/types@npm:^10.12.0, @motionone/types@npm:^10.14.0":
+  version: 10.14.0
+  resolution: "@motionone/types@npm:10.14.0"
+  checksum: 2fbd65f925c786b190d99867010960ffb458beda5f9b5499eeb0822094871ecbeded1aae917c194b605d80f0c56a55a13ff1e0fa4f6bad3ad8ff32fe5a3201dc
+  languageName: node
+  linkType: hard
+
+"@motionone/utils@npm:^10.12.0, @motionone/utils@npm:^10.14.0":
+  version: 10.14.0
+  resolution: "@motionone/utils@npm:10.14.0"
+  dependencies:
+    "@motionone/types": ^10.14.0
+    hey-listen: ^1.0.8
+    tslib: ^2.3.1
+  checksum: eb4c0a50e458ba7e7944dba7d0b063665744fed60aef9b4670bbc26fe02bed43f26595e9515f8ca6e4899ff5f31e7d81708feb42c16bf6e91c871d310085bc48
   languageName: node
   linkType: hard
 
@@ -13909,6 +13975,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "framer-motion@npm:6.5.1"
+  dependencies:
+    "@emotion/is-prop-valid": ^0.8.2
+    "@motionone/dom": 10.12.0
+    framesync: 6.0.1
+    hey-listen: ^1.0.8
+    popmotion: 11.0.3
+    style-value-types: 5.0.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ">=16.8 || ^17.0.0 || ^18.0.0"
+    react-dom: ">=16.8 || ^17.0.0 || ^18.0.0"
+  dependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+  checksum: 737959063137b4ccafe01e0ac0c9e5a9531bf3f729f62c34ca7a5d7955e6664f70affd22b044f7db51df41acb21d120a4f71a860e17a80c4db766ad66f2153a1
+  languageName: node
+  linkType: hard
+
+"framesync@npm:6.0.1":
+  version: 6.0.1
+  resolution: "framesync@npm:6.0.1"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: a23ebe8f7e20a32c0b99c2f8175b6f07af3ec6316aad52a2316316a6d011d717af8d2175dcc2827031c59fabb30232ed3e19a720a373caba7f070e1eae436325
+  languageName: node
+  linkType: hard
+
 "fresh@npm:0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
@@ -14994,6 +15090,13 @@ __metadata:
     capital-case: ^1.0.4
     tslib: ^2.0.3
   checksum: 571c83eeb25e8130d172218712f807c0b96d62b020981400bccc1503a7cf14b09b8b10498a962d2739eccf231d950e3848ba7d420b58a6acd2f9283439546cd9
+  languageName: node
+  linkType: hard
+
+"hey-listen@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "hey-listen@npm:1.0.8"
+  checksum: 6bad60b367688f5348e25e7ca3276a74b59ac5a09b0455e6ff8ab7d4a9e38cd2116c708a7dcd8a954d27253ce1d8717ec891d175723ea739885b828cf44e4072
   languageName: node
   linkType: hard
 
@@ -21312,6 +21415,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"popmotion@npm:11.0.3":
+  version: 11.0.3
+  resolution: "popmotion@npm:11.0.3"
+  dependencies:
+    framesync: 6.0.1
+    hey-listen: ^1.0.8
+    style-value-types: 5.0.0
+    tslib: ^2.1.0
+  checksum: 9fe7d03b4ec0e85bfb9dadc23b745147bfe42e16f466ba06e6327197d0e38b72015afc2f918a8051dedc3680310417f346ffdc463be6518e2e92e98f48e30268
+  languageName: node
+  linkType: hard
+
 "popper.js@npm:^1.14.4, popper.js@npm:^1.14.7":
   version: 1.16.1
   resolution: "popper.js@npm:1.16.1"
@@ -24945,6 +25060,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-value-types@npm:5.0.0":
+  version: 5.0.0
+  resolution: "style-value-types@npm:5.0.0"
+  dependencies:
+    hey-listen: ^1.0.8
+    tslib: ^2.1.0
+  checksum: 16d198302cd102edf9dba94e7752a2364c93b1eaa5cc7c32b42b28eef4af4ccb5149a3f16bc2a256adc02616a2404f4612bd15f3081c1e8ca06132cae78be6c0
+  languageName: node
+  linkType: hard
+
 "stylelint-a11y@npm:^1.2.3":
   version: 1.2.3
   resolution: "stylelint-a11y@npm:1.2.3"
@@ -25938,7 +26063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113


### PR DESCRIPTION
Contributes to #2304 

Same changes as https://github.com/carbon-design-system/ibm-cloud-cognitive/pull/2312 but for v11 branch.


This is a refactor of the entrance/exit animation for the SidePanel component using framer motion, in replace of the current approach. Because of the animation issue brought up in #2304 it seemed like a good time to take a look at refactoring the motion here. Especially because of the cross browser issues that have been brought up.

I started off just by replacing the entrance/exit animation/micro-interaction with framer motion. I think we could potentially at some point in the future replace the title animation with framer motion as well, but wanted to for now just focus on the entrance/exit.

#### What did you change?
```
config/jest-config-ibm-cloud-cognitive/setup/setupFiles.js
packages/cloud-cognitive/package.json
packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
packages/cloud-cognitive/src/global/js/utils/getBezierValues.js
packages/cloud-cognitive/src/global/js/utils/motionConstants.js
yarn.lock
```
#### How did you test and verify your work?
Storybook