### PR TITLE
fix(DataSpreadsheet): prevent delete error from header cells (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
@@ -422,6 +422,7 @@ export let DataSpreadsheet = React.forwardRef(
           rows,
           setActiveCellContent,
           updateData,
+          activeCellCoordinates,
         };
         // Allow arrow key navigation if there are less than two activeKeys OR
         // if one of the activeCellCoordinates is in a header position

--- a/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleCellDeletion.js
+++ b/packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleCellDeletion.js
@@ -9,12 +9,22 @@ import { deepCloneObject } from '../../../global/js/utils/deepCloneObject';
 import { rangeWithCallback } from '../../../global/js/utils/rangeWithCallback';
 
 export const handleCellDeletion = ({
+  activeCellCoordinates,
   selectionAreas,
   currentMatcher,
   rows,
   setActiveCellContent,
   updateData,
 }) => {
+  // This means that the delete key has been pressed when the active cell is in a header,
+  // not within the spreadsheet body. To delete an entire row/column, it must first be
+  // selected, and then can be deleted.
+  if (
+    activeCellCoordinates?.column === 'header' ||
+    activeCellCoordinates?.row === 'header'
+  ) {
+    return;
+  }
   const selectionAreaClone = deepCloneObject(selectionAreas);
   const indexOfCurrentSelectionArea = selectionAreaClone.findIndex(
     (item) => item.matcher === currentMatcher


### PR DESCRIPTION
Contributes to #1976 

Small update to cell deletion interaction (`handleCellDeletion`) to prevent deletion from any row or column header cells. The row/column needs to be selected first, and then deletion is allowed.

#### What did you change?
```
packages/cloud-cognitive/src/components/DataSpreadsheet/DataSpreadsheet.js
packages/cloud-cognitive/src/components/DataSpreadsheet/utils/handleCellDeletion.js
```
#### How did you test and verify your work?
Storybook, prior to this change there was an error in the browser console when pressing the `Delete` key while the active cell was in a column or row header.