### PR TITLE
fix(SidePanel): address positioning in static version

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -943,10 +943,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--side-panel__container .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation {
   position: fixed;
   z-index: 2;
-  top: calc(
-        var(--c4p--side-panel--title-text-height) +
-          var(--c4p--side-panel--label-text-height) + var(--cds-spacing-09, 3rem)
-      );
+  top: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--label-text-height));
   background-color: var(--cds-ui-01, #f4f4f4);
 }
 .c4p--side-panel__container .c4p--side-panel__subtitle-text.c4p--side-panel__subtitle-text-no-animation.c4p--side-panel__subtitle-text-is-animating {
@@ -961,7 +958,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container .c4p--side-panel__title-container.c4p--side-panel__title-container--no-title-animation {
   position: fixed;
-  top: var(--cds-spacing-09, 3rem);
   height: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--label-text-height));
 }
 .c4p--side-panel__container .c4p--side-panel__inner-content {
@@ -982,10 +978,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--side-panel__container .c4p--side-panel__action-toolbar.c4p--side-panel__action-toolbar-no-animation {
   position: fixed;
-  top: calc(
-        var(--c4p--side-panel--title-text-height) +
-          var(--c4p--side-panel--subtitle-container-height) + var(--cds-spacing-09, 3rem)
-      );
+  top: calc(var(--c4p--side-panel--title-text-height) + var(--c4p--side-panel--subtitle-container-height));
   width: 100%;
   border-bottom: 1px solid var(--cds-decorative-01, #e0e0e0);
 }

--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -204,7 +204,7 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       // stylelint-disable-next-line carbon/layout-token-use
       top: calc(
         var(--#{$block-class}--title-text-height) +
-          var(--#{$block-class}--label-text-height) + #{$spacing-09}
+          var(--#{$block-class}--label-text-height)
       );
       background-color: $ui-01;
     }
@@ -224,7 +224,6 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
 
     .#{$block-class}__title-container.#{$block-class}__title-container--no-title-animation {
       position: fixed;
-      top: $spacing-09;
       height: calc(
         var(--#{$block-class}--title-text-height) +
           var(--#{$block-class}--label-text-height)
@@ -279,7 +278,7 @@ $action-set-block-class: #{$pkg-prefix}--action-set;
       // stylelint-disable-next-line carbon/layout-token-use
       top: calc(
         var(--#{$block-class}--title-text-height) +
-          var(--#{$block-class}--subtitle-container-height) + #{$spacing-09}
+          var(--#{$block-class}--subtitle-container-height)
       );
       width: 100%;
       border-bottom: 1px solid $decorative-01;


### PR DESCRIPTION
Contributes to #2394 

Fixes the positioning of the title, subtitle, and action bar when used in static version of panel. I don't remember the reasoning for the extra spacing being added here, but I checked this change in Chrome, Firefox, and Safari and everything looks to be rendering as expected now.

The issue can be seen [here](https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel--with-static-title).

#### What did you change?
`_side-panel.scss`
#### How did you test and verify your work?
Storybook and updated styles snapshot