### PR TITLE
fix(InlineEdit): fix calc interpolation issue (v11)

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3555,8 +3555,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--inline-edit .c4p--inline-edit__input {
   display: inline-block;
   overflow: hidden;
-  width: calc(100% - var(--c4p--inline-edit--toolbar-width) - 1rem);
-  max-width: calc(100% - var(--c4p--inline-edit--toolbar-width) - 1rem);
+  width: calc(
+      100% - var(--c4p--inline-edit--toolbar-width) - 1rem
+    );
+  max-width: calc(
+      100% - var(--c4p--inline-edit--toolbar-width) - 1rem
+    );
   min-height: var(--c4p--inline-edit--size);
   /* stylelint-disable-next-line carbon/layout-token-use */
   margin-right: var(--c4p--inline-edit--toolbar-width);

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3555,9 +3555,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--inline-edit .c4p--inline-edit__input {
   display: inline-block;
   overflow: hidden;
-  width: calc(
-      100% - var(--c4p--inline-edit--toolbar-width) - 1rem
-    );
+  width: calc(100% - var(--c4p--inline-edit--toolbar-width) - 1rem);
   max-width: calc(
       100% - var(--c4p--inline-edit--toolbar-width) - 1rem
     );

--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -105,9 +105,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--inline-edit;
     overflow: hidden;
     // positions text and placeholder including when showing placeholder
     // NOTE: Using flex does strange things to a caret in content editable
-    width: calc(
-      100% - var(--#{$block-class}--toolbar-width) - #{$spacing-05}
-    );
+    width: calc(100% - var(--#{$block-class}--toolbar-width) - #{$spacing-05});
     max-width: calc(
       100% - var(--#{$block-class}--toolbar-width) - #{$spacing-05}
     );

--- a/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
+++ b/packages/cloud-cognitive/src/components/InlineEdit/_inline-edit.scss
@@ -105,8 +105,12 @@ $block-class: #{c4p-settings.$pkg-prefix}--inline-edit;
     overflow: hidden;
     // positions text and placeholder including when showing placeholder
     // NOTE: Using flex does strange things to a caret in content editable
-    width: calc(100% - var(--#{$block-class}--toolbar-width) - $spacing-05);
-    max-width: calc(100% - var(--#{$block-class}--toolbar-width) - $spacing-05);
+    width: calc(
+      100% - var(--#{$block-class}--toolbar-width) - #{$spacing-05}
+    );
+    max-width: calc(
+      100% - var(--#{$block-class}--toolbar-width) - #{$spacing-05}
+    );
     min-height: var(--#{$block-class}--size);
     /* stylelint-disable-next-line carbon/layout-token-use */
     margin-right: var(--#{$block-class}--toolbar-width);


### PR DESCRIPTION
Contributes to #2283 (v11)

Carbon tokens inside of calc needed to be interpolated in order to build correctly

#### What did you change?
`_inline-edit.scss`
`styles.test.js.snap`

#### How did you test and verify your work?
Styling still works correctly and after carbon token is interpolated correctly
