### PR TITLE
docs(Datagrid): add column alignment and inline edit docs

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+yarn dlx commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       "yarn prettier --write"
     ],
     "**/*.js": [
-      "yarn eslint --fix"
+      "yarn dlx eslint --fix"
     ],
     "**/*.scss": [
       "yarn stylelint"

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -205,6 +205,207 @@ const App = () => {
   />
 </Canvas>
 
+## Column alignment
+
+The default column alignment in the `Datagrid` is left, however there is support
+for center and right aligned as well. See
+[design guidance](https://pages.github.ibm.com/cdai-design/pal/components/data-table/column-alignment/usage)
+for details around when to change default column alignment.
+
+```jsx
+import {
+  Datagrid,
+  useDatagrid,
+  useColumnCenterAlign,
+  useColumnRightAlign,
+} from '@carbon/ibm-products';
+
+const defaultColumns = [
+  ...defaultCols,
+  {
+    Header: 'Bonus',
+    accessor: 'bonus',
+    width: 120,
+    rightAlignedColumn: true,
+  },
+  {
+    Header: 'Status',
+    accessor: 'status_icon',
+    width: 100,
+    centerAlignedColumn: true,
+  },
+];
+
+const App = () => {
+  const columns = React.useMemo(() => [...defaultHeader], []);
+  const [data] = useState(makeData(10));
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      initialState: {
+        pageSize: 10,
+        pageSizes: [5, 10, 25, 50],
+      },
+      DatagridActions,
+      DatagridPagination,
+    },
+    useColumnCenterAlign,
+    useColumnRightAlign
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+```
+
+<Canvas>
+  <Story
+    id={getStoryId(
+      Datagrid.displayName,
+      'column-alignment-story',
+      '/Extensions/ColumnAlignment'
+    )}
+  />
+</Canvas>
+
+## Inline editing
+
+The `Datagrid` supports inline editing when used with the `useInlineEdit` hook
+and columns are provided the required configuration. The four data types
+supported are strings, numbers, dates, and selection (dropdown).
+
+Below are example column configuration for the support inline edit data types:
+
+Default/string:
+
+```json
+{
+  Header: 'First Name',
+  accessor: 'firstName',
+  inlineEdit: {
+    type: 'text',
+    // required for including validation, this is used to set the invalid prop internally
+    validator: (n) => n.length >= 40,
+    // These props are passed to the Carbon component used for inline editing, in this case the TextInput
+    inputProps: {
+      invalidText: 'Invalid text, character count must be less than 40',
+    },
+  },
+}
+```
+
+Number:
+
+```json
+{
+  Header: 'Age',
+  accessor: 'age',
+  width: 120,
+  inlineEdit: {
+    // required for including validation, this is used to set the invalid prop internally
+    validator: (n) => n && n < 18,
+    type: 'number',
+    // These props are passed to the Carbon component used for inline editing, in this case NumberInput
+    inputProps: {
+      invalidText: 'Invalid number, must be 18 or greater',
+    },
+  },
+},
+```
+
+Date:
+
+```jsx
+{
+  Header: 'Active since',
+  accessor: 'activeSince',
+  inlineEdit: {
+    type: 'date',
+    inputProps: {
+      // optionally pass props here to be passed through to Carbon's DatePicker component
+      onChange: (newDateObj, cell) => {
+        console.log(newDateObj, cell);
+      },
+      labelText: 'Change active since date',
+      // optionally pass props here to be passed through to Carbon's DatePickerInput component
+      datePickerInputProps: {
+        labelText: 'Change active since date',
+      },
+    },
+  },
+},
+```
+
+Selection:
+
+```jsx
+{
+  Header: 'Chart type',
+  accessor: 'chartType',
+  inlineEdit: {
+    type: 'selection',
+    inputProps: {
+      // These props are passed to the Carbon component used for inline editing
+      items: [
+        {
+          id: 'option-0',
+          icon: ChartColumnFloating16,
+          text: 'Column Chart',
+        },
+        {
+          id: 'option-1',
+          icon: ChartBubble16,
+          text: 'Bubble Chart',
+        },
+        {
+          id: 'option-2',
+          icon: ChartVennDiagram16,
+          text: 'Venn Diagram',
+        },
+      ],
+      onChange: (item) => {
+        console.log(item);
+      },
+    },
+  },
+},
+```
+
+Using the column structure outlined above, along with the use of the
+`useInlineEdit` hook, the Datagrid will support inline editing. See example
+below:
+
+```jsx
+import { Datagrid, useDatagrid, useInlineEdit } from '@carbon/ibm-products';
+
+const App = () => {
+  const [data, setData] = useState(makeData(10));
+  const columns = React.useMemo(() => getInlineEditColumns(), []); // These columns follow the inline edit column configuration detailed above
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      onDataUpdate: setData,
+    },
+    useInlineEdit
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+```
+
+<Canvas>
+  <Story
+    id={getStoryId(
+      Datagrid.displayName,
+      'inline-edit-usage-story',
+      '/Extensions/InlineEdit'
+    )}
+  />
+</Canvas>
+
 ## Code sample
 
 <CodesandboxLink exampleDirectory="Datagrid" />

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -108,7 +108,7 @@ export const DatagridContent = ({ datagridState }) => {
       return;
     }
     const gridElement = document.querySelector(`#${tableId}`);
-    const tableHeader = document.querySelector(
+    const tableHeader = gridElement?.querySelector(
       `.${carbon.prefix}--data-table-header`
     );
     gridElement.style.setProperty(


### PR DESCRIPTION
Contributes to #2407 

Added Datagrid documentation around column alignment and inline editing. I hit some issues when trying to commit, to I made two small changes that allowed the precommit to successfully run again.

#### What did you change?
```
.husky/commit-msg
package.json
packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
```
#### How did you test and verify your work?
Viewed in Storybook docs tab for Datagrid component