### PR TITLE
fix(ActionSet): allow for non expressive buttons (v11)

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -167,14 +167,17 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   font-weight: var(--cds-body-short-01-font-weight, 400);
   line-height: var(--cds-body-short-01-line-height, 1.28572);
   letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
-  height: 4rem;
   align-items: center;
-  padding-top: 1rem;
-  padding-bottom: 2rem;
   margin: 0;
 }
+.c4p--action-set .c4p--action-set__action-button.c4p--action-set__action-button--expressive {
+  height: 4rem;
+  padding-top: 1rem;
+  padding-bottom: 2rem;
+}
 
-.c4p--action-set.cds--btn-set .c4p--action-set__action-button.cds--btn.cds--btn--expressive {
+.c4p--action-set.cds--btn-set .c4p--action-set__action-button.cds--btn.cds--btn--expressive,
+.c4p--action-set.cds--btn-set .c4p--action-set__action-button.cds--btn {
   max-width: none;
 }
 

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
@@ -31,6 +31,7 @@ const ActionSetButton = React.forwardRef(
       kind,
       label,
       loading,
+      isExpressive = true,
       // Collect any other property values passed in.
       ...rest
     },
@@ -41,12 +42,13 @@ const ActionSetButton = React.forwardRef(
         // Pass through any other property values as HTML attributes.
         ...rest
       }
-      isExpressive
+      isExpressive={isExpressive}
       className={cx(className, [
         `${blockClass}__action-button`,
         {
           [`${blockClass}__action-button--ghost`]:
             kind === 'ghost' || kind === 'danger--ghost',
+          [`${blockClass}__action-button--expressive`]: isExpressive,
         },
       ])}
       disabled={disabled || loading || false}

--- a/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
+++ b/packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
@@ -269,4 +269,18 @@ describe(`${componentName}.validateActions`, () => {
     );
     expect(v('md', props.twoGhosts, prop, componentName)).toBeInstanceOf(Error);
   });
+
+  it('should render both expressive and regular buttons inside of the button set', () => {
+    const { rerender } = render(<ActionSet actions={[actionG]} />);
+    const actionButton = screen.getByText(labelG);
+    expect(actionButton).toHaveClass(
+      `${carbon.prefix}--btn--expressive`,
+      `${blockClass}__action-button--expressive`
+    );
+    rerender(<ActionSet actions={[{ ...actionG, isExpressive: false }]} />);
+    expect(actionButton).not.toHaveClass(
+      `${carbon.prefix}--btn--expressive`,
+      `${blockClass}__action-button--expressive`
+    );
+  });
 });

--- a/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
+++ b/packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
@@ -22,15 +22,20 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
 .#{$action-set-block-class} .#{$action-set-block-class}__action-button {
   @include type.type-style('body-short-01');
 
-  height: $spacing-10;
   align-items: center;
-  padding-top: $spacing-05;
-  padding-bottom: $spacing-07;
   margin: 0;
+
+  &.#{$action-set-block-class}__action-button--expressive {
+    height: $spacing-10;
+    padding-top: $spacing-05;
+    padding-bottom: $spacing-07;
+  }
 }
 
 .#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set
-  .#{$action-set-block-class}__action-button.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--expressive {
+  .#{$action-set-block-class}__action-button.#{c4p-settings.$carbon-prefix}--btn.#{c4p-settings.$carbon-prefix}--btn--expressive,
+.#{$action-set-block-class}.#{c4p-settings.$carbon-prefix}--btn-set
+  .#{$action-set-block-class}__action-button.#{c4p-settings.$carbon-prefix}--btn {
   max-width: none;
 }
 


### PR DESCRIPTION
Contributes to #2437 

This PR allows for ActionSet buttons to not always be expressive (ie from the `isExpressive` prop). Prior to this change, we hard coded each button in the action set to be expressive.

#### What did you change?
```
packages/cloud-cognitive/src/components/ActionSet/ActionSet.js
packages/cloud-cognitive/src/components/ActionSet/ActionSet.test.js
packages/cloud-cognitive/src/components/ActionSet/_action-set.scss
```
#### How did you test and verify your work?
Storybook and added to ActionSet tests