### PR TITLE
chore(Datagrid): add nested row indicator for child rows (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -1584,7 +1584,7 @@ describe(componentName, () => {
 
     fireEvent.click(firstRow);
 
-    expect(row.classList[1]).toEqual('c4p--datagrid__carbon-row-expanded');
+    expect(row.classList[0]).toEqual('c4p--datagrid__carbon-row-expanded');
 
     const nestedRow = screen
       .getByRole('table')

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -35,21 +35,14 @@ const DatagridRow = (datagridState) => {
   const activeCellObject = activeCellId && getCellIdAsObject(activeCellId);
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
-    let totalVisibleNested = 0;
-    if (isExpanded && subRows?.length) {
-      totalVisibleNested += subRows.length;
-      subRows.forEach((nestedRow) => {
-        if (nestedRow.isExpanded) {
-          totalVisibleNested += nestedRow.subRows.length;
-          nestedRow.subRows.forEach((r) => {
-            if (r.isExpanded) {
-              totalVisibleNested += r.subRows.length;
-            }
-          });
-        }
+    let size = 0;
+    if (isExpanded && subRows) {
+      size += subRows.length;
+      subRows.forEach((child) => {
+        size += getVisibleNestedRowCount(child);
       });
     }
-    return totalVisibleNested;
+    return size;
   };
 
   return (

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -29,7 +29,7 @@ const rowHeights = {
 
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
-  const { row, rowSize } = datagridState;
+  const { row, rowSize, withNestedRows } = datagridState;
   const { state } = useContext(InlineEditContext);
   const { activeCellId } = state;
   const activeCellObject = activeCellId && getCellIdAsObject(activeCellId);
@@ -64,6 +64,9 @@ const DatagridRow = (datagridState) => {
       {...row.getRowProps()}
       key={row.id}
       onMouseEnter={(event) => {
+        if (!withNestedRows) {
+          return;
+        }
         const subRowCount = getVisibleNestedRowCount(row);
         const totalNestedRowIndicatorHeight = px(
           subRowCount * rowHeights[rowSize]

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -416,10 +416,20 @@
 }
 
 .#{$block-class}__carbon-row-expanded {
-  // Border applied to nested rows only on open chevron hover
-  &.#{$block-class}__carbon-row-expanded-hover-active
-    ~ .#{$block-class}__carbon-nested-row {
-    border-left: 1px solid $button-primary;
+  position: relative;
+  &.#{$block-class}__carbon-row-expanded-hover-active::before {
+    position: absolute;
+    z-index: 2;
+    /* stylelint-disable-next-line carbon/layout-token-use */
+    top: var(--#{$block-class}--row-height);
+    /* stylelint-disable-next-line carbon/layout-token-use */
+    left: calc(
+      var(--#{$block-class}--indicator-offset-amount) + #{$spacing-05}
+    );
+    width: 1px;
+    height: var(--#{$block-class}--indicator-height);
+    border-left: 1px solid $background-brand;
+    content: '';
   }
 }
 

--- a/packages/cloud-cognitive/src/components/Datagrid/useNestedRows.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useNestedRows.js
@@ -62,9 +62,14 @@ const useNestedRows = (hooks) => {
     ];
   };
 
+  const useInstance = (instance) => {
+    Object.assign(instance, { withNestedRows: true });
+  };
+
   hooks.getRowProps.push(getRowProps);
   hooks.getRowProps.push(getRowStyles);
   hooks.getCellProps.push(getCellProps);
+  hooks.useInstance.push(useInstance);
 };
 
 export default useNestedRows;

--- a/packages/cloud-cognitive/src/components/Datagrid/useNestedRows.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useNestedRows.js
@@ -6,6 +6,7 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import { pkg } from '../../settings';
+import cx from 'classnames';
 import useNestedRowExpander from './useNestedRowExpander';
 
 const blockClass = `${pkg.prefix}--datagrid`;
@@ -14,20 +15,29 @@ const useNestedRows = (hooks) => {
   useNestedRowExpander(hooks);
   const marginLeft = 24;
 
-  const getRowProps = (props, { row }) => [
-    props,
-    { className: row.depth > 0 ? `${blockClass}__carbon-nested-row` : '' },
-  ];
+  const getRowProps = (props, { row }) => {
+    return [
+      props,
+      {
+        className: cx({
+          [`${blockClass}__carbon-nested-row`]: row.depth > 0,
+          [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
+        }),
+      },
+    ];
+  };
   const getRowStyles = (props, { row }) => [
     props,
     {
       style: {
         marginLeft: `${row.depth > 0 ? marginLeft : 0}px`,
         paddingLeft: `${
-          row.depth > 1
+          row.depth === 2
+            ? marginLeft * (row.depth - 1) + marginLeft - 8
+            : row.depth > 2
             ? marginLeft * (row.depth - 1) + marginLeft
             : row.depth === 1
-            ? marginLeft
+            ? marginLeft - 16
             : 0
         }px`,
         maxWidth: `calc(100% - ${marginLeft * row.depth}px)`,


### PR DESCRIPTION
Contributes to #2291 

This PR adds the indicator line for nested rows that are also parent rows (ie they have sub rows within them). See attached screen recording for example:

https://user-images.githubusercontent.com/10215203/204433944-a31c5e75-f4d4-47d6-acc4-04a4916bf2ef.mp4


#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
packages/cloud-cognitive/src/components/Datagrid/useNestedRows.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
```
#### How did you test and verify your work?
Storybook and ran tests for Datagrid