### PR TITLE
fix(Datagrid): update inline edit selection type to support string items (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -280,7 +280,7 @@ export const InlineEditCell = ({
   };
 
   const handleTransformedItem = (items) => {
-    items?.length && typeof items[0] === 'object'
+    return items?.length && typeof items[0] === 'object'
       ? (item) => renderDropdownItem(item)
       : null;
   };

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
@@ -279,6 +279,12 @@ export const InlineEditCell = ({
     );
   };
 
+  const handleTransformedItem = (items) => {
+    items?.length && typeof items[0] === 'object'
+      ? (item) => renderDropdownItem(item)
+      : null;
+  };
+
   const renderSelectCell = () => {
     const { inputProps } = config || {};
     return (
@@ -296,8 +302,8 @@ export const InlineEditCell = ({
         })}
         items={inputProps?.items || []}
         initialSelectedItem={cell.value}
-        itemToElement={(item) => renderDropdownItem(item)}
-        renderSelectedItem={(item) => renderDropdownItem(item)}
+        itemToElement={handleTransformedItem(inputProps?.items)}
+        renderSelectedItem={handleTransformedItem(inputProps?.items)}
         onChange={(item) => {
           const newCellId = getNewCellId('Enter');
           saveCellData(item.selectedItem);
@@ -477,7 +483,7 @@ export const InlineEditCell = ({
           renderIcon={setRenderIcon()}
           label={
             type === 'selection'
-              ? value.text
+              ? value?.text ?? value
               : type === 'date'
               ? buildDate(value)
               : value


### PR DESCRIPTION
Contributes to #2545 

Allows the selection inline edit type in Datagrid to now use either an array of strings or array of objects. I tested this by passing an array of strings in `getInlineEditColumns.js` to the column that supports the `selection` type after I made the changes and confirmed that the interaction still worked as expected.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/InlineEdit/InlineEditCell/InlineEditCell.js
```
#### How did you test and verify your work?
Storybook