### PR TITLE
fix(NavList): use type.displayName

### DIFF
--- a/packages/security/src/components/Nav/Nav.js
+++ b/packages/security/src/components/Nav/Nav.js
@@ -15,8 +15,6 @@ import { getComponentNamespace } from '../../globals/namespace';
 
 export const navNamespace = getComponentNamespace('nav');
 
-const { name } = NavList;
-
 export default class Nav extends Component {
   constructor(props) {
     super(props);
@@ -110,7 +108,7 @@ export default class Nav extends Component {
    */
   handleListClick(id) {
     Children.forEach(this.props.children, ({ props, type }, index) => {
-      if (type.name === name) {
+      if (type.displayName === NavList.displayName) {
         const childId = `${navNamespace}__list--${index}`;
 
         if (childId !== id && !props.isExpandedOnPageload) {
@@ -142,7 +140,7 @@ export default class Nav extends Component {
 
         <ul className={`${navNamespace}__wrapper`} role="menubar">
           {Children.map(children, (child, index) =>
-            child.type.name === name
+            child.type.displayName === NavList.displayName
               ? this.buildNewListChild(child, index)
               : this.buildNewItemChild(child, index)
           )}

--- a/packages/security/src/components/Nav/NavList/NavList.js
+++ b/packages/security/src/components/Nav/NavList/NavList.js
@@ -191,3 +191,5 @@ NavList.propTypes = {
   /** @type {string} Label of the list. */
   title: string,
 };
+
+NavList.displayName = 'NavList';

--- a/packages/security/src/components/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/security/src/components/__tests__/__snapshots__/public-api-test.js.snap
@@ -6378,6 +6378,7 @@ Map {
       "tabIndex": 0,
       "title": "",
     },
+    "displayName": "NavList",
     "propTypes": {
       "activeHref": {
         "type": "string",


### PR DESCRIPTION
Contributes to #2333

Fix for NavList throwing error when using production build.

#### What did you change?
Swap from using type.name to type.displayName.   

type.name is not safe to use with production builds which may minify symbol names.

#### How did you test and verify your work?
- verified unit tests pass
- verified component functions correctly in storybook
