### PR TITLE
fix(Datagrid): get default table height for inifinite scroll fn (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/useInfiniteScroll.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useInfiniteScroll.js
@@ -15,7 +15,10 @@ const useInfiniteScroll = (hooks) => {
   useResizeTable(hooks);
 
   const useInstance = (instance) => {
-    const { isFetching, tableHeight, innerListRef, fetchMoreData } = instance;
+    const { isFetching, tableHeight, innerListRef, fetchMoreData, tableId } =
+      instance;
+    const tableElement = document.querySelector(`#${tableId}`);
+    const totalTableHeight = tableHeight || tableElement?.clientHeight;
 
     const loadMoreThreshold = 200;
 
@@ -33,7 +36,7 @@ const useInfiniteScroll = (hooks) => {
         if (
           !isFetching &&
           scrollDirection === 'forward' &&
-          scrollOffset + tableHeight >=
+          scrollOffset + totalTableHeight >=
             innerListRef.current.clientHeight - loadMoreThreshold
         ) {
           if (fetchMoreData) {


### PR DESCRIPTION
Contributes to #2355 

Fixed this issue by making sure that `tableHeight` is actually receiving a value. This is what was preventing the `fetchMoreData` function from being called.

#### What did you change?
`useInfiniteScroll`
#### How did you test and verify your work?
Storybook