### PR TITLE
fix(Datagrid): allow keyboard interaction with row expander (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -1411,14 +1411,15 @@ describe(componentName, () => {
   });
 
   function clickRow(rowNumber) {
-    var row = screen
+    const row = screen
       .getByRole('table')
       .getElementsByTagName('tbody')[0]
       .getElementsByTagName('tr')[rowNumber];
 
-    fireEvent.click(
-      row.getElementsByTagName('td')[0].getElementsByTagName('span')[0]
+    const rowExpander = row.querySelector(
+      `button[aria-label="Expand current row"]`
     );
+    fireEvent.click(rowExpander);
 
     setTimeout(1000);
 
@@ -1443,7 +1444,7 @@ describe(componentName, () => {
         .getElementsByClassName('c4p--datagrid__expanded-row')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[0]
-        .getElementsByTagName('span')[0]
+        .getElementsByTagName('button')[0]
     );
 
     expect(
@@ -1607,7 +1608,7 @@ describe(componentName, () => {
         .getElementsByTagName('tbody')[0]
         .getElementsByTagName('tr')[0]
         .getElementsByTagName('td')[0]
-        .getElementsByTagName('span')[0]
+        .getElementsByTagName('button')[0]
     );
     expect(
       screen

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -28,6 +28,7 @@ const DatagridRow = (datagridState) => {
     <TableRow
       className={cx(`${blockClass}__carbon-row`, {
         [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
+        [`${blockClass}__carbon-row-expandable`]: row.canExpand,
         [`${carbon.prefix}--data-table--selected`]: row.isSelected,
         [`${blockClass}__carbon-row-hover-active`]:
           activeCellObject && row.index === activeCellObject.row,
@@ -51,7 +52,7 @@ const DatagridRow = (datagridState) => {
         );
       }}
     >
-      {row.cells.map((cell) => {
+      {row.cells.map((cell, index) => {
         const cellProps = cell.getCellProps();
         const { children, ...restProps } = cellProps;
         const content = children || (
@@ -66,7 +67,10 @@ const DatagridRow = (datagridState) => {
         }
         return (
           <TableCell
-            className={`${blockClass}__cell`}
+            className={cx(`${blockClass}__cell`, {
+              [`${blockClass}__expandable-row-cell`]:
+                row.canExpand && index === 0,
+            })}
             {...restProps}
             key={cell.column.id}
           >

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
@@ -6,7 +6,7 @@
 * restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 
-@use '../../../global/styles/project-settings';
+@use '../../../global/styles/project-settings' as c4p-settings;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use './variables';
@@ -39,4 +39,22 @@
   left: 0;
   width: 100%;
   @include shared-pseudo-styles();
+}
+
+.#{variables.$block-class}__carbon-row.#{variables.$block-class}__carbon-row-expandable
+  .#{variables.$block-class}__cell.#{variables.$block-class}__expandable-row-cell {
+  padding: $spacing-03;
+  padding-right: 0;
+}
+
+.#{variables.$block-class}__row-expander.#{c4p-settings.$carbon-prefix}--btn {
+  display: flex;
+  width: $spacing-07;
+  height: $spacing-07;
+  min-height: $spacing-07;
+  justify-content: center;
+  padding: 0;
+  .#{variables.$block-class}__row-expander--icon {
+    fill: $layer-selected-inverse;
+  }
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
@@ -8,21 +8,37 @@
  */
 import React from 'react';
 import { ChevronDown, ChevronUp } from '@carbon/react/icons';
+import { pkg, carbon } from '../../settings';
+import cx from 'classnames';
+
+const blockClass = `${pkg.prefix}--datagrid`;
 
 const useRowExpander = (hooks) => {
   const visibleColumns = (columns) => {
     const expanderColumn = {
       id: 'expander',
-      Cell: ({ row }) =>
-        row.canExpand && (
-          <span {...row.getToggleRowExpandedProps()}>
-            {row.isExpanded ? (
-              <ChevronUp size={16} />
-            ) : (
-              <ChevronDown size={16} />
-            )}
-          </span>
-        ),
+      Cell: ({ row }) => {
+        return (
+          row.canExpand && (
+            <button
+              type="button"
+              aria-label="Expand current row"
+              className={cx(
+                `${blockClass}__row-expander`,
+                `${carbon.prefix}--btn`,
+                `${carbon.prefix}--btn--ghost`
+              )}
+              {...row.getToggleRowExpandedProps()}
+            >
+              {row.isExpanded ? (
+                <ChevronUp className={`${blockClass}__row-expander--icon`} />
+              ) : (
+                <ChevronDown className={`${blockClass}__row-expander--icon`} />
+              )}
+            </button>
+          )
+        );
+      },
       width: 48,
       disableResizing: true,
       disableSortBy: true,


### PR DESCRIPTION
Contributes to #1607 

Contributes to overall accessibility to the Datagrid component, specifically the row expanders. Previously it was not possible to interact with this element via keyboard. I changed the expander element from a `span` to a `button` to fix this issue.

See preview story with expandable rows [here](https://deploy-preview-2435--v11-carbon-for-ibm-products.netlify.app/?path=/story/ibm-products-components-datagrid-datagrid-canary-extensions-expandablerow--expandable-row-story)

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useExpandedRow.scss
packages/cloud-cognitive/src/components/Datagrid/useRowExpander.js
```
#### How did you test and verify your work?
Storybook