### PR TITLE
chore: removes eslint config to fix errors

### DIFF
--- a/examples/carbon-for-ibm-products/APIKeyModal/package.json
+++ b/examples/carbon-for-ibm-products/APIKeyModal/package.json
@@ -40,10 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/AboutModal/package.json
+++ b/examples/carbon-for-ibm-products/AboutModal/package.json
@@ -40,10 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/Cascade/package.json
+++ b/examples/carbon-for-ibm-products/Cascade/package.json
@@ -40,10 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/CreateTearsheet/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheet/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
+++ b/examples/carbon-for-ibm-products/CreateTearsheetNarrow/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/Datagrid/package.json
+++ b/examples/carbon-for-ibm-products/Datagrid/package.json
@@ -40,10 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/EmptyStates/package.json
+++ b/examples/carbon-for-ibm-products/EmptyStates/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/ExportModal/package.json
+++ b/examples/carbon-for-ibm-products/ExportModal/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/ExpressiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ExpressiveCard/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/OptionsTile/package.json
+++ b/examples/carbon-for-ibm-products/OptionsTile/package.json
@@ -40,10 +40,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/ProductiveCard/package.json
+++ b/examples/carbon-for-ibm-products/ProductiveCard/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/RemoveModal/package.json
+++ b/examples/carbon-for-ibm-products/RemoveModal/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/Saving/package.json
+++ b/examples/carbon-for-ibm-products/Saving/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/SidePanel/package.json
+++ b/examples/carbon-for-ibm-products/SidePanel/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/StatusIcon/package.json
+++ b/examples/carbon-for-ibm-products/StatusIcon/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/TagSet/package.json
+++ b/examples/carbon-for-ibm-products/TagSet/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/Tearsheet/package.json
+++ b/examples/carbon-for-ibm-products/Tearsheet/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/UserProfileImage/package.json
+++ b/examples/carbon-for-ibm-products/UserProfileImage/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/WebTerminal/package.json
+++ b/examples/carbon-for-ibm-products/WebTerminal/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }

--- a/examples/carbon-for-ibm-products/ccs-base-react-16/package.json
+++ b/examples/carbon-for-ibm-products/ccs-base-react-16/package.json
@@ -29,12 +29,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/examples/carbon-for-ibm-products/ccs-base-react-17/package.json
+++ b/examples/carbon-for-ibm-products/ccs-base-react-17/package.json
@@ -29,12 +29,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/examples/carbon-for-ibm-products/example-gallery/package.json
+++ b/examples/carbon-for-ibm-products/example-gallery/package.json
@@ -32,12 +32,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/examples/carbon-for-ibm-products/prefix-example/package.json
+++ b/examples/carbon-for-ibm-products/prefix-example/package.json
@@ -39,10 +39,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app"
-    ]
   }
 }


### PR DESCRIPTION
Contributes to #2379 

Removes eslint config since it's no longer needed with react-scripts

#### What did you change?
All package.json inside of `examples/`


