### PR TITLE
fix(InlineEdit): move warning inside component

### DIFF
--- a/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import { pconsole } from '../../global/js/utils/pconsole';
+import pconsole from '../../global/js/utils/pconsole';
 import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.

--- a/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
+import { pconsole } from '../../global/js/utils/pconsole';
 import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.
@@ -39,10 +40,6 @@ const defaults = {
 };
 
 const buttons = ['cancel', 'edit', 'save'];
-
-console.warn(
-  'the v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.'
-);
 
 /**
  * TODO: A description of the component.
@@ -84,6 +81,10 @@ export let InlineEditV1 = React.forwardRef(
     const showValidation = invalid; // || warn;
     const validationText = invalidText; // || warnText;
     const validationIcon = showValidation ? <WarningFilled16 /> : null;
+
+    pconsole.warn(
+      'the v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.'
+    );
 
     // sanitize the tooltip values
     const alignIsObject = typeof buttonTooltipAlignment === 'object';

--- a/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
@@ -83,7 +83,7 @@ export let InlineEditV1 = React.forwardRef(
     const validationIcon = showValidation ? <WarningFilled16 /> : null;
 
     pconsole.warn(
-      'the v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.'
+      `${componentName}: the v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.`
     );
 
     // sanitize the tooltip values

--- a/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.test.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.test.js
@@ -29,6 +29,15 @@ const value = 'hello; world';
 const requiredProps = { editDescription, cancelDescription, saveDescription };
 
 describe(componentName, () => {
+  let mockWarn;
+  beforeEach(() => {
+    mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockWarn.mockRestore();
+  });
+
   it('renders a component InlineEdit', () => {
     const { container } = render(<InlineEditV1 {...requiredProps} />);
     expect(container.firstChild).toHaveClass(blockClass);


### PR DESCRIPTION
Contributes to #2526 

This PR moves the v1 InlineEdit deprecation warning inside of the component so that it only logs the warning when using this component.

#### What did you change?
`InlineEditV1.js`
#### How did you test and verify your work?
Storybook, confirmed that the warning is only showing when using this component.