### PR TITLE
fix(PageHeader): button alignment logic based on variable value

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -352,7 +352,7 @@ export let PageHeader = React.forwardRef(
       ({ current }) => {
         // on window resize and other updates some values may have changed
         checkUpdateVerticalSpace();
-        setWidthIsNarrow(current.innerWidth < breakpoints.md.width); // small (below medium) media query
+        setWidthIsNarrow(current.innerWidth/16 < parseInt(breakpoints.md.width)); // small (below medium) media query
       },
       [
         actionBarItems,
@@ -755,7 +755,7 @@ export let PageHeader = React.forwardRef(
                   onWidthChange={handleWidthChange}
                   buttons={pageActions}
                   buttonSetOverflowLabel={pageActionsOverflowLabel}
-                  rightAlign
+                  rightAlign={!widthIsNarrow}
                 />
               )}
             </div>


### PR DESCRIPTION
Closes #2262 

The button alignment for the PageHeader component was off because the widthIsNarrow variable was being calculated wrong. The value was calculated based on if the current window width was smaller than the breakpoint. However, breakpoint values were in rem and window values returned in px so the value was almost always false unless the window was realllyyy tiny.

What did you change?
So I just divided the current width value by 16 (convert to rem) and added a parseInt to the breakpoint since it was returning a string so we can evaluate the int value (44rem -> 44)

How did you test and verify your work?
On my local, I checked to see if the rightAlign class was being applied or not based on the window size. It worked uwu