### PR TITLE
chore: fix yarn audit

### DIFF
--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -18,7 +18,7 @@ let auditLevel;
 
 async function audit() {
   auditLevel = level ? ' --level ' + level : '';
-  const auditCommand = 'yarn audit --groups ' + group + auditLevel;
+  const auditCommand = 'yarn npm audit --groups ' + group + auditLevel;
   console.log('Running audit using:', auditCommand);
   await exec(auditCommand);
 }


### PR DESCRIPTION
Contributes to issue with CI lint step hanging.

`yarn audit` from yarn 1 is renamed to `yarn npm audit` in yarn berry.
https://yarnpkg.com/getting-started/migration#renamed

#### What did you change?
`yarn audit` becomes `yarn npm audit` in our audit script

#### How did you test and verify your work?
`yarn ci-check:lint` now completes locally.