### PR TITLE
fix(Datagrid): customize columns checkbox fix

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -166,7 +166,7 @@ const Columns = ({
                     `${blockClass}__customize-columns-checkbox`
                   )}
                   checked={isColumnVisible(colDef)}
-                  onChange={onSelectColumn.bind(null, colDef)}
+                  onChange={(_, { checked }) => onSelectColumn(colDef, checked)}
                   id={`${blockClass}__customization-column-${colDef.id}`}
                   labelText={colDef.Header.props.title}
                   title={colDef.Header.props.title}


### PR DESCRIPTION
Contributes to #2399 

This PR fixes an issue where we were not using the [new onChange prop signature](https://github.com/carbon-design-system/carbon/blob/main/docs/migration/v11.md#checkbox) for the Carbon checkbox. This was causing the checkboxes in the customize columns modal to not work as expected. After using the new signature, where the checkbox state is returned in the second callback argument, it is working again.

Issue can be seen [here](https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary-extensions-columncustomization--column-customization-usage-story) and after opening the customize columns modal you'll notice that the checkboxes do not work.

_**Note**_: This is only a v11 issue

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
```
#### How did you test and verify your work?
Storybook