### PR TITLE
fix: move carbon packages back to peer dependencies (v11)

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -74,13 +74,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@carbon/grid": "^11.3.0",
-    "@carbon/layout": "^11.3.0",
-    "@carbon/motion": "^11.2.0",
-    "@carbon/react": "^1.9.0-rc.0",
     "@carbon/telemetry": "^0.1.0",
-    "@carbon/themes": "^11.4.0",
-    "@carbon/type": "^11.4.0",
     "immutability-helper": "^3.1.1",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
@@ -89,6 +83,12 @@
     "react-window": "^1.8.7"
   },
   "peerDependencies": {
+    "@carbon/grid": "^11.3.0",
+    "@carbon/layout": "^11.3.0",
+    "@carbon/motion": "^11.2.0",
+    "@carbon/react": "^1.13.0",
+    "@carbon/themes": "^11.4.0",
+    "@carbon/type": "^11.4.0",
     "react": "^16.8.6 || ^17.0.1",
     "react-dom": "^16.8.6 || ^17.0.1"
   }

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -163,14 +163,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -147,14 +147,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -130,14 +130,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -130,14 +130,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -129,14 +129,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Add16, Edit16, TrashCan16, Checkmark16 } from '@carbon/icons-react';
+import { Add, Edit, TrashCan, Checkmark } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -136,14 +136,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },
@@ -221,19 +221,19 @@ const manyRowActionButtonsProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
     {
       id: 'approve',
       itemText: 'Approve',
-      icon: Checkmark16,
+      icon: Checkmark,
       onClick: action('Clicked row action: approve'),
     },
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       hasDivider: true,
       onClick: action('Clicked row action: delete'),
@@ -299,33 +299,33 @@ const getBatchActions = () => {
   return [
     {
       label: 'Duplicate',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
     },
     {
       label: 'Add',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
     },
     {
       label: 'Select all',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
       type: 'select_all',
     },
     {
       label: 'Publish to catalog',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
     },
     {
       label: 'Download',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
     },
     {
       label: 'Delete',
-      renderIcon: Add16,
+      renderIcon: Add,
       onClick: action('Clicked batch action button'),
       hasDivider: true,
       kind: 'danger',

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,
@@ -130,14 +130,14 @@ const sharedDatagridProps = {
     {
       id: 'edit',
       itemText: 'Edit',
-      icon: Edit16,
+      icon: Edit,
       onClick: action('Clicked row action: edit'),
     },
 
     {
       id: 'delete',
       itemText: 'Delete',
-      icon: TrashCan16,
+      icon: TrashCan,
       isDelete: true,
       onClick: action('Clicked row action: delete'),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,13 +1856,7 @@ __metadata:
     "@babel/cli": ^7.18.10
     "@babel/core": ^7.18.13
     "@babel/runtime": ^7.18.9
-    "@carbon/grid": ^11.3.0
-    "@carbon/layout": ^11.3.0
-    "@carbon/motion": ^11.2.0
-    "@carbon/react": ^1.9.0-rc.0
     "@carbon/telemetry": ^0.1.0
-    "@carbon/themes": ^11.4.0
-    "@carbon/type": ^11.4.0
     babel-preset-ibm-cloud-cognitive: ^0.14.19
     chalk: ^4.1.2
     change-case: ^4.1.2
@@ -1886,6 +1880,12 @@ __metadata:
     sass: ^1.54.8
     yargs: ^17.5.1
   peerDependencies:
+    "@carbon/grid": ^11.3.0
+    "@carbon/layout": ^11.3.0
+    "@carbon/motion": ^11.2.0
+    "@carbon/react": ^1.13.0
+    "@carbon/themes": ^11.4.0
+    "@carbon/type": ^11.4.0
     react: ^16.8.6 || ^17.0.1
     react-dom: ^16.8.6 || ^17.0.1
   languageName: unknown


### PR DESCRIPTION
@SimonFinney noted that the Carbon dependencies moved from peer dependencies to production dependencies on the `carbon-v11` branch. This was unintentional during our migration from v10 to v11 support and this PR changes it back.

I also included some datagrid storybook updates where v10 icons were left in by accident.

#### What did you change?
`packages/cloud-cognitive/package.json`
`yarn.lock`
#### How did you test and verify your work?
Ran `yarn`, `yarn storybook`, and `yarn ci-check:v11` locally and everything still builds as expected.