### PR TITLE
feat(OptionsTile): add onChange prop and useControllableState hook (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -15,6 +15,7 @@ import cx from 'classnames';
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import uuidv4 from '../../global/js/utils/uuidv4';
 import { pkg } from '../../settings';
+import { useControllableState } from '../../global/js/hooks';
 
 // Carbon and package components we use.
 import { Toggle } from '@carbon/react';
@@ -34,6 +35,7 @@ const componentName = 'OptionsTile';
 
 // Default values for props
 const defaults = {
+  onChange: () => {},
   size: 'xl',
 };
 
@@ -52,6 +54,7 @@ export let OptionsTile = React.forwardRef(
       invalidText,
       locked,
       lockedText,
+      onChange = defaults.onChange,
       onToggle,
       open,
       size = defaults.size,
@@ -66,9 +69,14 @@ export let OptionsTile = React.forwardRef(
     },
     ref
   ) => {
-    const [isOpen, setIsOpen] = useState(open);
     const [prevIsOpen, setPrevIsOpen] = useState(open);
     const [closing, setClosing] = useState(false);
+
+    const [isOpen, setIsOpen] = useControllableState({
+      value: open,
+      defaultValue: open || null,
+      onChange: (value) => onChange(value),
+    });
 
     const detailsRef = useRef(null);
     const contentRef = useRef(null);
@@ -335,6 +343,12 @@ OptionsTile.propTypes = {
    * Provide a text explaining why the OptionsTile is in locked state.
    */
   lockedText: PropTypes.string,
+
+  /**
+   * Provide a function which will be called each time the user
+   * toggles the open state of the OptionsTile.
+   */
+  onChange: PropTypes.func,
 
   /**
    * Provide a function which will be called each time the user

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
@@ -85,7 +85,11 @@ const Template = (args) => {
   const disableControls = args.enabled === false || isLocked;
 
   return (
-    <OptionsTile onToggle={action('onToggle')} {...args}>
+    <OptionsTile
+      onToggle={action('onToggle')}
+      onChange={action('onChange')}
+      {...args}
+    >
       <FormGroup aria-labelledby={titleId} legendText="">
         <p>
           User interface defines the language the application is displayed in.
@@ -128,7 +132,18 @@ const TemplateStatic = ({ enabled, ...rest }) => {
     action('onToggle')(e);
   }
 
-  return <OptionsTile onToggle={onToggle} {...rest} enabled={liveEnabled} />;
+  function onChange(value) {
+    action('onChange')(value);
+  }
+
+  return (
+    <OptionsTile
+      onToggle={onToggle}
+      onChange={onChange}
+      {...rest}
+      enabled={liveEnabled}
+    />
+  );
 };
 
 export const optionsTile = prepareStory(Template, {

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
@@ -157,7 +157,9 @@ describe(componentName, () => {
   });
 
   it('can be controlled by setting props.open', () => {
-    const { container, rerender } = render(<OptionsTile {...props} />);
+    const { container, rerender } = render(
+      <OptionsTile {...props} open={false} />
+    );
     expect(container.querySelector('details').open).toBe(false);
 
     rerender(<OptionsTile {...props} open={true} />);
@@ -198,5 +200,16 @@ describe(componentName, () => {
     expect(onToggle).not.toBeCalled();
     fireEvent.click(screen.getByRole('switch'));
     expect(onToggle).toBeCalled();
+  });
+
+  it('should call the onChange prop if provided when option tile is opened or closed', () => {
+    const onChangeFn = jest.fn();
+    const { container } = render(
+      <OptionsTile onChange={onChangeFn} {...props} />
+    );
+    fireEvent.click(container.querySelector('summary'));
+    expect(onChangeFn).toHaveBeenCalledTimes(1);
+    fireEvent.click(container.querySelector('summary'));
+    expect(onChangeFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cloud-cognitive/src/global/js/hooks/index.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/index.js
@@ -15,3 +15,4 @@ export { usePreviousValue } from './usePreviousValue';
 export { useResetCreateComponent } from './useResetCreateComponent';
 export { useRetrieveStepData } from './useRetrieveStepData';
 export { useValidCreateStepCount } from './useValidCreateStepCount';
+export { useControllableState } from './useControllableState';

--- a/packages/cloud-cognitive/src/global/js/hooks/useControllableState.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useControllableState.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright IBM Corp. 2016, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import pconsole from '../utils/pconsole';
+
+/**
+ * This custom hook simplifies the behavior of a component if it has state that
+ * can be both controlled and uncontrolled. It functions identical to a
+ * useState() hook and provides [state, setState] for you to use. You can use
+ * the `onChange` argument to allow updates to the `state` to be communicated to
+ * owners of controlled components.
+ *
+ * Note: this hook will warn if a component is switching from controlled to
+ * uncontrolled, or vice-versa.
+ *
+ * @param {object} config
+ * @param {string} config.name - the name of the custom component
+ * @param {any} config.defaultValue - the default value used for the state. This will be
+ * the fallback value used if `value` is not defined.
+ * @param {Function} config.onChange - an optional function that is called when
+ * the value of the state changes. This is useful for communicating to parents of
+ * controlled components that the value is requesting to be changed.
+ * @param {any} config.value - a controlled value. Omitting this means that the state is
+ * uncontrolled
+ * @returns {[any, Function]}
+ */
+export function useControllableState({
+  defaultValue,
+  name = 'custom',
+  onChange,
+  value,
+}) {
+  const [state, internalSetState] = useState(value ?? defaultValue);
+  const controlled = useRef(null);
+
+  if (controlled.current === null) {
+    controlled.current = value !== undefined;
+  }
+
+  function setState(stateOrUpdater) {
+    const value =
+      typeof stateOrUpdater === 'function'
+        ? stateOrUpdater(state)
+        : stateOrUpdater;
+
+    if (controlled.current === false) {
+      internalSetState(value);
+    }
+
+    if (onChange) {
+      onChange(value);
+    }
+  }
+
+  useEffect(() => {
+    const controlledValue = value !== undefined;
+    // Uncontrolled -> Controlled
+    // If the component prop is uncontrolled, the prop value should be undefined
+    if (controlled.current === false && controlledValue) {
+      pconsole.warn(
+        `A component is changing an uncontrolled %s component to be controlled.
+          This is likely caused by the value changing to a defined value
+          from undefined. Decide between using a controlled or uncontrolled
+          value for the lifetime of the component.
+          More info: https://reactjs.org/link/controlled-components`
+      );
+    }
+
+    // Controlled -> Uncontrolled
+    // If the component prop is controlled, the prop value should be defined
+    if (controlled.current === true && !controlledValue) {
+      pconsole.warn(
+        `A component is changing a controlled %s component to be uncontrolled.
+        'This is likely caused by the value changing to an undefined value
+        'from a defined one. Decide between using a controlled or
+        'uncontrolled value for the lifetime of the component.
+        'More info: https://reactjs.org/link/controlled-components`
+      );
+    }
+  }, [name, value]);
+
+  if (controlled.current === true) {
+    return [value, setState];
+  }
+
+  return [state, setState];
+}


### PR DESCRIPTION
Contributes to #1540 

Incorporates the `useControllableState` hook from Carbon into the `OptionsTile` component and adds an `onChange` prop which is a callback function that will be called whenever the `OptionsTile` is either closed or opened.

#### What did you change?
```
packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.test.js
packages/cloud-cognitive/src/global/js/hooks/index.js
packages/cloud-cognitive/src/global/js/hooks/useControllableState.js
```
#### How did you test and verify your work?
Storybook and ran tests for OptionsTile