### PR TITLE
fix(ActionBar): overflow menu item onClick

### DIFF
--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBarOverflowItems.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBarOverflowItems.js
@@ -45,6 +45,7 @@ export const ActionBarOverflowItems = ({
         return (
           <OverflowMenuItem
             className={`${blockClass}__item`}
+            onClick={item.props.onClick}
             itemText={
               <div
                 className={`${blockClass}__item-content`}


### PR DESCRIPTION
Contributes to #2510

#### What did you change?
forward the action's onClick handler to the OverflowMenuItem

#### How did you test and verify your work?
verified in storybook, with and without a click handler
