### PR TITLE
feat(EditUpdateCards): Edit and update cards - v11

### DIFF
--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Import portions of React that are needed.
+import React from 'react';
+
+// Other standard imports.
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pkg /*, carbon */ } from '../../settings';
+import { ProductiveCard } from '../ProductiveCard';
+// import { children } from 'cheerio/lib/api/traversing';
+
+// Carbon and package components we use.
+/* TODO: @import(s) of carbon components and other package components. */
+
+// The block part of our conventional BEM class names (blockClass__E--M).
+const blockClass = `${pkg.prefix}--edit-update-cards`;
+const componentName = 'EditUpdateCards';
+
+// NOTE: the component SCSS is not imported here: it is rolled up separately.
+
+// Default values can be included here and then assigned to the prop params,
+// e.g. prop = defaults.prop,
+// This gathers default values together neatly and ensures non-primitive
+// values are initialized early to avoid react making unnecessary re-renders.
+// Note that default values are not required for props that are 'required',
+// nor for props where the component can apply undefined values reasonably.
+// Default values should be provided when the component needs to make a choice
+// or assumption when a prop is not supplied.
+
+// Default values for props
+// const defaults = {
+//   /* TODO: add defaults for relevant props if needed */
+// };
+
+/**
+ * TODO: A description of the component.
+ */
+
+export let EditUpdateCards = React.forwardRef(
+  (
+    {
+      // The component props, in alphabetical order (for consistency).
+      actionIcons,
+      actionsPlacement,
+      className,
+      description,
+      editChildren,
+      editMode,
+      label,
+      previewChildren,
+      title,
+      titleSize,
+      // Collect any other property values passed in.
+      ...rest
+    },
+    ref
+  ) => {
+    // const [editMode, setEditMode] = useState(false);
+
+    return (
+      <div
+        {
+          // Pass through any other property values as HTML attributes.
+          ...rest
+        }
+        className={cx(
+          blockClass, // Apply the block class to the main HTML element
+          className, // Apply any supplied class names to the main HTML element.
+          // example: `${blockClass}__template-string-class-${kind}-n-${size}`,
+          {
+            // switched classes dependant on props or state
+            // example: [`${blockClass}__here-if-small`]: size === 'sm',
+            [`${blockClass}__actions-bottom`]: actionsPlacement === 'bottom',
+          }
+        )}
+        ref={ref}
+        role="main"
+        {...getDevtoolsProps(componentName)}
+      >
+        <ProductiveCard
+          actionIcons={actionIcons}
+          actionsPlacement={actionsPlacement}
+          className={className}
+          description={description}
+          label={label}
+          title={title}
+          titleSize={titleSize}
+        >
+          {editMode === false && <div>{previewChildren}</div>}
+          {editMode && <div>{editChildren}</div>}
+        </ProductiveCard>
+      </div>
+    );
+  }
+);
+
+// Return a placeholder if not released and not enabled by feature flag
+EditUpdateCards = pkg.checkComponentEnabled(EditUpdateCards, componentName);
+
+// The display name of the component, used by React. Note that displayName
+// is used in preference to relying on function.name.
+EditUpdateCards.displayName = componentName;
+
+// The types and DocGen commentary for the component props,
+// in alphabetical order (for consistency).
+// See https://www.npmjs.com/package/prop-types#usage.
+EditUpdateCards.propTypes = {
+  /**
+   * Icons that are displayed on card. Refer to design documentation for implementation guidelines
+   */
+  actionIcons: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+      onKeyDown: PropTypes.func,
+      onClick: PropTypes.func,
+      iconDescription: PropTypes.string,
+      href: PropTypes.string,
+    })
+  ),
+  /**
+   * Determines if the action icons are on the top or bottom of the card
+   */
+  actionsPlacement: PropTypes.oneOf(['top', 'bottom']),
+  /**
+   * Optional label for the top of the card.
+   */
+  className: PropTypes.string,
+  /**
+   * Optional header description
+   */
+  description: PropTypes.string,
+  /**
+   * Edit mode children
+   */
+  editChildren: PropTypes.node,
+  /**
+   * Edit mode
+   */
+  editMode: PropTypes.bool,
+  /**
+   * Optional label for the top of the card
+   */
+  label: PropTypes.string,
+  /**
+   * Preview mode children
+   */
+  previewChildren: PropTypes.node,
+  /**
+   * Title that's displayed at the top of the card
+   */
+  title: PropTypes.string,
+  /**
+   * Determines title size
+   */
+  titleSize: PropTypes.oneOf(['default', 'large']),
+  /* TODO: add types and DocGen for all props. */
+};

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.mdx
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.mdx
@@ -1,0 +1,34 @@
+import { Story, ArgsTable, Source, Canvas } from '@storybook/addon-docs';
+import {
+  getStoryId,
+  CodesandboxLink,
+} from '../../global/js/utils/story-helper';
+import { EditUpdateCards } from '.';
+
+# EditUpdateCards
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Example usage](#example-usage)
+- [Component API](#component-api)
+
+## Overview
+
+<!-- TODO: Overview. -->
+
+## Example usage
+
+<!-- TODO: One example per designed use case. -->
+
+<Canvas>
+  <Story id={getStoryId(EditUpdateCards.displayName, 'edit-update-cards')} />
+</Canvas>
+
+## Code sample
+
+<!-- <CodesandboxLink exampleDirectory="EditUpdateCards" /> -->
+
+## Component API
+
+<ArgsTable />

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.stories.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.stories.js
@@ -1,0 +1,285 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+// TODO: import action to handle events if required.
+// import { action } from '@storybook/addon-actions';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+
+import { EditUpdateCards } from '.';
+import mdx from './EditUpdateCards.mdx';
+
+import styles from './_storybook-styles.scss';
+import {
+  Column,
+  Form,
+  FormLabel,
+  Grid,
+  Select,
+  SelectItem,
+  TextArea,
+  TextInput,
+} from '@carbon/react';
+import {
+  Edit,
+  Save,
+  Close,
+  ProgressBarRound,
+  CheckmarkFilled,
+} from '@carbon/react/icons';
+import { pkg /*, carbon */ } from '../../settings';
+
+export default {
+  title: getStoryTitle(EditUpdateCards.displayName),
+  component: EditUpdateCards,
+  // TODO: Define argTypes for props not represented by standard JS types.
+  // argTypes: {
+  //   egProp: { control: 'color' },
+  // },
+  parameters: {
+    styles,
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const defaultStoryProps = {
+  title: 'Edit and update',
+};
+
+/**
+ * TODO: Declare template(s) for one or more scenarios.
+ */
+const Template = (args) => {
+  const [bodyCopy, setBodyCopy] = useState(
+    'Editable card body content block. description inviting the user to take action on the card.'
+  );
+  const [name, setName] = useState('austin-server-123ABC');
+  const speedOptions = [
+    { value: '0', text: 'Choose speed' },
+    { value: '100', text: '100MBps' },
+    { value: '120', text: '120MBps' },
+    { value: '150', text: '150MBps' },
+    { value: '200', text: '200MBps' },
+  ];
+  const [speedValue, setSpeedValue] = useState('120');
+  const options = speedOptions.map((option) => {
+    return (
+      <SelectItem
+        key={option.value}
+        value={option.value}
+        text={option.text}
+        //  selected={option.value === speedValue}
+      />
+    );
+  });
+  const [editMode, setEditMode] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const onSave = (event) => {
+    event.preventDefault();
+    event.persist();
+    setLoading(true);
+
+    setTimeout(() => {
+      setBodyCopy(event.target.bodyCopy.value);
+      setName(event.target.name.value);
+      setSpeedValue(event.target.speed.value);
+      setEditMode(false);
+      setLoading(false);
+    }, 1000);
+  };
+
+  const actionIcons = [
+    {
+      id: '1',
+      icon: Edit,
+      onClick: () => {
+        setEditMode(true);
+      },
+      iconDescription: 'Edit',
+    },
+  ];
+
+  const actionIconsEditMode = [
+    {
+      id: '2',
+      icon: Close,
+      onClick: () => {
+        setEditMode(false);
+      },
+      iconDescription: 'Cancel',
+    },
+    {
+      id: '3',
+      icon: Save,
+      iconDescription: 'Save',
+      type: 'submit',
+      form: 'editForm',
+    },
+  ];
+
+  const actionIconsLoading = [
+    {
+      id: '4',
+      icon: ProgressBarRound,
+      iconDescription: 'Loading',
+      disabled: true,
+      className: pkg.prefix + '--loading',
+    },
+  ];
+
+  const preview = (
+    <div>
+      <Grid>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Name</FormLabel>
+          <p>{name}</p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Link status</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            <CheckmarkFilled />
+            Running
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Routing</FormLabel>
+          <p>Local</p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>BGP status</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            <CheckmarkFilled />
+            Running
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Location</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            NA-West
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Speed</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            {speedValue}MBps
+          </p>
+        </Column>
+        <Column
+          md={8}
+          sm={4}
+          className={pkg.prefix + `--edit-update-cards--items`}
+        >
+          <FormLabel>Other details</FormLabel>
+          <p>{bodyCopy}</p>
+        </Column>
+      </Grid>
+    </div>
+  );
+
+  const edit = (
+    <Form onSubmit={onSave} id="editForm">
+      <Grid>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <TextInput
+            name="name"
+            labelText="Name"
+            defaultValue={name}
+            id={name}
+          />
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Link status</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            <CheckmarkFilled />
+            Running
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Routing</FormLabel>
+          <p>Local</p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>BGP status</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            <CheckmarkFilled />
+            Running
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <FormLabel>Location</FormLabel>
+          <p className={pkg.prefix + `--edit-update-cards--icon-text`}>
+            NA-West
+          </p>
+        </Column>
+        <Column sm={4} className={pkg.prefix + `--edit-update-cards--items`}>
+          <Select
+            labelText="Speed"
+            name="speed"
+            id={'speed'}
+            defaultValue={speedValue}
+          >
+            {options}
+          </Select>
+        </Column>
+        <Column
+          md={8}
+          sm={4}
+          className={pkg.prefix + `--edit-update-cards--items`}
+        >
+          <TextArea
+            name="bodyCopy"
+            labelText="Other details"
+            rows={2}
+            defaultValue={bodyCopy}
+          />
+        </Column>
+      </Grid>
+    </Form>
+  );
+  return (
+    <Grid>
+      <Column sm={4} md={8}>
+        <EditUpdateCards
+          // TODO: handle events with action or local handler.
+          // onTodo={action('onTodo log action')}
+          actionIcons={
+            editMode && !loading
+              ? actionIconsEditMode
+              : editMode && loading
+              ? actionIconsLoading
+              : actionIcons
+          }
+          previewChildren={preview}
+          editChildren={edit}
+          editMode={editMode}
+          {...args}
+          id={`${
+            editMode ? pkg.prefix + '--edit-update-cards--edit' : ''
+          }`} /*Used id for overriding the SVG(icon) path fill*/
+        />
+      </Column>
+    </Grid>
+  );
+};
+
+/**
+ * TODO: Declare one or more stories, generally one per design scenario.
+ * NB no need for a 'Playground' because all stories have all controls anyway.
+ */
+export const editUpdateCards = prepareStory(Template, {
+  args: {
+    // TODO: Component args - https://storybook.js.org/docs/react/writing-stories/args#EditUpdateCards-args
+    ...defaultStoryProps,
+  },
+});

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
@@ -5,60 +5,61 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
-
-import { pkg } from '../../settings';
-import uuidv4 from '../../global/js/utils/uuidv4';
-
-import { EditUpdateCards } from '.';
-
-const blockClass = `${pkg.prefix}--edit-update-cards`;
-const componentName = EditUpdateCards.displayName;
-
-// values to use
-const children = `hello, world (${uuidv4()})`;
-const className = `class-${uuidv4()}`;
-const dataTestId = uuidv4();
-
-describe(componentName, () => {
-  it('renders a component EditUpdateCards', () => {
-    render(<EditUpdateCards> </EditUpdateCards>);
-    expect(screen.getByRole('main')).toHaveClass(blockClass);
-  });
-
-  it('has no accessibility violations', async () => {
-    const { container } = render(<EditUpdateCards> </EditUpdateCards>);
-    await expect(container).toBeAccessible(componentName);
-    await expect(container).toHaveNoAxeViolations();
-  });
-
-  it(`renders children`, () => {
-    render(<EditUpdateCards>{children}</EditUpdateCards>);
-    screen.getByText(children);
-  });
-
-  it('applies className to the containing node', () => {
-    render(<EditUpdateCards className={className}> </EditUpdateCards>);
-    expect(screen.getByRole('main')).toHaveClass(className);
-  });
-
-  it('adds additional props to the containing node', () => {
-    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
-    screen.getByTestId(dataTestId);
-  });
-
-  it('forwards a ref to an appropriate node', () => {
-    const ref = React.createRef();
-    render(<EditUpdateCards ref={ref}> </EditUpdateCards>);
-    expect(ref.current).toHaveClass(blockClass);
-  });
-
-  it('adds the Devtools attribute to the containing node', () => {
-    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
-
-    expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
-      componentName
-    );
-  });
-});
+ import React from 'react';
+ import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+ 
+ import { pkg } from '../../settings';
+ import uuidv4 from '../../global/js/utils/uuidv4';
+ 
+ import { EditUpdateCards } from '.';
+ 
+ const blockClass = `${pkg.prefix}--edit-update-cards`;
+ const componentName = EditUpdateCards.displayName;
+ 
+ // values to use
+ // const children = `hello, world (${uuidv4()})`;
+ const className = `class-${uuidv4()}`;
+ const dataTestId = uuidv4();
+ 
+ describe(componentName, () => {
+   it('renders a component EditUpdateCards', () => {
+     render(<EditUpdateCards> </EditUpdateCards>);
+     expect(screen.getByRole('main')).toHaveClass(blockClass);
+   });
+ 
+   it('has no accessibility violations', async () => {
+     const { container } = render(<EditUpdateCards> </EditUpdateCards>);
+     await expect(container).toBeAccessible(componentName);
+     await expect(container).toHaveNoAxeViolations();
+   });
+ 
+   // it(`renders children`, () => {
+   //   render(<EditUpdateCards>{children}</EditUpdateCards>);
+   //   screen.getByText(children);
+   // });
+ 
+   it('applies className to the containing node', () => {
+     render(<EditUpdateCards className={className}> </EditUpdateCards>);
+     expect(screen.getByRole('main')).toHaveClass(className);
+   });
+ 
+   it('adds additional props to the containing node', () => {
+     render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+     screen.getByTestId(dataTestId);
+   });
+ 
+   it('forwards a ref to an appropriate node', () => {
+     const ref = React.createRef();
+     render(<EditUpdateCards ref={ref}> </EditUpdateCards>);
+     expect(ref.current).toHaveClass(blockClass);
+   });
+ 
+   it('adds the Devtools attribute to the containing node', () => {
+     render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+ 
+     expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
+       componentName
+     );
+   });
+ });
+ 

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
@@ -5,61 +5,60 @@
  * LICENSE file in the root directory of this source tree.
  */
 
- import React from 'react';
- import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
- 
- import { pkg } from '../../settings';
- import uuidv4 from '../../global/js/utils/uuidv4';
- 
- import { EditUpdateCards } from '.';
- 
- const blockClass = `${pkg.prefix}--edit-update-cards`;
- const componentName = EditUpdateCards.displayName;
- 
- // values to use
- // const children = `hello, world (${uuidv4()})`;
- const className = `class-${uuidv4()}`;
- const dataTestId = uuidv4();
- 
- describe(componentName, () => {
-   it('renders a component EditUpdateCards', () => {
-     render(<EditUpdateCards> </EditUpdateCards>);
-     expect(screen.getByRole('main')).toHaveClass(blockClass);
-   });
- 
-   it('has no accessibility violations', async () => {
-     const { container } = render(<EditUpdateCards> </EditUpdateCards>);
-     await expect(container).toBeAccessible(componentName);
-     await expect(container).toHaveNoAxeViolations();
-   });
- 
-   // it(`renders children`, () => {
-   //   render(<EditUpdateCards>{children}</EditUpdateCards>);
-   //   screen.getByText(children);
-   // });
- 
-   it('applies className to the containing node', () => {
-     render(<EditUpdateCards className={className}> </EditUpdateCards>);
-     expect(screen.getByRole('main')).toHaveClass(className);
-   });
- 
-   it('adds additional props to the containing node', () => {
-     render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
-     screen.getByTestId(dataTestId);
-   });
- 
-   it('forwards a ref to an appropriate node', () => {
-     const ref = React.createRef();
-     render(<EditUpdateCards ref={ref}> </EditUpdateCards>);
-     expect(ref.current).toHaveClass(blockClass);
-   });
- 
-   it('adds the Devtools attribute to the containing node', () => {
-     render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
- 
-     expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
-       componentName
-     );
-   });
- });
- 
+import React from 'react';
+import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+
+import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { EditUpdateCards } from '.';
+
+const blockClass = `${pkg.prefix}--edit-update-cards`;
+const componentName = EditUpdateCards.displayName;
+
+// values to use
+// const children = `hello, world (${uuidv4()})`;
+const className = `class-${uuidv4()}`;
+const dataTestId = uuidv4();
+
+describe(componentName, () => {
+  it('renders a component EditUpdateCards', () => {
+    render(<EditUpdateCards> </EditUpdateCards>);
+    expect(screen.getByRole('main')).toHaveClass(blockClass);
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<EditUpdateCards> </EditUpdateCards>);
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  // it(`renders children`, () => {
+  //   render(<EditUpdateCards>{children}</EditUpdateCards>);
+  //   screen.getByText(children);
+  // });
+
+  it('applies className to the containing node', () => {
+    render(<EditUpdateCards className={className}> </EditUpdateCards>);
+    expect(screen.getByRole('main')).toHaveClass(className);
+  });
+
+  it('adds additional props to the containing node', () => {
+    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    render(<EditUpdateCards ref={ref}> </EditUpdateCards>);
+    expect(ref.current).toHaveClass(blockClass);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+
+    expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
+      componentName
+    );
+  });
+});

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/EditUpdateCards.test.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react'; // https://testing-library.com/docs/react-testing-library/intro
+
+import { pkg } from '../../settings';
+import uuidv4 from '../../global/js/utils/uuidv4';
+
+import { EditUpdateCards } from '.';
+
+const blockClass = `${pkg.prefix}--edit-update-cards`;
+const componentName = EditUpdateCards.displayName;
+
+// values to use
+const children = `hello, world (${uuidv4()})`;
+const className = `class-${uuidv4()}`;
+const dataTestId = uuidv4();
+
+describe(componentName, () => {
+  it('renders a component EditUpdateCards', () => {
+    render(<EditUpdateCards> </EditUpdateCards>);
+    expect(screen.getByRole('main')).toHaveClass(blockClass);
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<EditUpdateCards> </EditUpdateCards>);
+    await expect(container).toBeAccessible(componentName);
+    await expect(container).toHaveNoAxeViolations();
+  });
+
+  it(`renders children`, () => {
+    render(<EditUpdateCards>{children}</EditUpdateCards>);
+    screen.getByText(children);
+  });
+
+  it('applies className to the containing node', () => {
+    render(<EditUpdateCards className={className}> </EditUpdateCards>);
+    expect(screen.getByRole('main')).toHaveClass(className);
+  });
+
+  it('adds additional props to the containing node', () => {
+    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+    screen.getByTestId(dataTestId);
+  });
+
+  it('forwards a ref to an appropriate node', () => {
+    const ref = React.createRef();
+    render(<EditUpdateCards ref={ref}> </EditUpdateCards>);
+    expect(ref.current).toHaveClass(blockClass);
+  });
+
+  it('adds the Devtools attribute to the containing node', () => {
+    render(<EditUpdateCards data-testid={dataTestId}> </EditUpdateCards>);
+
+    expect(screen.getByTestId(dataTestId)).toHaveDevtoolsAttribute(
+      componentName
+    );
+  });
+});

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/_carbon-imports.scss
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/_carbon-imports.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Import any Carbon component styles used from EditUpdateCards in this file.
+// EditUpdateCards uses the following Carbon components:

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/_edit-update-cards.scss
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/_edit-update-cards.scss
@@ -1,0 +1,85 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Standard imports.
+
+// Other Carbon settings.
+// TODO: @import 'carbon-components/scss/globals/grid/grid'; if needed
+@use '@carbon/colors/' as *;
+@use '@carbon/motion/' as *;
+@use '../../global/styles/project-settings' as c4p-settings;
+
+// EditUpdateCards uses the following Carbon components:
+// TODO: @import(s) of Carbon component styles used by EditUpdateCards
+
+// EditUpdateCards uses the following Carbon for IBM Products components:
+// TODO: @import(s) of IBM Products component styles used by EditUpdateCards
+
+// Define all component styles in a mixin which is then exported using
+// the Carbon import-once mechanism.
+/* stylelint-disable max-nesting-depth */
+$block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
+
+.#{$block-class} {
+  &##{$block-class}--edit {
+    /* Used id for overriding the SVG path fill */
+
+    .#{c4p-settings.$pkg-prefix}--card__header,
+    .#{c4p-settings.$pkg-prefix}--card__footer {
+      button {
+        &:hover {
+          // stylelint-disable-next-line carbon/theme-token-use
+          background-color: $blue-60-hover;
+        }
+
+        &:focus {
+          box-shadow: none;
+        }
+
+        svg {
+          path {
+            // stylelint-disable-next-line carbon/theme-token-use
+            fill: $white-0;
+          }
+        }
+
+        &.#{c4p-settings.$pkg-prefix}--loading {
+          &:hover {
+            background-color: transparent;
+          }
+        }
+      }
+    }
+    .#{c4p-settings.$pkg-prefix}--card__footer {
+      // stylelint-disable-next-line carbon/theme-token-use
+      background-color: $blue-60;
+      // stylelint-disable-next-line carbon/theme-token-use
+      color: $white-0;
+    }
+    .#{c4p-settings.$pkg-prefix}--loading {
+      animation-duration: $duration-slow-02;
+      animation-fill-mode: forwards;
+      animation-iteration-count: infinite;
+      animation-name: rotate;
+      animation-timing-function: motion(standard, productive);
+
+      &:hover {
+        background-color: transparent;
+      }
+    }
+  }
+  &:not(.#{$block-class}__actions-bottom) {
+    &##{$block-class}--edit {
+      .#{c4p-settings.$pkg-prefix}--card__header {
+        // stylelint-disable-next-line carbon/theme-token-use
+        background-color: $blue-60;
+        // stylelint-disable-next-line carbon/theme-token-use
+        color: $white-0;
+      }
+    }
+  }
+}

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/_index-with-carbon.scss
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/_index-with-carbon.scss
@@ -1,0 +1,9 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './carbon-imports';
+@use './edit-update-cards';

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/_index.scss
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/_index.scss
@@ -1,0 +1,8 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use './edit-update-cards';

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/_storybook-styles.scss
@@ -1,0 +1,55 @@
+//
+// Copyright IBM Corp. 2022, 2022
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+@use '@carbon/colors/' as *;
+@use '@carbon/type/' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '../../global/styles/project-settings' as c4p-settings;
+
+// make the root full width to get a better idea of how the cards
+// look in a real grid situation
+/* stylelint-disable max-nesting-depth */
+#root {
+  width: 100%;
+}
+
+$block-class: #{c4p-settings.$pkg-prefix}--edit-update-cards;
+
+.#{$block-class} {
+  textarea,
+  input,
+  select {
+    width: 100%;
+    height: auto;
+    padding: 0;
+    // stylelint-disable-next-line
+    font-size: type-scale(3);
+    letter-spacing: 0;
+    // stylelint-disable-next-line carbon/type-token-use
+    line-height: 1.5;
+  }
+}
+.#{$block-class}--items {
+  margin-bottom: $spacing-06;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+.#{$block-class}--icon-text {
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: $spacing-01;
+
+    path {
+      // stylelint-disable-next-line carbon/theme-token-use
+      fill: $green-50;
+    }
+  }
+}

--- a/packages/cloud-cognitive/src/components/EditUpdateCards/index.js
+++ b/packages/cloud-cognitive/src/components/EditUpdateCards/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { EditUpdateCards } from './EditUpdateCards';

--- a/packages/cloud-cognitive/src/components/_index-with-carbon.scss
+++ b/packages/cloud-cognitive/src/components/_index-with-carbon.scss
@@ -45,3 +45,4 @@
 @use './InlineEdit/index-with-carbon' as *;
 @use './DataSpreadsheet/index-with-carbon' as *;
 @use './Datagrid/index-with-carbon' as *;
+@use './EditUpdateCards/index-with-carbon' as *;

--- a/packages/cloud-cognitive/src/components/_index.scss
+++ b/packages/cloud-cognitive/src/components/_index.scss
@@ -48,3 +48,4 @@
 @use './EditTearsheet';
 @use './EditTearsheetNarrow';
 @use './EditFullPage';
+@use './EditUpdateCards';

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -77,3 +77,4 @@ export {
 export { EditTearsheet } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';
 export { EditFullPage } from './EditFullPage';
+export { EditUpdateCards } from './EditUpdateCards';

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -68,6 +68,7 @@ const defaults = {
     EditTearsheet: false,
     EditTearsheetNarrow: false,
     EditFullPage: false,
+    EditUpdateCards: false,
     /* new component flags here - comment used by generate CLI */
   },
 

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -81,6 +81,7 @@ const s = [
               'c/EditTearsheet',
               'c/EditTearsheetNarrow',
               'c/EditFullPage',
+              'c/EditUpdateCards',
             ],
           },
           {


### PR DESCRIPTION
Contributes to #1259 

Editable cards allow a quick way to update assets in C&CS products.

#### What did you change?
- Included the edit and update feature for the "Productive Card".

![image](https://user-images.githubusercontent.com/40118548/196358236-366b955b-11de-4786-867d-3f0555f81728.png)
![image](https://user-images.githubusercontent.com/40118548/196358278-d7f716e6-977e-4619-bb43-635c30039be7.png)

PS: We are waiting for "Expressive Card" edit and update design.

#### How did you test and verify your work?
- Storybook
