### PR TITLE
fix(create full page): modal close issue fixed

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -167,6 +167,9 @@ export let CreateFullPage = React.forwardRef(
           size="sm"
           open={modalIsOpen}
           aria-label={modalTitle}
+          onClose={() => {
+            setModalIsOpen(false);
+          }}
         >
           <ModalHeader title={modalTitle} />
           <ModalBody>


### PR DESCRIPTION
Contributes to #2438 

Modal not opening after closing it with outside click

#### What did you change?

Added onClose function with a state change(onClose={()=>setModalIsOpen(false)})

#### How did you test and verify your work?
Storybook
