### PR TITLE
chore(Datagrid): add inline edit extension directory for story organization

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -275,6 +275,8 @@ export const InlineEdit = () => {
       data,
       onDataUpdate: setData,
       DatagridActions,
+      gridTitle: 'Test',
+      gridDescription: 'Testing description',
     },
     useInlineEdit
   );

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
-import { getInlineEditColumns } from './utils/getInlineEditColumns';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 
@@ -28,7 +27,6 @@ import {
   useStickyColumn,
   useActionsColumn,
   useColumnOrder,
-  useInlineEdit,
 } from '.';
 
 import {
@@ -263,23 +261,6 @@ export const WithPagination = () => {
     DatagridPagination,
   });
 
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-export const InlineEdit = () => {
-  const [data, setData] = useState(makeData(10));
-  const columns = React.useMemo(() => getInlineEditColumns(), []);
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      onDataUpdate: setData,
-      DatagridActions,
-      gridTitle: 'Test',
-      gridDescription: 'Testing description',
-    },
-    useInlineEdit
-  );
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -115,20 +115,13 @@ export const DatagridContent = ({ datagridState }) => {
       `--${blockClass}--grid-width`,
       px(totalColumnsWidth + 32)
     );
-    if (gridTitle && gridActive) {
+    if (gridActive) {
       gridElement.style.setProperty(
         `--${blockClass}--grid-header-height`,
-        px(tableHeader?.clientHeight)
+        px(tableHeader?.clientHeight || 0)
       );
     }
-  }, [
-    withInlineEdit,
-    tableId,
-    totalColumnsWidth,
-    datagridState,
-    gridTitle,
-    gridActive,
-  ]);
+  }, [withInlineEdit, tableId, totalColumnsWidth, datagridState, gridActive]);
 
   return (
     <>

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -7,7 +7,7 @@ import DatagridHead from './DatagridHead';
 import DatagridBody from './DatagridBody';
 import DatagridToolbar from './DatagridToolbar';
 import { handleGridKeyPress } from './addons/InlineEdit/handleGridKeyPress';
-import { pkg } from '../../../settings';
+import { carbon, pkg } from '../../../settings';
 import { InlineEditContext } from './addons/InlineEdit/InlineEditContext';
 import { handleGridFocus } from './addons/InlineEdit/handleGridFocus';
 import { useClickOutside } from '../../../global/js/hooks';
@@ -108,11 +108,28 @@ export const DatagridContent = ({ datagridState }) => {
       return;
     }
     const gridElement = document.querySelector(`#${tableId}`);
+    const tableHeader = document.querySelector(
+      `.${carbon.prefix}--data-table-header`
+    );
     gridElement.style.setProperty(
       `--${blockClass}--grid-width`,
       px(totalColumnsWidth + 32)
     );
-  }, [withInlineEdit, tableId, totalColumnsWidth, datagridState]);
+    if (gridTitle && gridActive) {
+      console.log(tableHeader, tableHeader.clientHeight);
+      gridElement.style.setProperty(
+        `--${blockClass}--grid-header-height`,
+        px(tableHeader?.clientHeight)
+      );
+    }
+  }, [
+    withInlineEdit,
+    tableId,
+    totalColumnsWidth,
+    datagridState,
+    gridTitle,
+    gridActive,
+  ]);
 
   return (
     <>
@@ -126,6 +143,7 @@ export const DatagridContent = ({ datagridState }) => {
           useDenseHeader ? `${blockClass}__dense-header` : '',
           {
             [`${blockClass}__grid-container-grid-active`]: gridActive,
+            [`${blockClass}__grid-container-inline-edit`]: withInlineEdit,
             [`${blockClass}__grid-container-grid-active--without-toolbar`]:
               withInlineEdit && !DatagridActions,
           }

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -116,7 +116,6 @@ export const DatagridContent = ({ datagridState }) => {
       px(totalColumnsWidth + 32)
     );
     if (gridTitle && gridActive) {
-      console.log(tableHeader, tableHeader.clientHeight);
       gridElement.style.setProperty(
         `--${blockClass}--grid-header-height`,
         px(tableHeader?.clientHeight)

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -1,0 +1,116 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit16, TrashCan16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid, useInlineEdit } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+import { getInlineEditColumns } from '../../utils/getInlineEditColumns';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/InlineEdit`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit16,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan16,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const InlineEditUsage = ({ ...args }) => {
+  const [data, setData] = useState(makeData(10));
+  const columns = React.useMemo(() => getInlineEditColumns(), []);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      onDataUpdate: setData,
+      ...args.defaultGridProps,
+    },
+    useInlineEdit
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const InlineEditTemplateWrapper = ({ ...args }) => {
+  return <InlineEditUsage defaultGridProps={{ ...args }} />;
+};
+
+const inlineEditUsageControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+};
+const basicUsageStoryName = 'With inline edit';
+export const InlineEditUsageStory = prepareStory(InlineEditTemplateWrapper, {
+  storyName: basicUsageStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+  },
+  args: {
+    ...inlineEditUsageControlProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -229,7 +229,7 @@ $row-heights: (
   bottom: 0;
   left: 0;
   width: 2px;
-  height: calc(100% - 50px);
+  height: calc(100% - 50px - var(--#{$block-class}--grid-header-height));
   background-color: $inverse-link;
   content: '';
 }
@@ -240,15 +240,14 @@ $row-heights: (
   right: 0;
   bottom: 0;
   width: 2px;
-  height: calc(100% - 50px);
+  height: calc(100% - 50px - var(--#{$block-class}--grid-header-height));
   background-color: $inverse-link;
   content: '';
 }
 
 .#{$block-class}
   .#{$block-class}__grid-container-grid-active
-  .#{$block-class}__table-grid-active
-  thead::before {
+  .#{$carbon-prefix}--data-table-content::before {
   position: absolute;
   z-index: 2;
   top: 0;
@@ -263,7 +262,7 @@ $row-heights: (
   .#{$block-class}__grid-container-grid-active.#{$block-class}__grid-container-grid-active--without-toolbar::before,
 .#{$block-class}
   .#{$block-class}__grid-container-grid-active.#{$block-class}__grid-container-grid-active--without-toolbar::after {
-  height: calc(100% - 2px);
+  height: calc(100% - 2px - var(--#{$block-class}--grid-header-height));
 }
 
 .#{$block-class}
@@ -271,6 +270,12 @@ $row-heights: (
   .#{$block-class}__table-container {
   outline: 2px solid $inverse-link;
   outline-offset: -2px;
+}
+
+.#{$block-class}
+  .#{$block-class}__grid-container-inline-edit
+  .#{$block-class}__table-container {
+  padding-top: $spacing-01;
 }
 
 .#{$block-class}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -56,6 +56,10 @@ $row-heights: (
   }
 }
 
+.#{$block-class} {
+  --#{$block-class}--grid-header-height: 0;
+}
+
 .#{$block-class}__inline-edit-cell {
   display: flex;
   height: 100%;

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -52,6 +52,7 @@ const s = [
               'c/Datagrid/Extensions/NestedRows',
               'c/Datagrid/Extensions/ColumnAlignment',
               'c/Datagrid/Extensions/ClickableRow',
+              'c/Datagrid/Extensions/InlineEdit',
             ],
           },
         ],


### PR DESCRIPTION
Contributes to #2270

This PR adds a new extension directory in storybook for the datagrid component for `InlineEdit`. While working on this, I found a few css issues with the focus region outlines which I've also provided fixes for.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
packages/core/story-structure.js
```
#### How did you test and verify your work?
Storybook