### PR TITLE
chore: use base carbon react package for icons in v11

### DIFF
--- a/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.js
+++ b/packages/cloud-cognitive/src/components/APIKeyModal/APIKeyModal.js
@@ -19,7 +19,7 @@ import {
   Form,
   Button,
 } from '@carbon/react';
-import { InformationFilled, Copy, ErrorFilled } from '@carbon/icons-react';
+import { InformationFilled, Copy, ErrorFilled } from '@carbon/react/icons';
 import { APIKeyDownloader } from './APIKeyDownloader';
 import { pkg } from '../../settings';
 

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.stories.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { Bee, Lightning } from '@carbon/icons-react';
+import { Bee, Lightning } from '@carbon/react/icons';
 
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.test.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ActionBar } from '.';
-import { Lightning, Bee } from '@carbon/icons-react';
+import { Lightning, Bee } from '@carbon/react/icons';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
 import { pkg, carbon } from '../../settings';

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -10,7 +10,7 @@ import React from 'react';
 import { AddSelectBody } from './AddSelectBody';
 import { pkg, carbon } from '../../settings';
 import { getGlobalFilterValues, normalize } from './add-select-utils';
-import { Document16 } from '@carbon/icons-react';
+import { Document16 } from '@carbon/react/icons';
 import image from '../UserProfileImage/headshot.jpg'; // cspell:disable-line
 
 const blockClass = `${pkg.prefix}--add-select`;

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Search, Tag, OverflowMenu, Checkbox, usePrefix } from '@carbon/react';
-import { Filter } from '@carbon/icons-react';
+import { Filter } from '@carbon/react/icons';
 import { pkg } from '../../settings';
 import { AddSelectList } from './AddSelectList';
 import { AddSelectSort } from './AddSelectSort';

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectFilter.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectFilter.js
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import { Button, ButtonSet, Dropdown, Search, Tag } from '@carbon/react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { Filter } from '@carbon/icons-react';
+import { Filter } from '@carbon/react/icons';
 import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--add-select__global-filter`;

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectList.js
@@ -15,7 +15,7 @@ import {
   StructuredListBody,
   Dropdown,
 } from '@carbon/react';
-import { ChevronRight, View } from '@carbon/icons-react';
+import { ChevronRight, View } from '@carbon/react/icons';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectMetaPanel.js
@@ -1,6 +1,6 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
-import { Close } from '@carbon/icons-react';
+import { Close } from '@carbon/react/icons';
 import { Button } from '@carbon/react';
 import { pkg } from '../../settings';
 

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectSort.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectSort.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { ArrowsVertical, ArrowUp, ArrowDown } from '@carbon/icons-react';
+import { ArrowsVertical, ArrowUp, ArrowDown } from '@carbon/react/icons';
 import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--add-select-sort`;

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -11,19 +11,21 @@ import React, { useState, useEffect, useRef } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Link, IconButton, usePrefix } from '@carbon/react';
-import { pkg } from '../../settings';
 import { useResizeDetector } from 'react-resize-detector';
-import { ArrowLeft } from '@carbon/icons-react';
 
 // Carbon and package components we use.
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Link,
+  IconButton,
   OverflowMenu,
   OverflowMenuItem,
+  usePrefix,
 } from '@carbon/react';
-import { OverflowMenuHorizontal } from '@carbon/icons-react';
+import { pkg } from '../../settings';
+import { ArrowLeft, OverflowMenuHorizontal } from '@carbon/react/icons';
+
 import uuidv4 from '../../global/js/utils/uuidv4';
 import '../../global/js/utils/props-helper';
 

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.stories.js
@@ -19,7 +19,7 @@ import mdx from './ButtonMenu.mdx';
 
 // import styles from './_storybook-styles.scss';
 
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 
 export default {
   title: getStoryTitle(ButtonMenu.displayName),

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
@@ -13,7 +13,7 @@ import { pkg, carbon } from '../../settings';
 
 import uuidv4 from '../../global/js/utils/uuidv4';
 
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 
 import { ButtonMenu, ButtonMenuItem } from '.';
 

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.test.js
@@ -9,14 +9,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ButtonSetWithOverflow } from '.';
-import { Bee16 } from '@carbon/icons-react';
+import { Bee } from '@carbon/react/icons';
 import { mockHTMLElement } from '../../global/js/utils/test-helper';
 
 import { carbon } from '../../settings';
 
 const buttons = (handleClick) =>
   [1, 2, 3].map((num) => ({
-    renderIcon: !(num % 3) ? Bee16 : null,
+    renderIcon: !(num % 3) ? Bee : null,
     iconDescription: !(num % 3) ? 'Busy bee' : null,
     label: `Action ${num}`,
     key: `key-${num}`,

--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ChevronDown, ChevronUp } from '@carbon/icons-react';
+import { ChevronDown, ChevronUp } from '@carbon/react/icons';
 
 import { Button, OverflowMenuItem, OverflowMenu } from '@carbon/react';
 

--- a/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
+++ b/packages/cloud-cognitive/src/components/ComboButton/ComboButton.stories.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CloudApp } from '@carbon/icons-react';
+import { CloudApp } from '@carbon/react/icons';
 import React from 'react';
 
 import {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -13,7 +13,7 @@ import { getInlineEditColumns } from './utils/getInlineEditColumns';
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 
 import { action } from '@storybook/addon-actions';
-import { Activity, Add } from '@carbon/icons-react';
+import { Activity, Add } from '@carbon/react/icons';
 import { DataTable } from '@carbon/react';
 import {
   Datagrid,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -38,7 +38,7 @@ import {
   TableBatchActions,
   TableBatchAction,
 } from '@carbon/react';
-import { Download, Restart, Filter, Activity } from '@carbon/icons-react';
+import { Download, Restart, Filter, Activity } from '@carbon/react/icons';
 import { carbon } from '../../settings';
 
 // import { DatagridActions, DatagridBatchActions, DatagridPagination, } from './Datagrid.stories';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Checkbox, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { CaretDown } from '@carbon/icons-react';
+import { CaretDown } from '@carbon/react/icons';
 import { pkg } from '../../../settings';
 // cspell:words columnheader
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { Add, OverflowMenuVertical } from '@carbon/icons-react';
+import { Add, OverflowMenuVertical } from '@carbon/react/icons';
 import { DataTable, TableBatchActions, TableBatchAction } from '@carbon/react';
 import { useResizeDetector } from 'react-resize-detector';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -8,7 +8,7 @@
  */
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Draggable } from '@carbon/icons-react';
+import { Draggable } from '@carbon/react/icons';
 import { useDrag, useDrop } from 'react-dnd';
 import cx from 'classnames';
 import { pkg } from '../../../settings';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/ButtonWrapper.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/ButtonWrapper.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Column } from '@carbon/icons-react';
+import { Column } from '@carbon/react/icons';
 import { Button } from '@carbon/react';
 import { pkg } from '../../../../../settings';
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -20,7 +20,7 @@ import {
   DatePicker,
   DatePickerInput,
 } from '@carbon/react';
-import { Edit, CaretSort, ChevronDown, Calendar } from '@carbon/icons-react';
+import { Edit, CaretSort, ChevronDown, Calendar } from '@carbon/react/icons';
 import { InlineEditButton } from '../InlineEditButton';
 import { pkg } from '../../../../../../settings';
 import cx from 'classnames';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Settings } from '@carbon/icons-react';
+import { Settings } from '@carbon/react/icons';
 import { IconButton, Popover, PopoverContent } from '@carbon/react';
 import cx from 'classnames';
 import RowSizeRadioGroup from './RowSizeRadioGroup';

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnAlignment/ColumnAlignment.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ExpandableRow/ExpandableRow.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/Header/Header.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/NestedRows/NestedRows.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowActionButtons/RowActionButtons.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Add, Edit, TrashCan, Checkmark } from '@carbon/icons-react';
+import { Add, Edit, TrashCan, Checkmark } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { Edit, TrashCan } from '@carbon/icons-react';
+import { Edit, TrashCan } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useNestedRowExpander.js
@@ -7,7 +7,7 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import React from 'react';
-import { ChevronRight } from '@carbon/icons-react';
+import { ChevronRight } from '@carbon/react/icons';
 import cx from 'classnames';
 import { pkg } from '../../settings';
 

--- a/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
@@ -7,7 +7,7 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import React from 'react';
-import { ChevronDown, ChevronUp } from '@carbon/icons-react';
+import { ChevronDown, ChevronUp } from '@carbon/react/icons';
 
 const useRowExpander = (hooks) => {
   const visibleColumns = (columns) => {

--- a/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import { Button } from '@carbon/react';
-import { ArrowUp, ArrowDown, ArrowsVertical } from '@carbon/icons-react';
+import { ArrowUp, ArrowDown, ArrowsVertical } from '@carbon/react/icons';
 
 const ordering = {
   ASC: 'ASC',

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { DataTable, Button } from '@carbon/react';
-import { Download, Filter, Add, Restart } from '@carbon/icons-react';
+import { Download, Filter, Add, Restart } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import { pkg } from '../../../settings';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -10,7 +10,7 @@ import {
   ChartBubble,
   ChartColumnFloating,
   ChartVennDiagram,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 
 export const inlineEditSelectItems = [
   {

--- a/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/EditSidePanel/EditSidePanel.stories.js
@@ -19,7 +19,7 @@ import {
   HeaderName,
   usePrefix,
 } from '@carbon/react';
-import { Copy, TrashCan, Settings } from '@carbon/icons-react';
+import { Copy, TrashCan, Settings } from '@carbon/react/icons';
 
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/EmptyStates.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import CustomIllustration from './story_assets/empty-state-bright-magnifying-glass.svg';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './ErrorEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './NoDataEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './NoTagsEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './NotFoundEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './NotificationsEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
+++ b/packages/cloud-cognitive/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import mdx from './UnauthorizedEmptyState.mdx';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
+++ b/packages/cloud-cognitive/src/components/ExportModal/ExportModal.js
@@ -20,7 +20,7 @@ import {
   PasswordInput,
 } from '@carbon/react';
 import cx from 'classnames';
-import { ErrorFilled, CheckmarkFilled } from '@carbon/icons-react';
+import { ErrorFilled, CheckmarkFilled } from '@carbon/react/icons';
 import PropTypes from 'prop-types';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { ArrowRight, Cloud } from '@carbon/icons-react';
+import { ArrowRight, Cloud } from '@carbon/react/icons';
 import { AspectRatio, Column, Grid, usePrefix } from '@carbon/react';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
+++ b/packages/cloud-cognitive/src/components/ImportModal/ImportModal.js
@@ -6,7 +6,7 @@
 //
 
 import React, { useState, forwardRef } from 'react';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import {
   ComposedModal,
   ModalHeader,

--- a/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
+++ b/packages/cloud-cognitive/src/components/InlineEdit/InlineEdit.js
@@ -24,7 +24,7 @@ import {
   EditOff,
   Checkmark,
   WarningFilled,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 
 // The block part of our conventional BEM class names (blockClass__E--M).
 const blockClass = `${pkg.prefix}--inline-edit`;

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabLabelNew.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabLabelNew.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--modified-tabs`;

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabLabelWithClose.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabLabelWithClose.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Close, CloseFilled } from '@carbon/icons-react';
+import { Close, CloseFilled } from '@carbon/react/icons';
 import { pkg } from '../../settings';
 
 const blockClass = `${pkg.prefix}--modified-tabs`;

--- a/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
+++ b/packages/cloud-cognitive/src/components/ModifiedTabs/ModifiedTabs.stories.js
@@ -1,4 +1,3 @@
-import { _4K16 } from '@carbon/icons-react';
 //
 // Copyright IBM Corp. 2020, 2020
 //

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -16,7 +16,7 @@ import mdx from './MultiAddSelect.mdx';
 import { Button } from '@carbon/react';
 // import { action } from '@storybook/addon-actions';
 import image from '../UserProfileImage/headshot.jpg'; // cspell:disable-line
-import { Group, Document } from '@carbon/icons-react';
+import { Group, Document } from '@carbon/react/icons';
 
 import { pkg } from '../../settings';
 const blockClass = `${pkg.prefix}--add-select__meta-panel`;

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.js
@@ -29,7 +29,7 @@ import {
   ChevronDown,
   Close,
   Settings,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 import { usePreviousValue } from '../../global/js/hooks';
 
 // The block part of our conventional BEM class names (blockClass__E--M).

--- a/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
+++ b/packages/cloud-cognitive/src/components/NotificationsPanel/NotificationsPanel.stories.js
@@ -15,7 +15,7 @@ import {
   HeaderGlobalBar,
   HeaderGlobalAction,
 } from '@carbon/react';
-import { User, Notification } from '@carbon/icons-react';
+import { User, Notification } from '@carbon/react/icons';
 import { white } from '@carbon/colors';
 import styles from './_storybook-styles.scss';
 import uuidv4 from '../../global/js/utils/uuidv4';

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -23,7 +23,7 @@ import {
   Locked,
   WarningAltFilled,
   WarningFilled,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 import * as carbonMotion from '@carbon/motion';
 
 // The block part of our conventional BEM class names (blockClass__E--M).

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -28,7 +28,7 @@ import { ActionBar } from '../ActionBar/';
 import { BreadcrumbWithOverflow } from '../BreadcrumbWithOverflow';
 import { TagSet, string_required_if_more_than_10_tags } from '../TagSet/TagSet';
 import { ButtonSetWithOverflow } from '../ButtonSetWithOverflow';
-import { ChevronUp } from '@carbon/icons-react';
+import { ChevronUp } from '@carbon/react/icons';
 
 const componentName = 'PageHeader';
 

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -37,7 +37,7 @@ import {
   Security,
   Settings,
   VolumeMute,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 import cx from 'classnames';
 
 import { ActionBarItem } from '../ActionBar';

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.test.js
@@ -12,7 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { pkg, carbon } from '../../settings';
 
 import { Tab, Tabs, TabList } from '@carbon/react';
-import { Lightning, Bee } from '@carbon/icons-react';
+import { Lightning, Bee } from '@carbon/react/icons';
 
 import { PageHeader } from '.';
 import {

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.stories.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { TrashCan, Edit } from '@carbon/icons-react';
+import { TrashCan, Edit } from '@carbon/react/icons';
 import { Grid, Column, usePrefix } from '@carbon/react';
 import {
   getStoryTitle,

--- a/packages/cloud-cognitive/src/components/Saving/Saving.js
+++ b/packages/cloud-cognitive/src/components/Saving/Saving.js
@@ -13,7 +13,7 @@ import {
   CheckmarkOutline,
   ErrorOutline,
   ErrorFilled,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 import PropTypes from 'prop-types';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -24,7 +24,7 @@ import { usePreviousValue } from '../../global/js/hooks';
 
 // Carbon and package components we use.
 import { Button } from '@carbon/react';
-import { Close, ArrowLeft } from '@carbon/icons-react';
+import { Close, ArrowLeft } from '@carbon/react/icons';
 import { ActionSet } from '../ActionSet';
 
 const blockClass = `${pkg.prefix}--side-panel`;

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.stories.js
@@ -26,7 +26,7 @@ import {
   HeaderContainer,
   HeaderName,
 } from '@carbon/react';
-import { Copy, TrashCan, Settings } from '@carbon/icons-react';
+import { Copy, TrashCan, Settings } from '@carbon/react/icons';
 import {
   getStoryTitle,
   prepareStory,

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.test.js
@@ -15,7 +15,7 @@ import { TextInput } from '@carbon/react';
 import { pkg } from '../../settings';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { SidePanel } from '.';
-import { Add } from '@carbon/icons-react';
+import { Add } from '@carbon/react/icons';
 
 const { prefix } = pkg;
 

--- a/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.js
+++ b/packages/cloud-cognitive/src/components/StatusIcon/StatusIcon.js
@@ -19,7 +19,7 @@ import {
   InformationSquareFilled,
   Renew,
   Time,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { pkg } from '../../settings';

--- a/packages/cloud-cognitive/src/components/Toolbar/Toolbar.stories.js
+++ b/packages/cloud-cognitive/src/components/Toolbar/Toolbar.stories.js
@@ -29,7 +29,7 @@ import {
   TextCreation,
   ZoomIn,
   ZoomOut,
-} from '@carbon/icons-react';
+} from '@carbon/react/icons';
 
 import { Dropdown, OverflowMenu, OverflowMenuItem } from '@carbon/react';
 

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.js
@@ -17,7 +17,7 @@ import '../../global/js/utils/props-helper';
 import { pkg } from '../../settings';
 
 // Carbon and package components we use.
-import { User, Group } from '@carbon/icons-react';
+import { User, Group } from '@carbon/react/icons';
 
 import { IconButton } from '@carbon/react';
 

--- a/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
+++ b/packages/cloud-cognitive/src/components/UserProfileImage/UserProfileImage.test.js
@@ -13,7 +13,7 @@ import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg, carbon } from '../../settings';
 
 import { UserProfileImage } from '.';
-import { Group } from '@carbon/icons-react';
+import { Group } from '@carbon/react/icons';
 
 const blockClass = `${pkg.prefix}--user-profile-image`;
 const componentName = UserProfileImage.displayName;

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.js
@@ -14,7 +14,7 @@ import cx from 'classnames';
 import { pkg } from '../../settings';
 
 // Carbon and package components we use.
-import { Close, Help } from '@carbon/icons-react';
+import { Close, Help } from '@carbon/react/icons';
 import { Button, OverflowMenu, OverflowMenuItem } from '@carbon/react';
 import { moderate02 } from '@carbon/motion';
 import { useWebTerminal } from './hooks';

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.stories.js
@@ -9,7 +9,7 @@
 
 import React from 'react';
 // Carbon and package components we use.
-import { Code, Copy } from '@carbon/icons-react';
+import { Code, Copy } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import { Navigation } from './preview-components';
 import {

--- a/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.test.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/WebTerminal.test.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Code, Copy } from '@carbon/icons-react';
+import { Code, Copy } from '@carbon/react/icons';
 import { act, renderHook } from '@testing-library/react-hooks';
 
 import { pkg } from '../../settings';

--- a/packages/cloud-cognitive/src/components/WebTerminal/preview-components/Navigation.js
+++ b/packages/cloud-cognitive/src/components/WebTerminal/preview-components/Navigation.js
@@ -12,7 +12,7 @@ import {
   HeaderGlobalAction,
   HeaderGlobalBar,
 } from '@carbon/react';
-import { Terminal, Search, User } from '@carbon/icons-react';
+import { Terminal, Search, User } from '@carbon/react/icons';
 
 import { useWebTerminal } from '../hooks';
 

--- a/packages/core/src/component-playground/components/Card/ProductiveCard.js
+++ b/packages/core/src/component-playground/components/Card/ProductiveCard.js
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { ProductiveCard as CCProductiveCard } from '../../../../../cloud-cognitive/src';
-import { TrashCan, Edit } from '@carbon/icons-react';
+import { TrashCan, Edit } from '@carbon/react/icons';
 import { StatusIcon } from '../../../../../cloud-cognitive/src';
 import { Column, Grid } from '@carbon/react';
 

--- a/packages/core/src/component-playground/components/PageHeader/PageHeader.js
+++ b/packages/core/src/component-playground/components/PageHeader/PageHeader.js
@@ -9,7 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { PageHeader as CCPageHeader } from '../../../../../cloud-cognitive/src';
-import { Lightning, Bee } from '@carbon/icons-react';
+import { Lightning, Bee } from '@carbon/react/icons';
 
 const PageHeader = (props) => {
   const content = (


### PR DESCRIPTION
Contributes to #2319 

As suggested by Simon and Carbon, icon imports in v11 should be imported from the base carbon react package (ie `@carbon/react/icons`. I have updated all of our icon imports to reflect that.

What we had previously on the `carbon-v11` branch was only working because `@carbon/icons-react` exists somewhere in the dependency tree.

#### What did you change?
Changed all carbon icon imports from `@carbon/icons-react` to `@carbon/react/icons`.
#### How did you test and verify your work?
Storybook, ran build script, and made sure that all tests still pass