### PR TITLE
fix(Datagrid): #2417 datagrid select rows filter issue

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -293,6 +293,8 @@ export const IsHoverOnRow = () => {
 export const SelectableRow = () => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const emptyStateTitle = 'Empty state title';
+  const emptyStateDescription = 'Description explaining why the table is empty';
   const datagridState = useDatagrid(
     {
       columns,
@@ -300,6 +302,8 @@ export const SelectableRow = () => {
       DatagridActions,
       batchActions: true,
       toolbarBatchActions: getBatchActions(),
+      emptyStateTitle,
+      emptyStateDescription,
     },
     useSelectRows,
     useStickyColumn

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -25,8 +25,12 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
   const [displayAllInMenu, setDisplayAllInMenu] = useState(false);
   const [initialListWidth, setInitialListWidth] = useState(null);
   const [receivedInitialWidth, setReceivedInitialWidth] = useState(false);
-  const { selectedFlatRows, toggleAllRowsSelected, toolbarBatchActions } =
-    datagridState;
+  const {
+    selectedFlatRows,
+    toggleAllRowsSelected,
+    toolbarBatchActions,
+    setGlobalFilter,
+  } = datagridState;
   const totalSelected = selectedFlatRows && selectedFlatRows.length;
 
   // Get initial width of batch actions container,
@@ -117,7 +121,10 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
     <TableBatchActions
       shouldShowBatchActions={totalSelected > 0}
       totalSelected={totalSelected}
-      onCancel={() => toggleAllRowsSelected(false)}
+      onCancel={() => {
+        toggleAllRowsSelected(false);
+        setGlobalFilter(null);
+      }}
     >
       {!displayAllInMenu &&
         toolbarBatchActions &&


### PR DESCRIPTION
Contributes to #2417 

Fixes an issue where if you search in a table with selectable rows, then select a row and clear the batch action toolbar the search is cleared but the filtered rows are not reset. The `globalFilter` value from `react-table` just needed to be reset in the batch action toolbar `onCancel`.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
```
#### How did you test and verify your work?
Storybook