### PR TITLE
fix(PageHeader): Update page header to use h1 -v11

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6721,6 +6721,12 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   transform: translateY(-2px);
   vertical-align: middle;
 }
+.c4p--page-header .c4p--page-header__title-wrapper {
+  font-size: var(--cds-productive-heading-04-font-size, 1.75rem);
+  font-weight: var(--cds-productive-heading-04-font-weight, 400);
+  line-height: var(--cds-productive-heading-04-line-height, 1.28572);
+  letter-spacing: var(--cds-productive-heading-04-letter-spacing, 0);
+}
 .c4p--page-header .c4p--page-header__page-actions {
   flex: 0 0 100%;
   margin-top: 1rem;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeaderTitle.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeaderTitle.js
@@ -81,7 +81,7 @@ export const PageHeaderTitle = ({ blockClass, hasBreadcrumbRow, title }) => {
       )}
       title={titleText}
     >
-      {titleInnards}
+      <h1 className={`${blockClass}__title-wrapper`}>{titleInnards}</h1>
     </div>
   );
 };

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -466,6 +466,10 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     vertical-align: middle;
   }
 
+  .#{$block-class}__title-wrapper {
+    @include type.type-style('productive-heading-04');
+  }
+
   .#{$block-class}__page-actions {
     flex: 0 0 100%;
     margin-top: $spacing-05;


### PR DESCRIPTION
Contributes to #2257 (v11)

Add h1 tag around the title to pass accessibility/WCAG requirements.

#### What did you change?
`_page-hedaer.scss`
`PageHeaderTitle.js`
`styles.test.js.snap`

#### How did you test and verify your work?
Updated snapshot tests and checked styling shows as expected