### PR TITLE
feat(Datagrid): add empty state type option

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import { pkg } from '../../../settings';
 import { DataTable } from 'carbon-components-react';
-import { NoDataEmptyState } from '../../EmptyStates/NoDataEmptyState';
+import { NoDataEmptyState, ErrorEmptyState } from '../../EmptyStates';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -21,6 +21,7 @@ const DatagridEmptyBody = (datagridState) => {
     emptyStateTitle,
     emptyStateDescription,
     emptyStateSize,
+    emptyStateType = 'noData',
     illustrationTheme,
   } = datagridState;
 
@@ -31,12 +32,22 @@ const DatagridEmptyBody = (datagridState) => {
     >
       <TableRow>
         <TableCell colSpan={headers.length}>
-          <NoDataEmptyState
-            illustrationTheme={illustrationTheme}
-            size={emptyStateSize}
-            title={emptyStateTitle}
-            subtitle={emptyStateDescription}
-          />
+          {emptyStateType === 'error' && (
+            <ErrorEmptyState
+              illustrationTheme={illustrationTheme}
+              size={emptyStateSize}
+              title={emptyStateTitle}
+              subtitle={emptyStateDescription}
+            />
+          )}
+          {emptyStateType === 'noData' && (
+            <NoDataEmptyState
+              illustrationTheme={illustrationTheme}
+              size={emptyStateSize}
+              title={emptyStateTitle}
+              subtitle={emptyStateDescription}
+            />
+          )}
         </TableCell>
       </TableRow>
     </TableBody>

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
@@ -35,6 +35,7 @@ export const ARG_TYPES = {
     type: { name: 'string', required: false },
   },
   emptyStateSize: { control: 'select', options: ['sm', 'lg'] },
+  emptyStateType: { control: 'select', options: ['error', 'noData'] },
   useDenseHeader: {
     control: { type: 'radio' },
     options: [true, false],


### PR DESCRIPTION
Adds empty state type property, allowing for error empty state to be used.

FYI @holmansze 

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
```
#### How did you test and verify your work?
Storybook and ran tests