### PR TITLE
fix(builds): add script to fix `node_modules` path in sass source maps (v11)

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -36,11 +36,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-s clean build-first build-all",
+    "build": "run-s clean build-first build-all build-css-update-maps",
     "build-all": "run-p 'build:*'",
     "build-first": "copyfiles 'src/**/*.scss' scss -u 1",
     "build:css-dev": "sass --style=expanded --load-path node_modules --load-path ../../node_modules scss:css",
     "build:css-min": "sass --style=compressed --load-path node_modules --load-path ../../node_modules scss/index.scss:css/index.min.css scss/index-full-carbon.scss:css/index-full-carbon.min.css scss/index-without-carbon.scss:css/index-without-carbon.min.css scss/index-without-carbon-released-only.scss:css/index-without-carbon-released-only.min.css",
+    "build-css-update-maps": "node ../../scripts/updateSourceMaps.js",
     "build:js-esm": "cross-env BABEL_ENV=esm yarn build:js:modules -d es",
     "build:js-cjs": "cross-env BABEL_ENV=cjs yarn build:js:modules -d lib",
     "build:js:modules": "babel src --ignore '**/__tests__','**/*.test.js','**/*.stories.js','src/utils/**/*'",

--- a/scripts/updateSourceMaps.js
+++ b/scripts/updateSourceMaps.js
@@ -31,10 +31,10 @@ readdir(
               return;
             }
 
-            // Each instance of `../../../node_modules` should be changed to `../../node_modules`
+            // Each instance of `../../../node_modules` should be changed to `../../../../node_modules`
             const updatedMap = fileContents
               .split('../../../node_modules/')
-              .join('../../node_modules/');
+              .join('../../../../node_modules/');
 
             writeFile(
               path.join(__dirname, `../packages/cloud-cognitive/css/${file}`),

--- a/scripts/updateSourceMaps.js
+++ b/scripts/updateSourceMaps.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { readFile, writeFile, readdir } = require('fs');
+const path = require('path');
+
+// Our project setup, as a monorepo, has introduced relative path issues in our
+// sass source maps. Changing the relative path each source map uses to find
+// the correct node_module directory fixes this issue.
+readdir(
+  path.join(__dirname, '../packages/cloud-cognitive/css'),
+  (err, files) => {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    files.forEach((file) => {
+      if (file.endsWith('.map')) {
+        readFile(
+          path.join(__dirname, `../packages/cloud-cognitive/css/${file}`),
+          'utf-8',
+          (err, fileContents) => {
+            if (err) {
+              console.log(err);
+              return;
+            }
+
+            // Each instance of `../../../node_modules` should be changed to `../../node_modules`
+            const updatedMap = fileContents
+              .split('../../../node_modules/')
+              .join('../../node_modules/');
+
+            writeFile(
+              path.join(__dirname, `../packages/cloud-cognitive/css/${file}`),
+              updatedMap,
+              'utf-8',
+              (err) => {
+                if (err) {
+                  console.log(err);
+                  return;
+                }
+                return;
+              }
+            );
+          }
+        );
+      }
+    });
+  }
+);


### PR DESCRIPTION
Contributes to #1864 

This PR includes a script that changes the relative path to the `node_modules` directory in each of the sass source maps (ie `.css.map` files) which fixes the path used within the map files themselves.

#### What did you change?
```
packages/cloud-cognitive/package.json
scripts/updateSourceMaps.js
```
#### How did you test and verify your work?
To test this change, I ran the build script from `packages/cloud-cognitive` which now includes a new script `"build-css-update-maps": node ../../scripts/updateSourceMaps.js` which is run after the source maps are created. This script changes the path to `node_modules` inside of each map file. After that was run, I copied over the generated `css` directory into a sample app that uses our package. Then I ran `react-scripts build` in the sample app and no longer see source map errors anymore.