### PR TITLE
Inline edit v2 design review

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -161,20 +161,18 @@ export let InlineEditV2 = forwardRef(
                 key="cancel"
                 className={`${blockClass}__btn ${blockClass}__btn-cancel`}
               />
-              {canSave && (
-                <Button
-                  hasIconOnly
-                  renderIcon={Checkmark24}
-                  size="sm"
-                  iconDescription={saveLabel}
-                  onClick={onSaveHandler}
-                  kind="ghost"
-                  tabIndex={0}
-                  key="save"
-                  className={`${blockClass}__btn ${blockClass}__btn-save`}
-                  disabled={!canSave}
-                />
-              )}
+              <Button
+                hasIconOnly
+                renderIcon={Checkmark24}
+                size="sm"
+                iconDescription={saveLabel}
+                onClick={onSaveHandler}
+                kind="ghost"
+                tabIndex={0}
+                key="save"
+                className={`${blockClass}__btn ${blockClass}__btn-save`}
+                disabled={!canSave}
+              />
             </>
           ) : (
             <Button

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -26,6 +26,7 @@ export let InlineEditV2 = forwardRef(
       onChange,
       onSave,
       readOnly,
+      readOnlyLabel,
       saveLabel,
       value,
       ...rest
@@ -180,10 +181,9 @@ export let InlineEditV2 = forwardRef(
               hasIconOnly
               renderIcon={readOnly ? EditOff24 : Edit24}
               size="sm"
-              iconDescription={editLabel}
+              iconDescription={readOnly ? readOnlyLabel : editLabel}
               onClick={onFocusHandler}
               kind="ghost"
-              disabled={readOnly}
               tabIndex={0}
               key="edit"
             />
@@ -234,6 +234,10 @@ InlineEditV2.propTypes = {
    * determines if the input is in readOnly mode
    */
   readOnly: PropTypes.bool,
+  /**
+   * label for the edit button that displays when in read only mode
+   */
+  readOnlyLabel: PropTypes.string,
   /**
    * label for save button
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
@@ -39,6 +39,7 @@ const defaultProps = {
   onChange: () => {},
   onSave: () => {},
   readOnly: false,
+  readOnlyLabel: 'This value is read only',
   saveLabel: 'Save',
   value: 'default',
 };

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
@@ -13,11 +13,13 @@ import {
 import { action } from '@storybook/addon-actions';
 import { InlineEditV2 } from '.';
 import mdx from './InlineEditV2.mdx';
+import styles from './_storybook-styles.scss';
 
 export default {
   title: getStoryTitle(InlineEditV2.displayName),
   component: InlineEditV2,
   parameters: {
+    styles,
     docs: {
       page: mdx,
     },
@@ -67,7 +69,7 @@ const Template = (args) => {
     onCancel,
   };
 
-  return <InlineEditV2 {...props} />;
+  return <InlineEditV2 {...props} className="inline-edit-v2-example" />;
 };
 
 export const Default = prepareStory(Template, {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -46,6 +46,8 @@
     }
 
     &__warning-icon {
+      /* stylelint-disable-next-line carbon/layout-token-use */
+      margin-right: 0.4375rem;
       color: $support-01;
     }
 
@@ -65,7 +67,8 @@
     outline: none;
   }
 
-  .#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-text-input} {
+  .#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-text-input},
+  .#{$block-class}-readonly .bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
     cursor: not-allowed;
   }
 

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -25,7 +25,7 @@
     }
 
     &:hover {
-      background: $hover-ui;
+      background: $field-01;
     }
 
     &:hover .#{$block-class}__btn-edit {
@@ -37,7 +37,7 @@
     }
 
     &-focused {
-      background: $hover-ui;
+      background: $field-01;
       outline: 2px solid $focus;
     }
 

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_storybook-styles.scss
@@ -1,0 +1,3 @@
+.inline-edit-v2-example {
+  width: 15rem;
+}


### PR DESCRIPTION
Contributes to #2342

address a few design issues pointed out during the review

* save button is now always visible but when a change hasn't been made it remain disabled
* a tooltip has been added to the edit button in read only mode
* some color issues have been addressed
* a width has been added to the storybook story to prevent width changing
