### PR TITLE
feat(Datagrid): allow for customizable virtual height

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -215,6 +215,9 @@ export const InfiniteScroll = () => {
       data,
       isFetching,
       fetchMoreData: fetchData,
+      virtualHeight: 540,
+      emptyStateTitle: 'Empty state title',
+      emptyStateDescription: 'Description explaining why the table is empty',
     },
     useInfiniteScroll
   );

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -37,6 +37,7 @@ const DatagridVirtualBody = (datagridState) => {
     onScroll,
     innerListRef,
     tableHeight = 400,
+    virtualHeight,
     listRef,
     rowSize,
     DatagridPagination,
@@ -59,7 +60,7 @@ const DatagridVirtualBody = (datagridState) => {
   return (
     <TableBody {...getTableBodyProps()} onScroll={onScroll}>
       <VariableSizeList
-        height={tableHeight}
+        height={virtualHeight || tableHeight}
         itemCount={visibleRows.length}
         itemSize={(index) =>
           visibleRows[index].isExpanded


### PR DESCRIPTION
Contributes to #2371 

Adds new property that can be passed inside of the `useDatagrid` hook to customize the height of the virtual table body (used with `useInfiniteScroll` hook).

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
```
#### How did you test and verify your work?
Storybook