### PR TITLE
chore: use new carbon-bot token for releases (v11)

### DIFF
--- a/.github/workflows/release-v11.yml
+++ b/.github/workflows/release-v11.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run: yarn lerna publish --preid rc --dist-tag next --no-verify-access --create-release github --ignore-changes 'config/**/*' 'packages/security/**/*' 'packages/cdai/**/*' 'packages/core/**/*' --yes # This publishes subsequent v2.x.x releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run: yarn lerna publish --no-verify-access --create-release github --yes
 
       - name: Rename to ibm-cloud-cognitive for legacy publish
@@ -58,5 +58,5 @@ jobs:
       - name: Publish with old name
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LERNA }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CARBON_BOT_NPM_TOKEN }}
         run: yarn lerna publish from-package --no-verify-access --yes


### PR DESCRIPTION
Contributes to #2427 

Changes the current npm access token we use to publish packages to one that was created by the `carbon-bot` account.

#### What did you change?
`github/workflows/release.yml`
`github/workflows/release-v11.yml`
#### How did you test and verify your work?
I made sure that the new token has correct privileges to publish our packages. 