### PR TITLE
fix(Datagrid): #2291 extend last nested row border (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -1580,7 +1580,7 @@ describe(componentName, () => {
       .getElementsByTagName('tr')[0];
     const firstRow = row
       .getElementsByTagName('td')[0]
-      .getElementsByTagName('span')[0];
+      .getElementsByTagName('button')[0];
 
     fireEvent.click(firstRow);
 
@@ -1593,7 +1593,9 @@ describe(componentName, () => {
 
     if (nestedRow.className === 'c4p--datagrid__carbon-nested-row') {
       fireEvent.click(
-        nestedRow.getElementsByTagName('td')[0].getElementsByTagName('span')[0]
+        nestedRow
+          .getElementsByTagName('td')[0]
+          .getElementsByTagName('button')[0]
       );
     }
 

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useNestedRows.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useNestedRows.scss
@@ -33,3 +33,20 @@
   td:first-child {
   border-bottom: none;
 }
+
+.#{$block-class} .#{$block-class}__carbon-row-expandable {
+  position: relative;
+}
+
+.#{$block-class}
+  tr.#{$block-class}__carbon-nested-row
+  + :not(tr.#{$block-class}__carbon-nested-row)::before {
+  position: absolute;
+  /* stylelint-disable-next-line carbon/layout-token-use */
+  top: -1px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: $border-subtle;
+  content: '';
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/useNestedRowExpander.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useNestedRowExpander.js
@@ -9,7 +9,7 @@
 import React from 'react';
 import { ChevronRight } from '@carbon/react/icons';
 import cx from 'classnames';
-import { pkg } from '../../settings';
+import { pkg, carbon } from '../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const useNestedRowExpander = (hooks) => {
@@ -18,14 +18,23 @@ const useNestedRowExpander = (hooks) => {
       id: 'expander',
       Cell: ({ row }) =>
         row.canExpand && (
-          <span {...row.getToggleRowExpandedProps()}>
+          <button
+            type="button"
+            aria-label="Expand current row"
+            className={cx(
+              `${blockClass}__row-expander`,
+              `${carbon.prefix}--btn`,
+              `${carbon.prefix}--btn--ghost`
+            )}
+            {...row.getToggleRowExpandedProps()}
+          >
             <ChevronRight
               className={cx(`${blockClass}__expander-icon`, {
                 [`${blockClass}__expander-icon--not-open`]: !row.isExpanded,
                 [`${blockClass}__expander-icon--open`]: row.isExpanded,
               })}
             />
-          </span>
+          </button>
         ),
       width: 48,
       disableResizing: true,


### PR DESCRIPTION
Contributes to #2291 

This PR adds some styling so that the border of the last nested row extends the full width of the row. I also added keyboard support for this expander, similar to `useRowExpander`.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/styles/_useNestedRows.scss
packages/cloud-cognitive/src/components/Datagrid/useNestedRowExpander.js
```
#### How did you test and verify your work?
Storybook

_Before_
![Screen Shot 2022-11-07 at 2 08 53 PM](https://user-images.githubusercontent.com/10215203/200394317-e8c79be2-8a88-4f92-8e91-91cf6f437b2b.png)


_After_
![Screen Shot 2022-11-07 at 2 11 13 PM](https://user-images.githubusercontent.com/10215203/200394566-449ce2f8-b9eb-4925-8f35-2eb6027c74d0.png)
