### PR TITLE
docs: add external docs urls for v11

### DIFF
--- a/packages/cloud-cognitive/carbon.yml
+++ b/packages/cloud-cognitive/carbon.yml
@@ -20,7 +20,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-generating-an-api-key-apikeymodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-generating-an-api-key-apikeymodal
     tags:
       - system-feedback
       - form
@@ -36,7 +36,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-about-modal-aboutmodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-about-modal-aboutmodal
     tags:
       - system-feedback
       - content-block
@@ -51,7 +51,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionbar
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionbar
     tags:
       - input-control
   action-set:
@@ -65,7 +65,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionset
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-actionset
     tags:
       - data-display
   breadcrumb-with-overflow:
@@ -79,7 +79,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-breadcrumbwithoverflow
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-breadcrumbwithoverflow
     tags:
       - structural-navigation
       - contextual-navigation
@@ -94,7 +94,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonmenu
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonmenu
     tags:
       - input-control
   button-set-with-overflow:
@@ -108,7 +108,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonsetwithoverflow
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-buttonsetwithoverflow
     tags:
       - input-control
   cascade:
@@ -123,7 +123,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-cascade-cascade
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-cascade-cascade
     tags:
       - content-block
   combo-button:
@@ -138,7 +138,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-combobutton
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-internal-combobutton
     tags:
       - input-control
   create-full-page:
@@ -153,7 +153,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createfullpage
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createfullpage
     tags:
       - content-block
       - system-feedback
@@ -170,7 +170,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createmodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createmodal
     tags:
       - input-control
       - form
@@ -186,7 +186,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheet
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheet
     tags:
       - form
       - input-control
@@ -202,7 +202,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheetnarrow
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-create-flows-createtearsheetnarrow
     tags:
       - form
       - input-control
@@ -218,7 +218,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-dataspreadsheet-dataspreadsheet-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-dataspreadsheet-dataspreadsheet-canary
     tags:
       - input-control
       - data-display
@@ -233,7 +233,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary
     tags:
       - input-control
       - content-block
@@ -250,7 +250,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-editsidepanel-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-editsidepanel-canary
     tags:
       - input-control
       - form
@@ -266,7 +266,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-empty-state-emptystate
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-empty-state-emptystate
     tags:
       - content-element
   export-modal:
@@ -281,7 +281,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-export-exportmodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-export-exportmodal
     tags:
       - system-feedback
       - form
@@ -297,7 +297,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-expressivecard
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-expressivecard
     tags:
       - content-block
       - contextual-navigation
@@ -313,7 +313,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-http-errors
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-http-errors
     tags:
       - system-feedback
       - content-block
@@ -330,7 +330,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-import-and-upload-importmodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-import-and-upload-importmodal
     tags:
       - system-feedback
       - input-control
@@ -347,7 +347,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-inlineedit
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-edit-and-update-inlineedit
     tags:
       - input-control
   modified-tabs:
@@ -362,7 +362,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-modified-tabs-modifiedtabs-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-modified-tabs-modifiedtabs-canary
     tags:
       - input-control
   multi-add-select:
@@ -377,7 +377,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-multiaddselect-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-multiaddselect-canary
     tags:
       - form
       - content-block
@@ -393,7 +393,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-notifications-notificationspanel
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-notifications-notificationspanel
     tags:
       - input-control
       - system-feedback
@@ -409,7 +409,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-options-tile-optionstile
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-options-tile-optionstile
     tags:
       - input-control
       - form
@@ -426,7 +426,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-page-header-pageheader
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-page-header-pageheader
     tags:
       - structural-navigation
       - shell
@@ -443,7 +443,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-cards-productivecard
     tags:
       - content-block
       - input-control
@@ -459,7 +459,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-remove-removemodal
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-remove-removemodal
     tags:
       - system-feedback
       - input-control
@@ -475,7 +475,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-saving-saving
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-saving-saving
     tags:
       - input-control
       - system-feedback
@@ -491,7 +491,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-side-panel-sidepanel
     tags:
       - input-control
       - form
@@ -509,7 +509,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-singleaddselect-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-add-select-singleaddselect-canary
     tags:
       - form
   status-icon:
@@ -524,7 +524,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-status-icons-statusicon
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-status-icons-statusicon
     tags:
       - media
       - content-element
@@ -541,7 +541,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tag-set-tagset
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tag-set-tagset
     tags:
       - data-display
   tearsheet:
@@ -556,7 +556,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet-tearsheet
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-tearsheet-tearsheet
     tags:
       - input-control
       - form
@@ -572,7 +572,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-toolbars-toolbar-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-toolbars-toolbar-canary
     tags:
       - input-control
   user-profile-image:
@@ -587,7 +587,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-user-profile-images-userprofileimage
     tags:
       - media
   web-terminal:
@@ -602,7 +602,7 @@ assets:
       - type: storybook
         name: Storybook
         action: link
-        url: https://carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-web-terminal-webterminal-canary
+        url: https://v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-patterns-web-terminal-webterminal
     tags:
       - content-block
       - shell

--- a/packages/cloud-cognitive/carbon.yml
+++ b/packages/cloud-cognitive/carbon.yml
@@ -2,8 +2,7 @@
 library:
   id: ibm-products
   name: IBM Products
-  description:
-    Discover React-based solutions designed for IBM's product portfolio.
+  description: Discover React-based solutions designed for IBM’s product portfolio.
   externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/
   designKits:
     ibm-products-g10-figma:
@@ -11,6 +10,7 @@ library:
 assets:
   api-key-modal:
     name: API key modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/generating-api-key/usage
     status: stable
     type: pattern
     platform: web
@@ -26,6 +26,7 @@ assets:
       - form
   about-modal:
     name: About modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/about-modal/usage
     status: stable
     type: pattern
     platform: web
@@ -112,6 +113,7 @@ assets:
       - input-control
   cascade:
     name: Cascade
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/cascade
     status: stable
     type: pattern
     platform: web
@@ -126,6 +128,7 @@ assets:
       - content-block
   combo-button:
     name: Combo button
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/button-guidance/menu-and-combo-buttons
     status: stable
     type: component
     platform: web
@@ -140,6 +143,7 @@ assets:
       - input-control
   create-full-page:
     name: Create full page
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#full-page
     status: stable
     type: pattern
     platform: web
@@ -156,6 +160,7 @@ assets:
       - form
   create-modal:
     name: Create modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#modal
     status: stable
     type: pattern
     platform: web
@@ -171,6 +176,7 @@ assets:
       - form
   create-tearsheet:
     name: Create tearsheet
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#wide-tearsheet
     status: stable
     type: pattern
     platform: web
@@ -186,6 +192,7 @@ assets:
       - input-control
   create-tearsheet-narrow:
     name: Create tearsheet narrow
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/creation-flows/usage#narrow-tearsheet
     status: stable
     type: pattern
     platform: web
@@ -201,6 +208,7 @@ assets:
       - input-control
   data-spreadsheet:
     name: Data spreadsheet
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/data-spreadsheet/usage
     status: experimental
     type: component
     platform: web
@@ -232,6 +240,7 @@ assets:
       - data-display
   edit-side-panel:
     name: Edit side panel
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#side-panel-edit
     status: experimental
     type: pattern
     platform: web
@@ -247,6 +256,7 @@ assets:
       - form
   empty-state:
     name: Empty state
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/empty-state/usage
     status: stable
     type: pattern
     platform: web
@@ -261,6 +271,7 @@ assets:
       - content-element
   export-modal:
     name: Export modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/exporting/usage
     status: stable
     type: pattern
     platform: web
@@ -276,6 +287,7 @@ assets:
       - form
   expressive-card:
     name: Expressive card
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/card/expressive/usage
     status: stable
     type: component
     platform: web
@@ -291,6 +303,7 @@ assets:
       - contextual-navigation
   http-error:
     name: HTTP error
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/http-errors/usage
     status: stable
     type: pattern
     platform: web
@@ -307,6 +320,7 @@ assets:
       - contextual-navigation
   import-modal:
     name: Import modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/importing/usage
     status: stable
     type: pattern
     platform: web
@@ -323,6 +337,7 @@ assets:
       - form
   inline-edit:
     name: Inline edit
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/edit/usage#inline-edit
     status: stable
     type: pattern
     platform: web
@@ -337,6 +352,7 @@ assets:
       - input-control
   modified-tabs:
     name: Modified tabs
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/modified-tabs/usage
     status: experimental
     type: component
     platform: web
@@ -351,6 +367,7 @@ assets:
       - input-control
   multi-add-select:
     name: Multi add select
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/add-and-select/usage
     status: experimental
     type: pattern
     platform: web
@@ -366,6 +383,7 @@ assets:
       - content-block
   notifications-panel:
     name: Notifications panel
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/notifications/usage
     status: stable
     type: pattern
     platform: web
@@ -381,6 +399,7 @@ assets:
       - system-feedback
   options-tile:
     name: Options tile
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/options-tile/usage
     status: stable
     type: component
     platform: web
@@ -397,6 +416,7 @@ assets:
       - content-block
   page-header:
     name: Page header
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/page-header/usage
     status: stable
     type: component
     platform: web
@@ -413,6 +433,7 @@ assets:
       - content-block
   productive-card:
     name: Productive card
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/card/productive/usage
     status: stable
     type: component
     platform: web
@@ -428,6 +449,7 @@ assets:
       - input-control
   remove-modal:
     name: Remove modal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/removing/usage
     status: stable
     type: pattern
     platform: web
@@ -443,6 +465,7 @@ assets:
       - input-control
   saving:
     name: Saving
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/saving/usage
     status: stable
     type: pattern
     platform: web
@@ -458,6 +481,7 @@ assets:
       - system-feedback
   side-panel:
     name: Side panel
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/side-panel/usage
     status: stable
     type: component
     platform: web
@@ -475,6 +499,7 @@ assets:
       - data-display
   single-add-select:
     name: Single add select
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/add-and-select/usage
     status: experimental
     type: pattern
     platform: web
@@ -489,6 +514,7 @@ assets:
       - form
   status-icon:
     name: Status icon
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/status-icons/usage
     status: stable
     type: pattern
     platform: web
@@ -505,6 +531,7 @@ assets:
       - system-feedback
   tag-set:
     name: Tag set
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/tag-set/usage
     status: stable
     type: component
     platform: web
@@ -519,6 +546,7 @@ assets:
       - data-display
   tearsheet:
     name: Tearsheet
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/components/tearsheet/usage
     status: stable
     type: component
     platform: web
@@ -534,6 +562,7 @@ assets:
       - form
   toolbar:
     name: Toolbar
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/toolbars/usage
     status: experimental
     type: pattern
     platform: web
@@ -548,6 +577,7 @@ assets:
       - input-control
   user-profile-image:
     name: User profile image
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/user-profile-images/usage
     status: stable
     type: pattern
     platform: web
@@ -562,6 +592,7 @@ assets:
       - media
   web-terminal:
     name: Web terminal
+    externalDocsUrl: https://pages.github.ibm.com/cdai-design/pal/patterns/web-terminal/usage
     status: stable
     type: pattern
     platform: web

--- a/packages/security/carbon.yml
+++ b/packages/security/carbon.yml
@@ -9,308 +9,308 @@ library:
       $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/ibm-products-g10-figma
 assets:
   decorator:
-      name: Decorator
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/decorator.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-decorator
-      tags:
-        - content-element
+    name: Decorator
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/decorator.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-decorator
+    tags:
+      - content-element
   delimited-list:
-      name: Delimited list
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/delimited-list.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-delimitedlist
-      tags:
-        - content-element
-        - data-display
+    name: Delimited list
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/delimited-list.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-delimitedlist
+    tags:
+      - content-element
+      - data-display
   external-link:
-      name: External link
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/external-link.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-externallink
-      tags:
-        - content-element
-        - contextual-navigation
+    name: External link
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/external-link.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-externallink
+    tags:
+      - content-element
+      - contextual-navigation
   ica:
-      name: ICA
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/ica.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-ica
-      tags:
-        - content-element
+    name: ICA
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/ica.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-ica
+    tags:
+      - content-element
   nav:
-      name: Nav
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/nav.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-nav
-      tags:
-        - structural-navigation
+    name: Nav
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/nav.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/story/security-components-nav
+    tags:
+      - structural-navigation
   stacked-notification:
-      name: Stacked notification
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/stacked-notification.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stackednotification
-      tags:
-        - system-feedback
+    name: Stacked notification
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/stacked-notification.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stackednotification
+    tags:
+      - system-feedback
   status-icon:
-      name: Status icon
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/status-icon.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-statusicon
-      tags:
-        - system-feedback
+    name: Status icon
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/status-icon.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-statusicon
+    tags:
+      - system-feedback
   string-formatter:
-      name: String formatter
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/string-formatter.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stringformatter
-      tags:
-        - content-element
+    name: String formatter
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/string-formatter.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-stringformatter
+    tags:
+      - content-element
   time-indicator:
-      name: Time indicator
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/time-indicator.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-timeindicator
-      tags:
-        - system-feedback
-        - content-element 
+    name: Time indicator
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/time-indicator.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-timeindicator
+    tags:
+      - system-feedback
+      - content-element 
   truncated-list:
-      name: Truncated list
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/truncated-list.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-truncatedlist
-      tags:
-        - data-display
-        - content-element
+    name: Truncated list
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/truncated-list.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-truncatedlist
+    tags:
+      - data-display
+      - content-element
   type-layout:
-      name: Type layout
-      status: stable
-      type: component
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/type-layout.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-typelayout
-      tags:
-        - data-display
-        - content-element
+    name: Type layout
+    status: stable
+    type: component
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/type-layout.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-components-typelayout
+    tags:
+      - data-display
+      - content-element
   combo-button:
-      name: Combo button
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/combo-button.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-combobutton
-      tags:
-        - input-control
+    name: Combo button
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/combo-button.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-combobutton
+    tags:
+      - input-control
   filter-panel:
-      name: Filter panel
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/filter-panel.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-filterpanel
-      tags:
-        - form
+    name: Filter panel
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/filter-panel.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-filterpanel
+    tags:
+      - form
   icon-button-bar:
-      name: Icon button bar
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/icon-button-bar.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-iconbuttonbar
-      tags:
-        - input-control
+    name: Icon button bar
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/icon-button-bar.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-iconbuttonbar
+    tags:
+      - input-control
   non-entitled-section:
-      name: Non entitled section
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/non-entitled-section.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-nonentitledsection
-      tags:
-        - content-block
+    name: Non entitled section
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/non-entitled-section.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-nonentitledsection
+    tags:
+      - content-block
   search-bar:
-      name: Search bar
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/search-bar.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-searchbar
-      tags:
-        - input-control
-        - form
+    name: Search bar
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/search-bar.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-searchbar
+    tags:
+      - input-control
+      - form
   status-indicator:
-      name: Status indicator
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/status-indicator.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-statusindicator
-      tags:
-        - system-feedback
+    name: Status indicator
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/status-indicator.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-statusindicator
+    tags:
+      - system-feedback
   tag-wall:
-      name: Tag wall
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/tag-wall.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwall
-      tags:
-        - input-control
-        - data-display
+    name: Tag wall
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/tag-wall.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwall
+    tags:
+      - input-control
+      - data-display
   tag-wall-filter:
-      name: Tag wall filter
-      status: stable
-      type: pattern
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/tag-wall-filter.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwallfilter
-      tags:
-        - input-control
-        - data-display
-        - form
+    name: Tag wall filter
+    status: stable
+    type: pattern
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/tag-wall-filter.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-patterns-tagwallfilter
+    tags:
+      - input-control
+      - data-display
+      - form
   detail:
-      name: Detail
-      status: stable
-      type: template
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/detail.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-detail
-      tags:
-        - content-block
-        - data-display
+    name: Detail
+    status: stable
+    type: template
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/detail.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-detail
+    tags:
+      - content-block
+      - data-display
   overview:
-      name: Overview
-      status: stable
-      type: template
-      platform: web
-      framework: react
-      thumbnailPath: './thumbnails/overview.svg'
-      demoLinks:
-        - type: storybook
-          name: Storybook
-          action: link
-          url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-overview
-      tags:
-        - content-block
-        - data-display
+    name: Overview
+    status: stable
+    type: template
+    platform: web
+    framework: react
+    thumbnailPath: './thumbnails/overview.svg'
+    demoLinks:
+      - type: storybook
+        name: Storybook
+        action: link
+        url: https://carbon-for-ibm-products.netlify.app/?path=/docs/security-layouts-overview
+    tags:
+      - content-block
+      - data-display
     


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/carbon-platform/issues/1380

- Adds `externalDocsUrl`s to the index, so the IBM Products library’s assets have `View asset docs` in Carbon Platform.
- Replaces Storybook links with v11 equivalents

#### What did you change?
- add external docs urls
- clean up ibm security carbon yml formatting
- fix smart quote in description
- replace v1/v10 Storybook links with v2/v11 Storybook links

#### How did you test and verify your work?
Storybook