### PR TITLE
fix(CreateTearsheetNarrow): Update formTitle prop as optional

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
@@ -143,9 +143,9 @@ CreateTearsheetNarrow.propTypes = {
   formDescription: PropTypes.node,
 
   /**
-   * Specifies a required field that provides a title for a form
+   * Specifies an optional field that provides a title for a form
    */
-  formTitle: PropTypes.node.isRequired,
+  formTitle: PropTypes.node,
 
   /**
    * A label for the tearsheet, displayed in the header area of the tearsheet
@@ -190,7 +190,7 @@ CreateTearsheetNarrow.propTypes = {
   /**
    * The main title of the tearsheet, displayed in the header area.
    */
-  title: PropTypes.node,
+  title: PropTypes.node.isRequired,
 
   /**
    * The position of the top of tearsheet in the viewport. The 'normal'

--- a/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
+++ b/packages/cloud-cognitive/src/components/CreateTearsheetNarrow/CreateTearsheetNarrow.js
@@ -190,7 +190,7 @@ CreateTearsheetNarrow.propTypes = {
   /**
    * The main title of the tearsheet, displayed in the header area.
    */
-  title: PropTypes.node.isRequired,
+  title: PropTypes.node,
 
   /**
    * The position of the top of tearsheet in the viewport. The 'normal'


### PR DESCRIPTION
Contributes to #2278 

Need to make the `formTitle` prop as optional.

#### What did you change?
- Updated the `formTitle` prop as optional. 
<img width="1477" alt="image" src="https://user-images.githubusercontent.com/40118548/192713265-10644c22-d78c-4106-b3b0-f3ee721df3c3.png">

#### How did you test and verify your work?
Storybook
