### PR TITLE
chore(Datagrid): create customize columns storybook extension (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
+++ b/packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
@@ -484,7 +484,7 @@ button.#{$block-class}__global-filter-toggle {
   margin-top: $spacing-03;
 }
 
-.#{$carbon-prefix}--tooltip,
-.#{$carbon-prefix}--overflow-menu-options {
+.#{$block-class} .#{$carbon-prefix}--tooltip,
+.#{$block-class} .#{$carbon-prefix}--overflow-menu-options {
   z-index: 9000;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -22,15 +22,12 @@ import {
   useSelectRows,
   useSortableColumns,
   useDisableSelectRows,
-  useCustomizeColumns,
   useSelectAllWithToggle,
   useStickyColumn,
   useActionsColumn,
-  useColumnOrder,
 } from '.';
 
 import {
-  CustomizeColumnStory,
   RowSizeDropdownStory,
   SelectAllWitHToggle,
   LeftPanelStory,
@@ -421,60 +418,6 @@ export const SelectItemsInAllPages = () => {
   );
 };
 SelectItemsInAllPages.story = SelectAllWitHToggle;
-
-export const CustomizingColumns = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
-  const [data] = useState(makeData(10));
-  const datagridState = useDatagrid(
-    {
-      columns,
-      className: `c4p--datagrid__hidden--columns`,
-      data,
-      initialState: {
-        hiddenColumns: ['age'],
-        columnOrder: [],
-      },
-      customizeColumnsProps: {
-        onSaveColumnPrefs: (newColDefs) => {
-          console.log(newColDefs);
-        },
-        labels: {
-          findColumnPlaceholderLabel: 'Find column',
-          resetToDefaultLabel: 'Reset to default',
-          customizeModalHeadingLabel: 'Customize display',
-          primaryButtonTextLabel: 'Save',
-          secondaryButtonTextLabel: 'Cancel',
-          instructionsLabel:
-            'Deselect columns to hide them. Click and drag the white box to reorder the columns. These specifications will be saved and persist if you leave and return to the data table.',
-          iconTooltipLabel: 'Customize columns',
-          assistiveTextInstructionsLabel:
-            'Press space bar to toggle drag drop mode, use arrow keys to move selected elements.',
-          assistiveTextDisabledInstructionsLabel:
-            'Reordering columns are disabled because they are filtered currently.',
-          selectAllLabel: 'Column name',
-        },
-      },
-      DatagridActions,
-      DatagridBatchActions,
-    },
-    useCustomizeColumns,
-    useColumnOrder
-  );
-
-  return (
-    <>
-      <Datagrid datagridState={{ ...datagridState }} />
-      <div>
-        Hidden column ids:
-        <pre>{JSON.stringify(datagridState.state.hiddenColumns, null, 2)}</pre>
-      </div>
-      <p>
-        More details in the <strong>Notes</strong> section
-      </p>
-    </>
-  );
-};
-CustomizingColumns.story = CustomizeColumnStory;
 
 export const RowSizeDropdown = () => {
   const columns = React.useMemo(

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -27,11 +27,7 @@ import {
   useActionsColumn,
 } from '.';
 
-import {
-  RowSizeDropdownStory,
-  SelectAllWitHToggle,
-  LeftPanelStory,
-} from './Datagrid.stories';
+import { SelectAllWitHToggle, LeftPanelStory } from './Datagrid.stories';
 import mdx from './Datagrid.mdx';
 
 import { pkg } from '../../settings';
@@ -418,59 +414,6 @@ export const SelectItemsInAllPages = () => {
   );
 };
 SelectItemsInAllPages.story = SelectAllWitHToggle;
-
-export const RowSizeDropdown = () => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader.slice(0, 3),
-      {
-        Header: 'Different cell content',
-        id: 'rowSizeDemo-cell',
-        disableSortBy: true,
-        Cell: ({ rowSize }) => rowSize,
-      },
-    ],
-    []
-  );
-  const [data] = useState(makeData(10));
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      rowSize: 'xs',
-      rowSizes: [
-        {
-          value: 'xl',
-          labelText: 'More than super',
-        },
-        {
-          value: 'lg',
-          labelText: 'Super tall row',
-        },
-        {
-          value: 'md',
-        },
-        {
-          value: 'xs',
-          labelText: 'Teeny tiny row',
-        },
-      ],
-      onRowSizeChange: (value) => {
-        console.log('row size changed to: ', value);
-      },
-      DatagridActions,
-      DatagridBatchActions,
-    },
-    useSelectRows
-  );
-
-  return (
-    <Wrapper>
-      <Datagrid datagridState={{ ...datagridState }} />
-    </Wrapper>
-  );
-};
-RowSizeDropdown.story = RowSizeDropdownStory;
 
 export const LeftPanel = () => {
   const columns = React.useMemo(() => defaultHeader, []);

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -176,7 +176,10 @@ DatagridContent.propTypes = {
       PropTypes.element,
       PropTypes.func,
     ]),
-    CustomizeColumnsModal: PropTypes.element,
+    CustomizeColumnsModal: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.func,
+    ]),
     isFetching: PropTypes.bool,
     leftPanel: PropTypes.object,
     fullHeightDatagrid: PropTypes.bool,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/ButtonWrapper.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/ButtonWrapper.js
@@ -41,6 +41,10 @@ const ButtonWrapper = ({
   );
 };
 
+ButtonWrapper.defaultProps = {
+  onClick: () => {},
+};
+
 ButtonWrapper.propTypes = {
   iconTooltipLabel: PropTypes.string,
   isModalOpen: PropTypes.bool.isRequired,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -16,7 +16,7 @@ import update from 'immutability-helper';
 import { pkg } from '../../../../../settings';
 import DraggableElement from '../../DraggableElement';
 import { isColumnVisible } from './common';
-import classNames from 'classnames';
+import cx from 'classnames';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -96,22 +96,17 @@ const Columns = ({
           </span>
           <div
             id={`${blockClass}__customize-columns-select-all`}
-            className={classNames(
-              {
-                [`${blockClass}__customize-columns-select-all`]:
-                  getVisibleColumnsCount() === 0,
-                [`${blockClass}__customize-columns-select-all-selected`]:
-                  getVisibleColumnsCount() > 0,
-              }
-
-              // `${blockClass}__customize-columns-select-all`,
-            )}
+            className={cx({
+              [`${blockClass}__customize-columns-select-all`]:
+                getVisibleColumnsCount() === 0,
+              [`${blockClass}__customize-columns-select-all-selected`]:
+                getVisibleColumnsCount() > 0,
+            })}
             selected={getVisibleColumnsCount() > 0}
           >
             <Checkbox
-              wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
+              className={`${blockClass}__customize-columns-checkbox-wrapper`}
               checked={getVisibleColumnsCount() === columns.length}
-              empty={!!getVisibleColumnsCount() === 0}
               indeterminate={
                 getVisibleColumnsCount() < columns.length &&
                 getVisibleColumnsCount() > 0
@@ -166,13 +161,15 @@ const Columns = ({
                 selected={isColumnVisible(colDef)}
               >
                 <Checkbox
-                  wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
+                  className={cx(
+                    `${blockClass}__customize-columns-checkbox-wrapper`,
+                    `${blockClass}__customize-columns-checkbox`
+                  )}
                   checked={isColumnVisible(colDef)}
                   onChange={onSelectColumn.bind(null, colDef)}
                   id={`${blockClass}__customization-column-${colDef.id}`}
                   labelText={colDef.Header.props.title}
                   title={colDef.Header.props.title}
-                  className={`${blockClass}__customize-columns-checkbox`}
                 />
               </DraggableElement>
             ))}

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsModal.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsModal.js
@@ -112,7 +112,6 @@ const CustomizeColumnsModal = ({
       onRequestClose={onRequestClose}
       onRequestSubmit={onRequestSubmit}
       size="sm"
-      hasForm
     >
       <div className={`${blockClass}__customize-columns-instructions`}>
         {instructionsLabel}

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -1,0 +1,239 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Edit, TrashCan } from '@carbon/react/icons';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import {
+  Datagrid,
+  useDatagrid,
+  useCustomizeColumns,
+  useColumnOrder,
+} from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { DatagridPagination } from '../../utils/DatagridPagination';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+import { CodeSnippet } from '@carbon/react';
+import { pkg } from '../../../../settings';
+
+export default {
+  title: `${getStoryTitle(
+    Datagrid.displayName
+  )}/Extensions/ColumnCustomization`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const blockClass = `${pkg.prefix}--datagrid`;
+
+const defaultHeader = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    width: 60,
+  },
+  {
+    Header: 'Someone 1',
+    accessor: 'someone1',
+  },
+  {
+    Header: 'Someone 2',
+    accessor: 'someone2',
+  },
+  {
+    Header: 'Someone 3',
+    accessor: 'someone3',
+  },
+  {
+    Header: 'Someone 4',
+    accessor: 'someone4',
+  },
+  {
+    Header: 'Someone 5',
+    accessor: 'someone5',
+  },
+  {
+    Header: 'Someone 6',
+    accessor: 'someone6',
+  },
+  {
+    Header: 'Someone 7',
+    accessor: 'someone7',
+  },
+  {
+    Header: 'Someone 8',
+    accessor: 'someone8',
+  },
+  {
+    Header: 'Someone 9',
+    accessor: 'someone9',
+  },
+  {
+    Header: 'Someone 10',
+    accessor: 'someone10',
+  },
+];
+
+const sharedDatagridProps = {
+  emptyStateTitle: 'Empty state title',
+  emptyStateDescription: 'Description text explaining why table is empty',
+  emptyStateSize: 'lg',
+  gridTitle: 'Data table title',
+  gridDescription: 'Additional information if needed',
+  useDenseHeader: false,
+  rowSize: 'lg',
+  rowSizes: [
+    {
+      value: 'xl',
+      labelText: 'Extra large',
+    },
+    {
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'md',
+      labelText: 'Medium',
+    },
+    {
+      value: 'xs',
+      labelText: 'Small',
+    },
+  ],
+  onRowSizeChange: (value) => {
+    console.log('row size changed to: ', value);
+  },
+  rowActions: [
+    {
+      id: 'edit',
+      itemText: 'Edit',
+      icon: Edit,
+      onClick: action('Clicked row action: edit'),
+    },
+
+    {
+      id: 'delete',
+      itemText: 'Delete',
+      icon: TrashCan,
+      isDelete: true,
+      onClick: action('Clicked row action: delete'),
+    },
+  ],
+  customizeColumnsProps: {
+    onSaveColumnPrefs: (newColDefs) => {
+      console.log(newColDefs);
+    },
+    labels: {
+      findColumnPlaceholderLabel: 'Find column',
+      resetToDefaultLabel: 'Reset to default',
+      customizeModalHeadingLabel: 'Customize display',
+      primaryButtonTextLabel: 'Save',
+      secondaryButtonTextLabel: 'Cancel',
+      instructionsLabel:
+        'Deselect columns to hide them. Click and drag the white box to reorder the columns. These specifications will be saved and persist if you leave and return to the data table.',
+      iconTooltipLabel: 'Customize columns',
+      assistiveTextInstructionsLabel:
+        'Press space bar to toggle drag drop mode, use arrow keys to move selected elements.',
+      assistiveTextDisabledInstructionsLabel:
+        'Reordering columns are disabled because they are filtered currently.',
+      selectAllLabel: 'Column name',
+    },
+  },
+};
+
+const ColumnCustomizationUsage = ({ ...args }) => {
+  const columns = React.useMemo(() => defaultHeader, []);
+  const [data] = useState(makeData(10));
+
+  const datagridState = useDatagrid(
+    {
+      className: `c4p--datagrid__hidden--columns`,
+      columns,
+      data,
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+        hiddenColumns: ['age'],
+        columnOrder: [],
+      },
+      DatagridActions,
+      DatagridPagination,
+      ...args.defaultGridProps,
+    },
+    useCustomizeColumns,
+    useColumnOrder
+  );
+
+  return (
+    <>
+      <Datagrid datagridState={datagridState} />
+      <div className={`${blockClass}-story__hidden-column-id-snippet`}>
+        <p>Hidden column ids:</p>
+        <CodeSnippet type="multi">
+          {JSON.stringify(datagridState.state.hiddenColumns, null, 2)}
+        </CodeSnippet>
+      </div>
+    </>
+  );
+};
+
+const ColumnCustomizationWrapper = ({ ...args }) => {
+  return <ColumnCustomizationUsage defaultGridProps={{ ...args }} />;
+};
+
+const columnCustomizationControlProps = {
+  gridTitle: sharedDatagridProps.gridTitle,
+  gridDescription: sharedDatagridProps.gridDescription,
+  useDenseHeader: sharedDatagridProps.useDenseHeader,
+  customizeColumnsProps: sharedDatagridProps.customizeColumnsProps,
+};
+const columnCustomizationStoryName = 'With column customization';
+export const ColumnCustomizationUsageStory = prepareStory(
+  ColumnCustomizationWrapper,
+  {
+    storyName: columnCustomizationStoryName,
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      customizeColumnsProps: ARG_TYPES.customizeColumnsProps,
+    },
+    args: {
+      ...columnCustomizationControlProps,
+    },
+  }
+);

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -93,3 +93,7 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.#{$block-class}-story__hidden-column-id-snippet {
+  padding-top: $spacing-07;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsModal.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsModal.scss
@@ -65,6 +65,7 @@
 .#{variables.$block-class}__customize-columns-select-all {
   display: flex;
   height: $spacing-09;
+  align-items: center;
   padding-left: $spacing-08;
   border-bottom: 1px solid $layer-active;
   background-color: $layer-01;
@@ -75,6 +76,7 @@
 .#{variables.$block-class}__customize-columns-select-all-selected {
   display: flex;
   height: $spacing-09;
+  align-items: center;
   padding-left: $spacing-08;
   border-bottom: 1px solid $layer-active;
   background-color: $layer-selected-01;

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
@@ -75,4 +75,9 @@ export const ARG_TYPES = {
     description:
       'This value controls the height of the expanded content area. _This value is set/passed inside of the `datagridState` object._',
   },
+  customizeColumnsProps: {
+    control: 'object',
+    description:
+      'This is an object containing all of the props used with the column customization extension. _This value is set/passed inside of the `datagridState` object._',
+  },
 };

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -53,6 +53,7 @@ const s = [
               'c/Datagrid/Extensions/ColumnAlignment',
               'c/Datagrid/Extensions/ClickableRow',
               'c/Datagrid/Extensions/InlineEdit',
+              'c/Datagrid/Extensions/ColumnCustomization',
             ],
           },
         ],


### PR DESCRIPTION
Contributes to #2270 

Adds column customization storybook directory for datagrid component.
![Screen Shot 2022-10-04 at 9 41 59 AM](https://user-images.githubusercontent.com/10215203/193835209-0119fa8e-53a4-404a-a6cb-748e0180b6d8.png)

#### What did you change?
```
packages/cloud-cognitive/src/components/AddSelect/_add-select.scss
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/ButtonWrapper.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsModal.js
packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsModal.scss
packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
packages/core/story-structure.js
```
#### How did you test and verify your work?
Storybook and ran tests