### PR TITLE
chore: address sass deprecation warnings

### DIFF
--- a/packages/cdai/src/components/IdeCard/_IdeCard.scss
+++ b/packages/cdai/src/components/IdeCard/_IdeCard.scss
@@ -22,7 +22,7 @@ $ide-card-size: carbon--mini-units(30);
   flex: 1 0 21%;
   padding: 0;
   // stylelint-disable-next-line carbon/layout-token-use
-  margin: $spacing-01 / 2;
+  margin: calc(#{$spacing-01} * 0.5);
   background-color: $ui-background;
 
   .#{$ide-prefix}-card--card-overides {

--- a/packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_index.scss
+++ b/packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_index.scss
@@ -26,7 +26,7 @@
   }
 
   &__filter-list {
-    width: calc(100% + #{$filter-subcategory__spacing__padding / 2});
+    width: calc(100% + #{$filter-subcategory__spacing__padding * 0.5});
     padding-left: 0;
   }
 

--- a/packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_mixins.scss
+++ b/packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_mixins.scss
@@ -11,7 +11,7 @@
   @include filter-panel-accordion-item;
 
   &__filter-list {
-    width: calc(100% + #{$carbon--spacing-05 / 2});
+    width: calc(100% + #{$carbon--spacing-05 * 0.5});
     padding-left: 0;
   }
 }

--- a/packages/security/src/components/IconButton/_mixins.scss
+++ b/packages/security/src/components/IconButton/_mixins.scss
@@ -31,7 +31,9 @@ $button--icon__transition__timing-function: $timing-function;
     $count: $count,
   );
 
-  $button--icon__tooltip__position: $button--icon__sizing__dimensions--size / 2;
+  $button--icon__tooltip__position: calc(
+    #{$button--icon__sizing__dimensions--size} * 0.5
+  );
 
   width: $button--icon__sizing__dimensions--size;
   height: $button--icon__sizing__dimensions--size;

--- a/packages/security/src/globals/grid/vendor/css-gridish/scss/_functions.scss
+++ b/packages/security/src/globals/grid/vendor/css-gridish/scss/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'sass-list-maps';
 
 // Transform the gutter property into a padding property for web
@@ -11,7 +13,7 @@
           map-merge(
             $breakpoint,
             (
-              padding: map-get($breakpoint, gutter) / 2,
+              padding: calc(#{map-get($breakpoint, gutter)} * 0.5),
             )
           ),
       )
@@ -104,11 +106,11 @@
     $n: $n * 10;
   }
   @if $mode == round {
-    @return round($number * $n) / $n;
+    @return math.div(round($number * $n), $n);
   } @else if $mode == ceil {
-    @return ceil($number * $n) / $n;
+    @return math.div(ceil($number * $n), $n);
   } @else if $mode == floor {
-    @return floor($number * $n) / $n;
+    @return math.div(floor($number * $n), $n);
   } @else {
     @warn "#{ $mode } is undefined keyword.";
     @return $number;

--- a/packages/security/src/globals/grid/vendor/css-gridish/scss/_mixins.scss
+++ b/packages/security/src/globals/grid/vendor/css-gridish/scss/_mixins.scss
@@ -1,4 +1,6 @@
 // Set the width of a grid’s column
+@use "sass:math";
+
 @mixin grid($breakpoint, $breakpointName) {
   @if (map-get($breakpoint, columns) != null) {
     $columnSize: get-fluid-size($breakpointName, 1);
@@ -12,9 +14,8 @@
       &.#{$prefix}-grid--fixed-columns {
         grid-template-columns: repeat(
           auto-fill,
-          map-get($breakpoint, breakpoint) *
-            1rem /
-            map-get($breakpoint, columns)
+          math.div(map-get($breakpoint, breakpoint) *
+            1rem, map-get($breakpoint, columns))
         );
       }
 
@@ -52,9 +53,8 @@
         // Loop each column in current breakpoint for new class
         // Ex: .yourPrefix-grid__col--sm--1, .yourPrefix-grid__col--sm--2, etc.
         @for $i from 1 through map-get($currentBreakpoint, columns) {
-          $columnMultiplier: $i *
-            map-get($breakpoint, columns) /
-            map-get($currentBreakpoint, columns);
+          $columnMultiplier: math.div($i *
+            map-get($breakpoint, columns), map-get($currentBreakpoint, columns));
           $columnSize: get-fluid-size($name, $columnMultiplier);
 
           $isSecondToLast: is-same-breakpoint(

--- a/packages/security/src/globals/grid/vendor/css-gridish/scss/_sass-list-maps.scss
+++ b/packages/security/src/globals/grid/vendor/css-gridish/scss/_sass-list-maps.scss
@@ -55,7 +55,7 @@ $maps-sort-dir: 'asc';
     $map-of-maps: type-of($maps) == 'map';
 
     @if $map-of-maps {
-      $seed-map: nth(nth($maps, ceil(length($maps) / 2)), 2);
+      $seed-map: nth(nth($maps, ceil(length($maps) * 0.5)), 2);
 
       $seed-value: map-get-nested($seed-map, $keys...);
 
@@ -111,7 +111,7 @@ $maps-sort-dir: 'asc';
 
       @return map-merge(map-merge($less, $equal), $greater);
     } @else {
-      $seed-map: nth($maps, ceil(length($maps) / 2));
+      $seed-map: nth($maps, ceil(length($maps) * 0.5));
 
       $seed-value: map-get-nested($seed-map, $keys...);
 

--- a/packages/security/src/globals/grid/vendor/css-gridish/scss/_utilities.scss
+++ b/packages/security/src/globals/grid/vendor/css-gridish/scss/_utilities.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import 'functions';
 @import 'values';
 @import 'variables';
@@ -60,7 +62,7 @@
     $container: map-get($breakpoint, breakpoint) * 1rem;
   }
 
-  $multiplier: round-decimal($columnSpan / $columnTotal, 4, floor);
+  $multiplier: round-decimal(math.div($columnSpan, $columnTotal), 4, floor);
 
   // For IE, we can't have a 0 in the $fluidWidth calc().
   @if ($margin == 0) {


### PR DESCRIPTION
Contributes to #2393 

We have had a lot of sass deprecation warnings in our local development server regarding `/` outside of a `calc()`. The changes in this PR remove all of the warnings. Some instances have been addressed by simply multiplying instead of dividing (ie multiplying by ` * 0.5` in cases of `/ 2`) and some instances where that is not possible the sass:math built in module has been used (ie `math.div()`).


_**Note**_: this is only currently possible on the `carbon-v11` branch because it uses the module system. Because `main` is not using the module system yet, we can't `@use "sass:math";`.

#### What did you change?
```
packages/cdai/src/components/IdeCard/_IdeCard.scss
packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_index.scss
packages/security/src/components/FilterPanel/LEGACY_FilterPanel/FilterSubcategory/_mixins.scss
packages/security/src/components/IconButton/_mixins.scss
packages/security/src/globals/grid/vendor/css-gridish/scss/_functions.scss
packages/security/src/globals/grid/vendor/css-gridish/scss/_mixins.scss
packages/security/src/globals/grid/vendor/css-gridish/scss/_sass-list-maps.scss
packages/security/src/globals/grid/vendor/css-gridish/scss/_utilities.scss
```
#### How did you test and verify your work?
Made sure that running the storybook server still worked and there were no more sass warnings.


_Before_
![Screen Shot 2022-10-20 at 1 38 59 PM](https://user-images.githubusercontent.com/10215203/197206279-922f1211-5b6b-4e35-8d8a-c88f73352bbb.png)
_After_
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/10215203/197549180-b2db694c-243d-4fbd-a093-26e09d4b9b4d.png">
