### PR TITLE
feat(Datagrid): add validation to inline editing

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -77,6 +77,32 @@ export const InlineEditCell = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Reverts cellValue back to initialValue when exiting edit mode via clicking outside
+  // of the cell (either on a regular cell or clicking into another inline edit cell) and the
+  // edit input is in an invalid state
+  useEffect(() => {
+    if (
+      (previousState?.editId === cellId && !editId) ||
+      (previousState?.editId === cellId && cellId !== editId)
+    ) {
+      const { validator } = config || {};
+      const isInvalid = validator?.(cellValue);
+      if (isInvalid) {
+        setCellValue(initialValue);
+        saveCellData(initialValue);
+        return;
+      }
+    }
+  }, [
+    previousState?.editId,
+    editId,
+    cellId,
+    cellValue,
+    config,
+    initialValue,
+    saveCellData,
+  ]);
+
   // If you are in edit mode and click outside of the cell,
   // this changes the cell back to the InlineEditButton
   useEffect(() => {
@@ -203,6 +229,13 @@ export const InlineEditCell = ({
         if (inEditMode) {
           // Dropdown saves are handled in the Dropdown's/DatePicker's onChange prop
           if (type === 'selection' || type === 'date') {
+            return;
+          }
+          const { validator } = config || {};
+          const isInvalid = validator?.(cellValue);
+          // If an invalid state is detected, Tab/Enter should not do anything
+          // until the input has a valid state once again
+          if (isInvalid) {
             return;
           }
           const newCellId = getNewCellId(key);
@@ -374,6 +407,53 @@ export const InlineEditCell = ({
     return null;
   };
 
+  const renderNumberInput = () => {
+    const { validator } = config || {};
+    return (
+      <NumberInput
+        placeholder={placeholder}
+        label={cellLabel}
+        {...inputProps}
+        id={cellId}
+        hideLabel
+        defaultValue={cellValue}
+        invalid={validator?.(cellValue)}
+        invalidText={inputProps?.invalidText || 'Provide missing invalidText'}
+        onChange={(event) => {
+          setCellValue(event.imaginaryTarget.value);
+          if (inputProps.onChange) {
+            inputProps.onChange(event.imaginaryTarget.value);
+          }
+        }}
+        ref={numberInputRef}
+      />
+    );
+  };
+
+  const renderTextInput = () => {
+    const { validator } = config || {};
+    const isInvalid = validator?.(cellValue);
+    return (
+      <TextInput
+        labelText={cellLabel}
+        placeholder={placeholder}
+        {...inputProps}
+        id={cellId}
+        hideLabel
+        defaultValue={cellValue}
+        invalid={isInvalid}
+        invalidText={inputProps?.invalidText || 'Provide missing invalidText'}
+        onChange={(event) => {
+          setCellValue(event.target.value);
+          if (inputProps.onChange) {
+            inputProps.onChange(event.target.value);
+          }
+        }}
+        ref={textInputRef}
+      />
+    );
+  };
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
@@ -388,6 +468,8 @@ export const InlineEditCell = ({
       className={cx(`${blockClass}__inline-edit--outer-cell-button`, {
         [`${blockClass}__inline-edit--outer-cell-button--${rowSize}`]: rowSize,
         [`${blockClass}__inline-edit--outer-cell-button--lg`]: !rowSize,
+        [`${blockClass}__inline-edit--outer-cell-button--invalid`]:
+          config?.validator?.(cellValue),
       })}
     >
       {!inEditMode && (
@@ -413,40 +495,8 @@ export const InlineEditCell = ({
       )}
       {!nonEditCell && inEditMode && cellId === activeCellId && (
         <>
-          {type === 'text' && (
-            <TextInput
-              labelText={cellLabel}
-              placeholder={placeholder}
-              {...inputProps}
-              id={cellId}
-              hideLabel
-              defaultValue={cellValue}
-              onChange={(event) => {
-                setCellValue(event.target.value);
-                if (inputProps.onChange) {
-                  inputProps.onChange(event.target.value);
-                }
-              }}
-              ref={textInputRef}
-            />
-          )}
-          {type === 'number' && (
-            <NumberInput
-              placeholder={placeholder}
-              label={cellLabel}
-              {...inputProps}
-              id={cellId}
-              hideLabel
-              defaultValue={cellValue}
-              onChange={(event) => {
-                setCellValue(event.imaginaryTarget.value);
-                if (inputProps.onChange) {
-                  inputProps.onChange(event.imaginaryTarget.value);
-                }
-              }}
-              ref={numberInputRef}
-            />
-          )}
+          {type === 'text' && renderTextInput()}
+          {type === 'number' && renderNumberInput()}
           {type === 'selection' && renderSelectCell()}
           {type === 'date' && renderDateCell()}
         </>

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
@@ -32,12 +32,12 @@ export const handleGridKeyPress = ({
     // Attempting to exit date picker
     if (focusedCell.getAttribute('data-inline-type') === 'date') {
       dispatch({ type: 'EXIT_EDIT_MODE', payload: activeCellId });
+      const inlineEditArea = document.querySelector(
+        `#${instance.tableId} .${blockClass}__table-with-inline-edit`
+      );
+      inlineEditArea.focus();
     }
     event.preventDefault();
-    const inlineEditArea = document.querySelector(
-      `#${instance.tableId} .${blockClass}__table-with-inline-edit`
-    );
-    inlineEditArea.focus();
     return;
   }
 

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -216,8 +216,14 @@ $row-heights: (
   background-color: $hover-ui;
 }
 
-.#{$block-class} [data-invalid] ~ .#{$carbon-prefix}--form-requirement,
-.#{$block-class} [data-invalid] .#{$carbon-prefix}--form-requirement {
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  [data-invalid]
+  ~ .#{$carbon-prefix}--form-requirement,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  [data-invalid]
+  .#{$carbon-prefix}--form-requirement {
   position: absolute;
   z-index: 1;
   top: calc(100% - #{$spacing-01});
@@ -230,24 +236,35 @@ $row-heights: (
 }
 
 .#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
   .#{$carbon-prefix}--list-box[data-invalid]:focus-within
   ~ .#{$carbon-prefix}--form-requirement {
   outline: $spacing-01 solid $focus;
 }
 
-.#{$block-class} .#{$carbon-prefix}--list-box__invalid-icon,
-.#{$block-class} .#{$carbon-prefix}--text-input__invalid-icon,
-.#{$block-class} .#{$carbon-prefix}--number__invalid {
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--list-box__invalid-icon,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--text-input__invalid-icon,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number__invalid {
   z-index: 2;
   top: calc(100% + #{$spacing-04} + #{$spacing-01});
   right: $spacing-03;
 }
 
-.#{$block-class} .#{$carbon-prefix}--number__invalid {
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number__invalid {
   top: calc(100% + #{$spacing-02} + #{$spacing-01});
 }
 
-.#{$block-class} .#{$carbon-prefix}--form-requirement::before {
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--form-requirement::before {
   position: absolute;
   top: 0;
   left: $spacing-01;
@@ -257,7 +274,9 @@ $row-heights: (
   content: '';
 }
 
-.#{$block-class} .#{$carbon-prefix}--form-requirement::after {
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--form-requirement::after {
   position: absolute;
   top: $spacing-01;
   left: $spacing-03;
@@ -268,10 +287,12 @@ $row-heights: (
 }
 
 .#{$block-class} tbody tr:hover {
-  .#{$carbon-prefix}--form-requirement::before {
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+    .#{$carbon-prefix}--form-requirement::before {
     background-color: $ui-03;
   }
-  .#{$carbon-prefix}--form-requirement::after {
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+    .#{$carbon-prefix}--form-requirement::after {
     background-color: transparent;
   }
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -38,7 +38,7 @@ $row-heights: (
   .#{$block-class}
     .#{$block-class}__inline-edit--outer-cell-button--#{$size}
     .#{$carbon-prefix}--number__control-btn::after {
-    height: calc($size-value - 0.25rem);
+    height: calc(#{$size-value} - 0.25rem);
   }
   .#{$block-class}
     .#{$block-class}__inline-edit--select.#{$block-class}__inline-edit--select-#{$size}.#{$carbon-prefix}--list-box {
@@ -214,4 +214,93 @@ $row-heights: (
 .#{$carbon-prefix}--data-table .#{$block-class}__carbon-row-hover-active td {
   border-top-color: $hover-ui;
   background-color: $hover-ui;
+}
+
+.#{$block-class} [data-invalid] ~ .#{$carbon-prefix}--form-requirement,
+.#{$block-class} [data-invalid] .#{$carbon-prefix}--form-requirement {
+  position: absolute;
+  z-index: 1;
+  top: calc(100% - #{$spacing-01});
+  width: 100%;
+  padding: $spacing-03 $spacing-06 $spacing-03 $spacing-03;
+  margin: 0;
+  background-color: $ui-01;
+  outline: $spacing-01 solid $danger-02;
+  outline-offset: calc(-1 * #{$spacing-01});
+}
+
+.#{$block-class}
+  .#{$carbon-prefix}--list-box[data-invalid]:focus-within
+  ~ .#{$carbon-prefix}--form-requirement {
+  outline: $spacing-01 solid $focus;
+}
+
+.#{$block-class} .#{$carbon-prefix}--list-box__invalid-icon,
+.#{$block-class} .#{$carbon-prefix}--text-input__invalid-icon,
+.#{$block-class} .#{$carbon-prefix}--number__invalid {
+  z-index: 2;
+  top: calc(100% + #{$spacing-04} + #{$spacing-01});
+  right: $spacing-03;
+}
+
+.#{$block-class} .#{$carbon-prefix}--number__invalid {
+  top: calc(100% + #{$spacing-02} + #{$spacing-01});
+}
+
+.#{$block-class} .#{$carbon-prefix}--form-requirement::before {
+  position: absolute;
+  top: 0;
+  left: $spacing-01;
+  width: calc(100% - (#{$spacing-01} * 2));
+  height: $spacing-01;
+  background-color: $ui-01;
+  content: '';
+}
+
+.#{$block-class} .#{$carbon-prefix}--form-requirement::after {
+  position: absolute;
+  top: $spacing-01;
+  left: $spacing-03;
+  width: calc(100% - (#{$spacing-03} * 2));
+  height: 1px;
+  background-color: $ui-03;
+  content: '';
+}
+
+.#{$block-class} tbody tr:hover {
+  .#{$carbon-prefix}--form-requirement::before {
+    background-color: $ui-03;
+  }
+  .#{$carbon-prefix}--form-requirement::after {
+    background-color: transparent;
+  }
+}
+
+// Keep input focus states using $support-01 when inline edit cell is invalid
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--text-input:focus,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number
+  input[type='number']:focus,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number
+  input[type='number']:focus
+  ~ .#{$carbon-prefix}--number__controls
+  .#{$carbon-prefix}--number__control-btn:hover,
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number__control-btn:focus {
+  outline-color: $support-01;
+}
+
+.#{$block-class}
+  .#{$block-class}__inline-edit--outer-cell-button--invalid
+  .#{$carbon-prefix}--number
+  input[type='number'][data-invalid]:focus
+  ~ .#{$carbon-prefix}--number__controls
+  .#{$carbon-prefix}--number__control-btn.up-icon::after {
+  background-color: $support-01;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -41,7 +41,12 @@ export const getInlineEditColumns = () => {
       accessor: 'firstName',
       inlineEdit: {
         type: 'text',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n.length >= 40,
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid text, character count must be less than 40',
+        },
       },
     },
     {
@@ -49,7 +54,12 @@ export const getInlineEditColumns = () => {
       accessor: 'lastName',
       inlineEdit: {
         type: 'text',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n.length >= 40,
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid text, character count must be less than 40',
+        },
       },
     },
     {
@@ -57,8 +67,13 @@ export const getInlineEditColumns = () => {
       accessor: 'age',
       width: 120,
       inlineEdit: {
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n && n < 18,
         type: 'number',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid number, must be 18 or greater',
+        },
       },
     },
     {
@@ -96,7 +111,9 @@ export const getInlineEditColumns = () => {
         inputProps: {
           // These props are passed to the Carbon component used for inline editing
           items: inlineEditSelectItems,
-          onChange: (item) => console.log(item),
+          onChange: (item) => {
+            console.log(item);
+          },
         },
       },
     },


### PR DESCRIPTION
Contributes to #1924 

@Ratheeshrajan I took over from where you had left off since you're looking at https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1923 right now.

This change adds validation to the text and number types for Datagrid inline edit (`useInlineEdit`). In order for the component to know whether a field is invalid, there is a `validator` function that is included in the column inline editing configuration. Also included according to [PAL guidance](https://pages.github.ibm.com/cdai-design/pal/components/data-table/inline-editing/usage#validation), when in edit mode and input is invalid, `enter` and `tab` do not allow the cell to make new changes until the input is valid once again.

See example below:
```js
{
      Header: 'Age',
      accessor: 'age',
      width: 120,
      inlineEdit: {
        // required for including validation, this is used to set the invalid prop internally
        validator: (n) => n < 18,
        type: 'number',
        // These props are passed to the Carbon component used for inline editing
        inputProps: {
          invalidText: 'Invalid number, must be 18 or greater',
        },
      },
    },
```

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
```
#### How did you test and verify your work?
Storybook