### PR TITLE
fix(Datagrid): fixed some issues in filter flyout

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -238,7 +238,7 @@ const FilterFlyout = ({
                     value: [...filtersState[column]],
                     type,
                   });
-                  components.option.onChange?.(isSelected);
+                  option.onChange?.(isSelected);
                 }}
                 checked={option.selected}
               />
@@ -274,11 +274,11 @@ const FilterFlyout = ({
         return (
           <Dropdown
             {...components.Dropdown}
+            selectedItem={filtersState[column]}
             onChange={({ selectedItem }) => {
               setFiltersState({
                 ...filtersState,
                 [column]: selectedItem,
-                type,
               });
               applyFilters({
                 column,
@@ -359,14 +359,6 @@ const FilterFlyout = ({
 };
 
 FilterFlyout.propTypes = {
-  /**
-   * React children of carbon filters
-   */
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).isRequired,
-
   /**
    * Array of filters to render
    */


### PR DESCRIPTION
These changes were reflected in the v11 PR for FilterFlyout and FilterSummary #2525. This PR just adds those changes here too for v10.

- Fixed where Checkbox on change wasn't being called correctly
- Removed children from Proptypes
- Adds the `selectedItem` prop to Dropdown to sync with state