### PR TITLE
chore: add inline edit v2 tests

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -158,7 +158,7 @@ export let InlineEditV2 = forwardRef(
                 kind="ghost"
                 tabIndex={0}
                 key="cancel"
-                className={`${blockClass}__btn`}
+                className={`${blockClass}__btn ${blockClass}__btn-cancel`}
               />
               {canSave && (
                 <Button
@@ -170,14 +170,14 @@ export let InlineEditV2 = forwardRef(
                   kind="ghost"
                   tabIndex={0}
                   key="save"
-                  className={`${blockClass}__btn`}
+                  className={`${blockClass}__btn ${blockClass}__btn-save`}
                   disabled={!canSave}
                 />
               )}
             </>
           ) : (
             <Button
-              className={cx(`${blockClass}__btn`, `${blockClass}__btn-edit`)}
+              className={`${blockClass}__btn ${blockClass}__btn-edit`}
               hasIconOnly
               renderIcon={readOnly ? EditOff24 : Edit24}
               size="sm"
@@ -203,14 +203,50 @@ InlineEditV2 = pkg.checkComponentEnabled(InlineEditV2, componentName);
 InlineEditV2.displayName = componentName;
 
 InlineEditV2.propTypes = {
+  /**
+   * label for cancel button
+   */
   cancelLabel: PropTypes.string.isRequired,
+  /**
+   * label for edit button
+   */
   editLabel: PropTypes.string.isRequired,
+  /**
+   * determines if the input is invalid
+   */
   invalid: PropTypes.bool,
+  /**
+   * text that is displayed if the input is invalid
+   */
   invalidLabel: PropTypes.string,
+  /**
+   * handler that is called when the cancel button is pressed or when the user removes focus from the input and there is no new value
+   */
   onCancel: PropTypes.func.isRequired,
+  /**
+   * handler that is called when the input is updated
+   */
   onChange: PropTypes.func.isRequired,
+  /**
+   * handler that is called when the save button is pressed or when the user removes focus from the input if it has a new value
+   */
   onSave: PropTypes.func.isRequired,
+  /**
+   * determines if the input is in readOnly mode
+   */
   readOnly: PropTypes.bool,
+  /**
+   * label for save button
+   */
   saveLabel: PropTypes.string.isRequired,
+  /**
+   * current value of the input
+   */
   value: PropTypes.string.isRequired,
+};
+
+InlineEditV2.defaultProps = {
+  invalid: false,
+  invalidLabel: '',
+  readOnly: false,
 };

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.mdx
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.mdx
@@ -1,0 +1,24 @@
+import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
+import {
+  getStoryId,
+  CodesandboxLink,
+} from '../../global/js/utils/story-helper';
+import { InlineEditV2 } from '.';
+
+# InlineEditV2
+
+[Usage guidelines](#)
+
+## Example usage
+
+<Canvas>
+  <Story id={getStoryId(InlineEditV2.displayName, 'default')} />
+</Canvas>
+
+## Code sample
+
+<CodesandboxLink exampleDirectory="InlineEditV2" />
+
+## Component API
+
+<ArgsTable />

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.test.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.test.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InlineEditV2 } from '.';
+
+const componentName = InlineEditV2.displayName;
+
+const defaultProps = {
+  cancelLabel: 'Cancel',
+  editLabel: 'Edit',
+  invalid: false,
+  invalidLabel: 'This field is required',
+  onCancel: () => {},
+  onChange: () => {},
+  onSave: () => {},
+  readOnly: false,
+  saveLabel: 'Save',
+  value: 'default',
+};
+
+describe(componentName, () => {
+  it('renders InlineEditV2', () => {
+    render(<InlineEditV2 {...defaultProps} />);
+  });
+
+  it('renders in readOnly mode', () => {
+    render(<InlineEditV2 {...defaultProps} readOnly />);
+    const input = screen.getByDisplayValue(defaultProps.value);
+    expect(input).toHaveAttribute('readOnly');
+
+    // for coverage
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+  });
+
+  it('renders in invalid mode', () => {
+    render(<InlineEditV2 {...defaultProps} invalid />);
+    const input = screen.getByDisplayValue(defaultProps.value);
+    userEvent.click(input);
+    expect(screen.getByText(defaultProps.invalidLabel)).toBeVisible();
+  });
+
+  it('focuses the input when the component is clicked', () => {
+    render(<InlineEditV2 {...defaultProps} />);
+    const input = screen.getByDisplayValue(defaultProps.value);
+    userEvent.click(input);
+    expect(screen.getByLabelText(defaultProps.cancelLabel)).toBeVisible();
+  });
+
+  it('focuses the input when the edit button is clicked', () => {
+    render(<InlineEditV2 {...defaultProps} />);
+    const editBtn = screen.getByLabelText(defaultProps.editLabel);
+    userEvent.click(editBtn);
+    expect(screen.getByLabelText(defaultProps.cancelLabel)).toBeVisible();
+  });
+
+  it('handles onChange', () => {
+    const onChange = jest.fn();
+    const props = {
+      ...defaultProps,
+      onChange,
+    };
+    render(<InlineEditV2 {...props} />);
+    const input = screen.getByDisplayValue(props.value);
+    fireEvent.change(input, {
+      target: { value: 'new value' },
+    });
+    expect(onChange).toHaveBeenCalledWith('new value');
+
+    // for coverage- dirtyInput check in onChangeHandler
+    fireEvent.change(input, {
+      target: { value: 'new value 2' },
+    });
+  });
+
+  it('handles onSave', async () => {
+    const onSave = jest.fn();
+    const props = {
+      ...defaultProps,
+      onSave,
+    };
+    const { rerender } = render(<InlineEditV2 {...props} />);
+    rerender(<InlineEditV2 {...props} value="new value" />);
+    userEvent.click(screen.getByLabelText(props.editLabel));
+    userEvent.click(screen.getByLabelText(props.saveLabel));
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('handles onCancel', () => {
+    const onCancel = jest.fn();
+    const props = {
+      ...defaultProps,
+      onCancel,
+    };
+    const { rerender } = render(<InlineEditV2 {...props} />);
+    rerender(<InlineEditV2 {...props} value="new value" />);
+    userEvent.click(screen.getByLabelText(props.editLabel));
+    userEvent.click(screen.getByLabelText(props.cancelLabel));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('handles blur save', () => {
+    const onSave = jest.fn();
+    const props = {
+      ...defaultProps,
+      onSave,
+    };
+    const { rerender } = render(<InlineEditV2 {...props} />);
+    rerender(<InlineEditV2 {...props} value="new value" />);
+    userEvent.click(screen.getByLabelText(props.editLabel));
+    const input = screen.getByDisplayValue('new value');
+    fireEvent.blur(input);
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('handles blur cancel', () => {
+    const onCancel = jest.fn();
+    const props = {
+      ...defaultProps,
+      onCancel,
+    };
+    render(<InlineEditV2 {...props} />);
+    userEvent.click(screen.getByLabelText(props.editLabel));
+    const input = screen.getByDisplayValue(props.value);
+    fireEvent.blur(input);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('handles keydown', () => {
+    render(<InlineEditV2 {...defaultProps} />);
+    const input = screen.getByDisplayValue(defaultProps.value);
+
+    // for coverage- default switch statement case
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'M' });
+  });
+
+  it('handles escape key', () => {
+    const onCancel = jest.fn();
+    const props = {
+      ...defaultProps,
+      onCancel,
+    };
+    const { rerender } = render(<InlineEditV2 {...props} />);
+    const input = screen.getByDisplayValue(props.value);
+
+    // clicks escape without making changes
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+
+    // clicks escape with new value
+    rerender(<InlineEditV2 {...props} value="new value" />);
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('handles enter key', () => {
+    const onSave = jest.fn();
+    const props = {
+      ...defaultProps,
+      onSave,
+    };
+    const { rerender } = render(<InlineEditV2 {...props} />);
+    const input = screen.getByDisplayValue(props.value);
+
+    // clicks enter without making changes
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSave).not.toHaveBeenCalled();
+
+    // clicks enter with new value
+    rerender(<InlineEditV2 {...props} value="new value" />);
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSave).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Contributes to #2341 

adds tests for inline edit v2. code coverage is at 100%

<img width="664" alt="Screen Shot 2022-10-06 at 2 56 00 PM" src="https://user-images.githubusercontent.com/6370760/194406535-612d213e-1cc3-4fe8-a599-f837f344ad51.png">

