### PR TITLE
chore(Datagrid): add inline edit extension directory for story organization (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.js
@@ -354,11 +354,11 @@ AddSelectBody.propTypes = {
       PropTypes.shape({
         avatar: PropTypes.shape({
           alt: PropTypes.string,
-          icon: PropTypes.func,
+          icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
           src: PropTypes.string,
         }),
         children: PropTypes.object,
-        icon: PropTypes.func,
+        icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
         id: PropTypes.string.isRequired,
         meta: PropTypes.oneOfType([
           PropTypes.arrayOf(

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -10,7 +10,7 @@ import React from 'react';
 import { AddSelectBody } from './AddSelectBody';
 import { pkg, carbon } from '../../settings';
 import { getGlobalFilterValues, normalize } from './add-select-utils';
-import { Document16 } from '@carbon/react/icons';
+import { Document } from '@carbon/react/icons';
 import image from '../UserProfileImage/headshot.jpg'; // cspell:disable-line
 
 const blockClass = `${pkg.prefix}--add-select`;
@@ -192,7 +192,7 @@ const itemWithIcon = {
       id: '1',
       value: 'kansas',
       title: 'Kansas',
-      icon: Document16,
+      icon: Document,
     },
   ],
 };

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -8,7 +8,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
-import { getInlineEditColumns } from './utils/getInlineEditColumns';
 
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 
@@ -28,7 +27,6 @@ import {
   useStickyColumn,
   useActionsColumn,
   useColumnOrder,
-  useInlineEdit,
 } from '.';
 
 import {
@@ -256,21 +254,6 @@ export const WithPagination = () => {
     DatagridPagination,
   });
 
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
-export const InlineEdit = () => {
-  const [data, setData] = useState(makeData(10));
-  const columns = React.useMemo(() => getInlineEditColumns(), []);
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      onDataUpdate: setData,
-      DatagridActions,
-    },
-    useInlineEdit
-  );
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -7,7 +7,7 @@ import DatagridHead from './DatagridHead';
 import DatagridBody from './DatagridBody';
 import DatagridToolbar from './DatagridToolbar';
 import { handleGridKeyPress } from './addons/InlineEdit/handleGridKeyPress';
-import { pkg } from '../../../settings';
+import { carbon, pkg } from '../../../settings';
 import { InlineEditContext } from './addons/InlineEdit/InlineEditContext';
 import { handleGridFocus } from './addons/InlineEdit/handleGridFocus';
 import { useClickOutside } from '../../../global/js/hooks';
@@ -107,11 +107,20 @@ export const DatagridContent = ({ datagridState }) => {
       return;
     }
     const gridElement = document.querySelector(`#${tableId}`);
+    const tableHeader = document.querySelector(
+      `.${carbon.prefix}--data-table-header`
+    );
     gridElement.style.setProperty(
       `--${blockClass}--grid-width`,
       px(totalColumnsWidth + 32)
     );
-  }, [withInlineEdit, tableId, totalColumnsWidth, datagridState]);
+    if (gridActive) {
+      gridElement.style.setProperty(
+        `--${blockClass}--grid-header-height`,
+        px(tableHeader?.clientHeight || 0)
+      );
+    }
+  }, [withInlineEdit, tableId, totalColumnsWidth, datagridState, gridActive]);
 
   return (
     <>
@@ -125,6 +134,7 @@ export const DatagridContent = ({ datagridState }) => {
           useDenseHeader ? `${blockClass}__dense-header` : '',
           {
             [`${blockClass}__grid-container-grid-active`]: gridActive,
+            [`${blockClass}__grid-container-inline-edit`]: withInlineEdit,
             [`${blockClass}__grid-container-grid-active--without-toolbar`]:
               withInlineEdit && !DatagridActions,
           }

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -1,0 +1,116 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit, TrashCan } from '@carbon/react/icons';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid, useInlineEdit } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+import { getInlineEditColumns } from '../../utils/getInlineEditColumns';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/InlineEdit`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+};
+
+const InlineEditUsage = ({ ...args }) => {
+  const [data, setData] = useState(makeData(10));
+  const columns = React.useMemo(() => getInlineEditColumns(), []);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      onDataUpdate: setData,
+      ...args.defaultGridProps,
+    },
+    useInlineEdit
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const InlineEditTemplateWrapper = ({ ...args }) => {
+  return <InlineEditUsage defaultGridProps={{ ...args }} />;
+};
+
+const inlineEditUsageControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+};
+const basicUsageStoryName = 'With inline edit';
+export const InlineEditUsageStory = prepareStory(InlineEditTemplateWrapper, {
+  storyName: basicUsageStoryName,
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+  },
+  args: {
+    ...inlineEditUsageControlProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
@@ -64,6 +64,10 @@ $row-heights: (
   }
 }
 
+.#{variables.$block-class} {
+  --#{variables.$block-class}--grid-header-height: 0;
+}
+
 .#{variables.$block-class}__inline-edit-cell {
   display: flex;
   height: 100%;
@@ -249,7 +253,9 @@ $row-heights: (
   bottom: 0;
   left: 0;
   width: 2px;
-  height: calc(100% - 50px);
+  height: calc(
+    100% - 50px - var(--#{variables.$block-class}--grid-header-height)
+  );
   background-color: $link-inverse;
   content: '';
 }
@@ -261,15 +267,16 @@ $row-heights: (
   right: 0;
   bottom: 0;
   width: 2px;
-  height: calc(100% - 50px);
+  height: calc(
+    100% - 50px - var(--#{variables.$block-class}--grid-header-height)
+  );
   background-color: $link-inverse;
   content: '';
 }
 
 .#{variables.$block-class}
   .#{variables.$block-class}__grid-container-grid-active
-  .#{variables.$block-class}__table-grid-active
-  thead::before {
+  .#{c4p-settings.$carbon-prefix}--data-table-content::before {
   position: absolute;
   z-index: 2;
   top: 0;
@@ -284,7 +291,9 @@ $row-heights: (
   .#{variables.$block-class}__grid-container-grid-active.#{variables.$block-class}__grid-container-grid-active--without-toolbar::before,
 .#{variables.$block-class}
   .#{variables.$block-class}__grid-container-grid-active.#{variables.$block-class}__grid-container-grid-active--without-toolbar::after {
-  height: calc(100% - 2px);
+  height: calc(
+    100% - 2px - var(--#{variables.$block-class}--grid-header-height)
+  );
 }
 
 .#{variables.$block-class}
@@ -292,6 +301,12 @@ $row-heights: (
   .#{variables.$block-class}__table-container {
   outline: 2px solid $link-inverse;
   outline-offset: -2px;
+}
+
+.#{variables.$block-class}
+  .#{variables.$block-class}__grid-container-inline-edit
+  .#{variables.$block-class}__table-container {
+  padding-top: $spacing-01;
 }
 
 .#{variables.$block-class}

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.mdx
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.mdx
@@ -45,7 +45,7 @@ items: {
             title: 'file1.pdf',
             fileType: 'pdf',
             size: '100',
-            icon: Document16, // designates if an icon should be displayed. While similar to avatar icon, both have different displays.
+            icon: Document, // designates if an icon should be displayed. While similar to avatar icon, both have different displays.
             tag: 'business',
             avatar: { // designates if an avatar should be displayed
               alt: 'alt text',

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -52,6 +52,7 @@ const s = [
               'c/Datagrid/Extensions/NestedRows',
               'c/Datagrid/Extensions/ColumnAlignment',
               'c/Datagrid/Extensions/ClickableRow',
+              'c/Datagrid/Extensions/InlineEdit',
             ],
           },
         ],


### PR DESCRIPTION
Contributes to #2270

This PR adds a new extension directory in storybook for the datagrid component for `InlineEdit`. While working on this, I found a few css issues with the focus region outlines which I've also provided fixes for.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useInlineEdit.scss
packages/core/story-structure.js
```
#### How did you test and verify your work?
Storybook