### PR TITLE
fix(PageHeader): restrict useEffect logic to prevent scrolling

### DIFF
--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -438,7 +438,7 @@ export let PageHeader = React.forwardRef(
     };
 
     useEffect(() => {
-      if (typeof collapseHeader === 'boolean') {
+      if (collapseHeader === true) {
         utilSetCollapsed(
           collapseHeader,
           metrics.headerOffset,


### PR DESCRIPTION
Contributes to #2400 

This addresses the scrolling issue in the PageHeader. The only portion of the PageHeader that scrolls the page is from a utility called `utilSetCollapsed` that is called from inside of a `useEffect`. I think the issue here is that the previous check to run this function only look to see if `collapseHeader` was a `boolean` type. But we only want to ever run this utility if `collapseHeader` is true.

#### What did you change?
```
packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
```
#### How did you test and verify your work?
Haven't been able to fully reproduce this issue, but `utilSetCollapsed` should only ever be called when `collapsed` is true. So I think the useEffect containing `utilSetCollapsed` is being run when it shouldn't be which is causing the scrolling.