### PR TITLE
fix(ActionSet): allow for non expressive buttons

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -230,14 +230,17 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   font-weight: var(--cds-body-short-01-font-weight, 400);
   line-height: var(--cds-body-short-01-line-height, 1.28572);
   letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  height: var(--cds-spacing-10, 4rem);
   align-items: center;
-  padding-top: var(--cds-spacing-05, 1rem);
-  padding-bottom: var(--cds-spacing-07, 2rem);
   margin: 0;
 }
+.c4p--action-set .c4p--action-set__action-button.c4p--action-set__action-button--expressive {
+  height: var(--cds-spacing-10, 4rem);
+  padding-top: var(--cds-spacing-05, 1rem);
+  padding-bottom: var(--cds-spacing-07, 2rem);
+}
 
-.c4p--action-set.bx--btn-set .c4p--action-set__action-button.bx--btn.bx--btn--expressive {
+.c4p--action-set.bx--btn-set .c4p--action-set__action-button.bx--btn.bx--btn--expressive,
+.c4p--action-set.bx--btn-set .c4p--action-set__action-button.bx--btn {
   max-width: none;
 }
 

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -31,6 +31,7 @@ const ActionSetButton = React.forwardRef(
       kind,
       label,
       loading,
+      isExpressive = true,
       // Collect any other property values passed in.
       ...rest
     },
@@ -41,12 +42,13 @@ const ActionSetButton = React.forwardRef(
         // Pass through any other property values as HTML attributes.
         ...rest
       }
-      isExpressive
+      isExpressive={isExpressive}
       className={cx(className, [
         `${blockClass}__action-button`,
         {
           [`${blockClass}__action-button--ghost`]:
             kind === 'ghost' || kind === 'danger--ghost',
+          [`${blockClass}__action-button--expressive`]: isExpressive,
         },
       ])}
       disabled={disabled || loading || false}

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -278,4 +278,18 @@ describe(`${componentName}.validateActions`, () => {
     );
     expect(v('md', props.twoGhosts, prop, componentName)).toBeInstanceOf(Error);
   });
+
+  it('should render both expressive and regular buttons inside of the button set', () => {
+    const { rerender } = render(<ActionSet actions={[actionG]} />);
+    const actionButton = screen.getByText(labelG);
+    expect(actionButton).toHaveClass(
+      `${carbon.prefix}--btn--expressive`,
+      `${blockClass}__action-button--expressive`
+    );
+    rerender(<ActionSet actions={[{ ...actionG, isExpressive: false }]} />);
+    expect(actionButton).not.toHaveClass(
+      `${carbon.prefix}--btn--expressive`,
+      `${blockClass}__action-button--expressive`
+    );
+  });
 });

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -25,15 +25,20 @@
   .#{$block-class} .#{$block-class}__action-button {
     @include carbon--type-style('body-short-01');
 
-    height: $spacing-10;
     align-items: center;
-    padding-top: $spacing-05;
-    padding-bottom: $spacing-07;
     margin: 0;
+
+    &.#{$block-class}__action-button--expressive {
+      height: $spacing-10;
+      padding-top: $spacing-05;
+      padding-bottom: $spacing-07;
+    }
   }
 
   .#{$block-class}.#{$carbon-prefix}--btn-set
-    .#{$block-class}__action-button.#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--expressive {
+    .#{$block-class}__action-button.#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--expressive,
+  .#{$block-class}.#{$carbon-prefix}--btn-set
+    .#{$block-class}__action-button.#{$carbon-prefix}--btn {
     max-width: none;
   }
 


### PR DESCRIPTION
Contributes to #2437 

This PR allows for ActionSet buttons to not always be expressive (ie from the `isExpressive` prop). Prior to this change, we hard coded each button in the action set to be expressive.

#### What did you change?
```
packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
```
#### How did you test and verify your work?
Storybook and added to ActionSet tests