### PR TITLE
fix(Datagrid): allow keyboard interaction with row expander

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -1484,14 +1484,14 @@ describe(componentName, () => {
   });
 
   function clickRow(rowNumber) {
-    var row = screen
+    const row = screen
       .getByRole('table')
       .getElementsByTagName('tbody')[0]
       .getElementsByTagName('tr')[rowNumber];
-
-    fireEvent.click(
-      row.getElementsByTagName('td')[0].getElementsByTagName('span')[0]
+    const rowExpander = row.querySelector(
+      `button[aria-label="Expand current row"]`
     );
+    fireEvent.click(rowExpander);
 
     setTimeout(1000);
 
@@ -1516,7 +1516,7 @@ describe(componentName, () => {
         .getElementsByClassName('c4p--datagrid__expanded-row')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[0]
-        .getElementsByTagName('span')[0]
+        .getElementsByTagName('button')[0]
     );
 
     expect(
@@ -1702,7 +1702,7 @@ describe(componentName, () => {
         .getElementsByTagName('tbody')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[0]
-        .getElementsByTagName('span')[0]
+        .getElementsByTagName('button')[0]
     );
     expect(
       screen

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -28,6 +28,7 @@ const DatagridRow = (datagridState) => {
     <TableRow
       className={cx(`${blockClass}__carbon-row`, {
         [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
+        [`${blockClass}__carbon-row-expandable`]: row.canExpand,
         [`${carbon.prefix}--data-table--selected`]: row.isSelected,
         [`${blockClass}__carbon-row-hover-active`]:
           activeCellObject && row.index === activeCellObject.row,
@@ -51,7 +52,7 @@ const DatagridRow = (datagridState) => {
         );
       }}
     >
-      {row.cells.map((cell) => {
+      {row.cells.map((cell, index) => {
         const cellProps = cell.getCellProps();
         const { children, ...restProps } = cellProps;
         const content = children || (
@@ -66,7 +67,10 @@ const DatagridRow = (datagridState) => {
         }
         return (
           <TableCell
-            className={`${blockClass}__cell`}
+            className={cx(`${blockClass}__cell`, {
+              [`${blockClass}__expandable-row-cell`]:
+                row.canExpand && index === 0,
+            })}
             {...restProps}
             key={cell.column.id}
           >

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -35,3 +35,21 @@
   width: 100%;
   @include shared-pseudo-styles();
 }
+
+.#{$block-class}__carbon-row.#{$block-class}__carbon-row-expandable
+  .#{$block-class}__cell.#{$block-class}__expandable-row-cell {
+  padding: $spacing-03;
+  padding-right: 0;
+}
+
+.#{$block-class}__row-expander.#{$carbon-prefix}--btn {
+  display: flex;
+  width: $spacing-07;
+  height: $spacing-07;
+  min-height: $spacing-07;
+  justify-content: center;
+  padding: 0;
+  .#{$block-class}__row-expander--icon {
+    fill: $ui-05;
+  }
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
@@ -8,17 +8,39 @@
  */
 import React from 'react';
 import { ChevronDown16, ChevronUp16 } from '@carbon/icons-react';
+import cx from 'classnames';
+import { pkg, carbon } from '../../settings';
+
+const blockClass = `${pkg.prefix}--datagrid`;
 
 const useRowExpander = (hooks) => {
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
-      Cell: ({ row }) =>
-        row.canExpand && (
-          <span {...row.getToggleRowExpandedProps()}>
-            {row.isExpanded ? <ChevronUp16 /> : <ChevronDown16 />}
-          </span>
-        ),
+      Cell: ({ row }) => {
+        return (
+          row.canExpand && (
+            <button
+              type="button"
+              aria-label="Expand current row"
+              className={cx(
+                `${blockClass}__row-expander`,
+                `${carbon.prefix}--btn`,
+                `${carbon.prefix}--btn--ghost`
+              )}
+              {...row.getToggleRowExpandedProps()}
+            >
+              {row.isExpanded ? (
+                <ChevronUp16 className={`${blockClass}__row-expander--icon`} />
+              ) : (
+                <ChevronDown16
+                  className={`${blockClass}__row-expander--icon`}
+                />
+              )}
+            </button>
+          )
+        );
+      },
       width: 48,
       disableResizing: true,
       disableSortBy: true,


### PR DESCRIPTION
Contributes to #1607 

Contributes to overall accessibility to the Datagrid component, specifically the row expanders. Previously it was not possible to interact with this element via keyboard. I changed the expander element from a `span` to a `button` to fix this issue.

See preview story with expandable rows [here](https://deploy-preview-2434--carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary-extensions-expandablerow--expandable-row-story)

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
```
#### How did you test and verify your work?
Storybook