### PR TITLE
feat(Datagrid): add validation to inline editing (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
@@ -32,12 +32,12 @@ export const handleGridKeyPress = ({
     // Attempting to exit date picker
     if (focusedCell.getAttribute('data-inline-type') === 'date') {
       dispatch({ type: 'EXIT_EDIT_MODE', payload: activeCellId });
+      const inlineEditArea = document.querySelector(
+        `#${instance.tableId} .${blockClass}__table-with-inline-edit`
+      );
+      inlineEditArea.focus();
     }
     event.preventDefault();
-    const inlineEditArea = document.querySelector(
-      `#${instance.tableId} .${blockClass}__table-with-inline-edit`
-    );
-    inlineEditArea.focus();
     return;
   }
 

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -44,7 +44,7 @@ $row-heights: (
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
     .#{c4p-settings.$carbon-prefix}--number__control-btn::after {
-    height: calc($size-value - 0.25rem);
+    height: calc(#{$size-value} - 0.25rem);
   }
   .#{variables.$block-class}
     .#{variables.$block-class}__inline-edit--outer-cell-button--#{$size}
@@ -236,4 +236,114 @@ $row-heights: (
   td {
   border-top-color: $layer-hover;
   background-color: $layer-hover;
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  [data-invalid]
+  ~ .#{c4p-settings.$carbon-prefix}--form-requirement,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  [data-invalid]
+  .#{c4p-settings.$carbon-prefix}--form-requirement {
+  position: absolute;
+  z-index: 1;
+  top: calc(100% - #{$spacing-01});
+  width: 100%;
+  padding: $spacing-03 $spacing-06 $spacing-03 $spacing-03;
+  margin: 0;
+  background-color: $layer-01;
+  outline: $spacing-01 solid $support-error;
+  outline-offset: calc(-1 * #{$spacing-01});
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--list-box[data-invalid]:focus-within
+  ~ .#{c4p-settings.$carbon-prefix}--form-requirement {
+  outline: $spacing-01 solid $focus;
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--list-box__invalid-icon,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--text-input__invalid-icon,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number__invalid {
+  z-index: 2;
+  top: calc(100% + #{$spacing-04} + #{$spacing-01});
+  right: $spacing-03;
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number__invalid {
+  top: calc(100% + #{$spacing-02} + #{$spacing-01});
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--form-requirement::before {
+  position: absolute;
+  top: 0;
+  left: $spacing-01;
+  width: calc(100% - (#{$spacing-01} * 2));
+  height: $spacing-01;
+  background-color: $layer-01;
+  content: '';
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--form-requirement::after {
+  position: absolute;
+  top: $spacing-01;
+  left: $spacing-03;
+  width: calc(100% - (#{$spacing-03} * 2));
+  height: 1px;
+  background-color: $layer-accent-01;
+  content: '';
+}
+
+.#{variables.$block-class} tbody tr:hover {
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+    .#{c4p-settings.$carbon-prefix}--form-requirement::before {
+    background-color: $layer-accent-01;
+  }
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+    .#{c4p-settings.$carbon-prefix}--form-requirement::after {
+    background-color: transparent;
+  }
+}
+
+// Keep input focus states using $support-01 when inline edit cell is invalid
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--text-input:focus,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number
+  input[type='number']:focus,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number
+  input[type='number']:focus
+  ~ .#{c4p-settings.$carbon-prefix}--number__controls
+  .#{c4p-settings.$carbon-prefix}--number__control-btn:hover,
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number__control-btn:focus {
+  outline-color: $support-error;
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__inline-edit--outer-cell-button--invalid
+  .#{c4p-settings.$carbon-prefix}--number
+  input[type='number'][data-invalid]:focus
+  ~ .#{c4p-settings.$carbon-prefix}--number__controls
+  .#{c4p-settings.$carbon-prefix}--number__control-btn.up-icon::after {
+  background-color: $support-error;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -42,7 +42,12 @@ export const getInlineEditColumns = () => {
       accessor: 'firstName',
       inlineEdit: {
         type: 'text',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n.length > 40,
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid text, character count must be less than 40',
+        },
       },
     },
     {
@@ -50,7 +55,12 @@ export const getInlineEditColumns = () => {
       accessor: 'lastName',
       inlineEdit: {
         type: 'text',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n.length > 40,
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid text, character count must be less than 40',
+        },
       },
     },
     {
@@ -58,8 +68,13 @@ export const getInlineEditColumns = () => {
       accessor: 'age',
       width: 120,
       inlineEdit: {
+        // required for including validation, this is used to set the invalid prop internally
+        validator: (n) => n && n < 18,
         type: 'number',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid number, must be 18 or greater',
+        },
       },
     },
     {


### PR DESCRIPTION
Contributes to #1924 

@Ratheeshrajan I took over from where you had left off since you're looking at https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/1923 right now.

This change adds validation to the text and number types for Datagrid inline edit (`useInlineEdit`). In order for the component to know whether a field is invalid, there is a `validator` function that is included in the column inline editing configuration. Also included according to [PAL guidance](https://pages.github.ibm.com/cdai-design/pal/components/data-table/inline-editing/usage#validation), when in edit mode and input is invalid, `enter` and `tab` do not allow the cell to make new changes until the input is valid once again.

See example below:
```js
{
      Header: 'Age',
      accessor: 'age',
      width: 120,
      inlineEdit: {
        // required for including validation, this is used to set the invalid prop internally
        validator: (n) => n < 18,
        type: 'number',
        // These props are passed to the Carbon component used for inline editing
        inputProps: {
          invalidText: 'Invalid number, must be 18 or greater',
        },
      },
    },
```

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/handleGridKeyPress.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
```
#### How did you test and verify your work?
Storybook

**Note: The number input component when used with steppers is acting up a bit but will be fixed in this [Carbon PR](https://github.com/carbon-design-system/carbon/pull/12167)