### PR TITLE
fix(Datagrid): render pagination as component (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -156,10 +156,9 @@ export const DatagridContent = ({ datagridState }) => {
           )}
         </div>
       </TableContainer>
-      {rows?.length > 0 &&
-        !isFetching &&
-        DatagridPagination &&
-        DatagridPagination(datagridState)}
+      {rows?.length > 0 && !isFetching && DatagridPagination && (
+        <DatagridPagination {...datagridState} />
+      )}
       {CustomizeColumnsModal && (
         <CustomizeColumnsModal instance={datagridState} />
       )}


### PR DESCRIPTION
Contributes to #2345 

This should resolve the issue initially brought up in #2345, specifically the warning about a change in the order of react hooks.
![image](https://user-images.githubusercontent.com/10215203/198660235-9300d192-93e0-439b-ba2b-8f76bd901473.png)

I also noticed this react warning when starting up a sample application using the Datagrid. Thanks @johannwagner for adding details around this issue.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Storybook, component still renders as expected.