### PR TITLE
feat(Datagrid): makes seperate story file and adds docs for FilterFlyout (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -389,6 +389,371 @@ const App = () => {
   />
 </Canvas>
 
+## Filtering
+
+Table filtering allows a user to add or remove data items from a data table by
+selecting or clearing predefined attributes. Filters can help a user find
+something they're looking for, view available options within a certain set of
+criteria, and decide between many options. These guidelines are an extension of
+[Carbon's filter documentation.](https://carbondesignsystem.com/patterns/filtering/)
+
+Filtering results in a table is a different type of action from searching. While
+both actions can help the user narrow results down, searching is meant to help
+the user find a specific result, whereas filtering allows users to trim results
+according to its attributes.
+
+Applied filters can affect both the data that is visible in the table and also
+data that might not be displayed in the columns available in the table. Filter
+options can be displayed in many form components, including dropdowns, text
+inputs, checkboxes, radio buttons, and date range pickers.
+
+[Check out the Guidance here.](https://pages.github.ibm.com/cdai-design/pal/components/data-table/filters/)
+
+### Preparing your column headers
+
+To utilize filtering, you have to add some extra properties into your headers
+that are going to be filtered.
+
+Two things you need to do is:
+
+1. Specify a `filter` to use (unless it's text match which is default)
+2. (Optional) Render the component with the `Cell` property to display the right
+   information. Use this if the data you send into the table isn't how you want
+   to display it, for example like Dates. See the example for `passwordStrength`
+   below.
+
+For example; here we are specifying that the `joined` header column should be
+filtered using a `filter: 'date'`, and render the cell using it's value and
+converting it to string. (Since the value of joined is a date object, react
+isn't going to allow you to render it as jsx so we have to convert it to string)
+
+```js
+{
+    Header: 'Joined',
+    accessor: 'joined',
+    filter: 'date',
+    Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
+  },
+```
+
+The different types of filters are:
+
+1. text (default)
+2. date
+3. number
+4. checkbox
+5. radio
+6. dropdown
+
+```jsx
+const columns = [
+  {
+    Header: 'Row Index',
+    accessor: (row, i) => i,
+    sticky: 'left',
+    id: 'rowIndex', // id is required when accessor is a function.
+  },
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    width: 50,
+  },
+  {
+    Header: 'Visits',
+    accessor: 'visits',
+    filter: 'number',
+    width: 60,
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    filter: 'dropdown',
+  },
+  // Shows the date filter example
+  {
+    Header: 'Joined',
+    accessor: 'joined',
+    filter: 'date',
+    Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
+  },
+  // Shows the checkbox filter example
+  {
+    Header: 'Password strength',
+    accessor: 'passwordStrength',
+    filter: 'checkbox',
+    Cell: ({ cell: { value } }) => {
+      const iconProps = {
+        size: 'sm',
+        theme: 'light',
+        kind: value,
+        iconDescription: value,
+      };
+      return (
+        <span
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <StatusIcon {...iconProps} />
+          {iconProps.iconDescription}
+        </span>
+      );
+    },
+  },
+  // Shows the checkbox filter example
+  {
+    Header: 'Role',
+    accessor: 'role',
+    filter: 'radio',
+  },
+];
+```
+
+### Store you data into state, this can also come from an API
+
+```jsx
+const [data] = useState([
+  {
+    activeSince: new Date('09/26/81'),
+    age: 41,
+    firstName: 'Joel',
+    lastName: 'Miller',
+    passwordStrength: 'normal',
+    role: 'developer',
+    visits: '81',
+  },
+  {
+    activeSince: new Date('08/30/97'),
+    age: 19,
+    firstName: 'Ellie',
+    lastName: 'N/A',
+    passwordStrength: 'critical',
+    role: 'designer',
+    visits: '7',
+  },
+  {
+    activeSince: new Date('01/26/03'),
+    age: 39,
+    firstName: 'Tommy',
+    lastName: 'Miller',
+    passwordStrength: 'minor-warning',
+    role: 'researcher',
+    visits: '25',
+  },
+]);
+```
+
+### Create your filters for flyout variant
+
+To add filters to the flyout, you have to pass in an array of filters. These
+filters will be converted to it's respective component. Each filters has 3
+important props, `type`, `column`, `props`.
+
+- `type`: the type of filter (this should be the same `filter` property in the
+  headers)
+- `column`: the column that it should be filtered on
+- `props`: the props for the components needed to render the filter.
+
+Please refer to all the available filters that you can use below.
+
+```jsx
+const filters = [
+  {
+    type: 'date',
+    column: 'joined',
+    props: {
+      DatePicker: {
+        datePickerType: 'range',
+        // Add any other Carbon DatePicker props here
+      },
+      DatePickerInput: {
+        start: {
+          id: 'date-picker-input-id-start',
+          placeholder: 'mm/dd/yyyy',
+          labelText: 'Joined start date',
+          // Add any other Carbon DatePickerInput props here
+        },
+        end: {
+          id: 'date-picker-input-id-end',
+          placeholder: 'mm/dd/yyyy',
+          labelText: 'Joined end date',
+          // Add any other Carbon DatePickerInput props here
+        },
+      },
+    },
+  },
+  {
+    type: 'number',
+    column: 'visits',
+    props: {
+      NumberInput: {
+        min: 0,
+        id: 'visits-number-input',
+        invalidText: 'A valid value is required',
+        label: 'Visits',
+        placeholder: 'Type a number amount of visits',
+        // Add any other Carbon NumberInput props here
+      },
+    },
+  },
+  {
+    type: 'checkbox',
+    column: 'passwordStrength',
+    props: {
+      FormGroup: {
+        legendText: 'Password strength',
+        // Add any other Carbon FormGroup props here
+      },
+      Checkbox: [
+        {
+          id: 'normal',
+          labelText: 'Normal',
+          value: 'normal',
+          // Add any other Carbon Checkbox props here
+        },
+        {
+          id: 'minor-warning',
+          labelText: 'Minor warning',
+          value: 'minor-warning',
+          // Add any other Carbon Checkbox props here
+        },
+        {
+          id: 'critical',
+          labelText: 'Critical',
+          value: 'critical',
+          // Add any other Carbon Checkbox props here
+        },
+      ],
+    },
+  },
+  {
+    type: 'radio',
+    column: 'role',
+    props: {
+      FormGroup: {
+        legendText: 'Role',
+        // Add any other Carbon FormGroup props here
+      },
+      RadioButtonGroup: {
+        orientation: 'vertical',
+        legend: 'Role legend',
+        name: 'role-radio-button-group',
+        // Add any other Carbon RadioButtonGroup props here
+      },
+      RadioButton: [
+        {
+          id: 'developer',
+          labelText: 'Developer',
+          value: 'developer',
+          // Add any other Carbon RadioButton props here
+        },
+        {
+          id: 'designer',
+          labelText: 'Designer',
+          value: 'designer',
+          // Add any other Carbon RadioButton props here
+        },
+        {
+          id: 'researcher',
+          labelText: 'Researcher',
+          value: 'researcher',
+          // Add any other Carbon RadioButton props here
+        },
+      ],
+    },
+  },
+  {
+    type: 'dropdown',
+    column: 'status',
+    props: {
+      Dropdown: {
+        id: 'marital-status-dropdown',
+        ariaLabel: 'Marital status dropdown',
+        items: ['relationship', 'complicated', 'single'],
+        label: 'Marital status',
+        titleText: 'Marital status',
+        // Add any other Carbon Dropdown props here
+      },
+    },
+  },
+];
+```
+
+### Create your filters for panel variant
+
+Filter panel coming soon.
+
+### Putting it all together
+
+```jsx
+import { Datagrid, useDatagrid, useFiltering } from '@carbon/ibm-products';
+const App = () => {
+  const columns = [...];
+  const [data] = useState([...]);
+  const filters = [...];
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      filterProps: {
+        variation: 'flyout', // default
+        updateMethod: 'batch', // default
+        primaryActionLabel: 'Apply', // default
+        secondaryActionLabel: 'Cancel', // default
+        flyoutIconDescription: 'Open filters', // default
+        shouldClickOutsideToClose: false, // default
+        filters,
+      },
+      DatagridActions,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
+    },
+    useFiltering
+  );
+  return <Datagrid datagridState={datagridState} />;
+};
+```
+
+### `filterProps` types
+
+```ts
+filterProps: {
+  /** The variation of filtering */
+  variation: 'flyout'|'panel',
+  /** The update method in which to filter, instant automatically
+      applies the filters, batch the user has to click apply */
+  updateMethod: 'batch'|'instant',
+  /** Text for primary action button, default is 'Apply' */
+  primaryActionLabel: string,
+  /** Text for secondary action button, default is 'Cancel' */
+  secondaryActionLabel: string,
+  /** Text for flyout icon description */
+  flyoutIconDescription: string,
+  /** Array of objects to render filters in flyout */
+  filters: object[]
+}
+```
+
+<Canvas>
+  <Story
+    id={getStoryId(
+      Datagrid.displayName,
+      'filtering-usage-story',
+      '/Extensions/Filtering'
+    )}
+  />
+</Canvas>
+
 ## Code sample
 
 <CodesandboxLink exampleDirectory="Datagrid" />

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -23,7 +23,6 @@ import {
   useSelectAllWithToggle,
   useStickyColumn,
   useActionsColumn,
-  useFiltering,
 } from '.';
 
 import { SelectAllWithToggle, LeftPanelStory } from './Datagrid.stories/index';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -7,7 +7,6 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { StatusIcon } from '../StatusIcon';
 import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
@@ -27,7 +26,7 @@ import {
   useFiltering,
 } from '.';
 
-import { SelectAllWitHToggle, LeftPanelStory } from './Datagrid.stories/index';
+import { SelectAllWithToggle, LeftPanelStory } from './Datagrid.stories/index';
 import mdx from './Datagrid.mdx';
 
 import { pkg } from '../../settings';
@@ -309,216 +308,6 @@ export const SelectableRow = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const Filtering = () => {
-  const headers = [
-    {
-      Header: 'Row Index',
-      accessor: (row, i) => i,
-      sticky: 'left',
-      id: 'rowIndex', // id is required when accessor is a function.
-    },
-    {
-      Header: 'First Name',
-      accessor: 'firstName',
-    },
-    {
-      Header: 'Last Name',
-      accessor: 'lastName',
-    },
-    {
-      Header: 'Age',
-      accessor: 'age',
-      width: 50,
-    },
-    {
-      Header: 'Visits',
-      accessor: 'visits',
-      filter: 'number',
-      width: 60,
-    },
-    {
-      Header: 'Status',
-      accessor: 'status',
-    },
-    // Shows the date filter example
-    {
-      Header: 'Joined',
-      accessor: 'joined',
-      filter: 'date',
-      Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
-    },
-    // Shows the checkbox filter example
-    {
-      Header: 'Password strength',
-      accessor: 'passwordStrength',
-      filter: 'checkbox',
-      Cell: ({ cell: { value } }) => {
-        const iconProps = {
-          size: 'sm',
-          theme: 'light',
-          kind: value,
-          iconDescription: value,
-        };
-
-        return (
-          <span
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
-            <StatusIcon {...iconProps} />
-            {iconProps.iconDescription}
-          </span>
-        );
-      },
-    },
-    // Shows the checkbox filter example
-    {
-      Header: 'Role',
-      accessor: 'role',
-    },
-  ];
-
-  const columns = React.useMemo(() => headers, []);
-  const [data] = useState(makeData(20));
-
-  const filters = [
-    {
-      type: 'date',
-      column: 'joined',
-      props: {
-        DatePicker: {
-          datePickerType: 'range',
-        },
-        DatePickerInput: {
-          start: {
-            id: 'date-picker-input-id-start',
-            placeholder: 'mm/dd/yyyy',
-            labelText: 'Joined start date',
-          },
-          end: {
-            id: 'date-picker-input-id-end',
-            placeholder: 'mm/dd/yyyy',
-            labelText: 'Joined end date',
-          },
-        },
-      },
-    },
-    {
-      type: 'number',
-      column: 'visits',
-      props: {
-        NumberInput: {
-          min: 0,
-          id: 'visits-number-input',
-          invalidText: 'A valid value is required',
-          label: 'Visits',
-          placeholder: 'Type a number amount of visits',
-        },
-      },
-    },
-    {
-      type: 'checkbox',
-      column: 'passwordStrength',
-      props: {
-        FormGroup: {
-          legendText: 'Password strength',
-        },
-        Checkbox: [
-          {
-            id: 'normal',
-            labelText: 'Normal',
-            value: 'normal',
-          },
-          {
-            id: 'minor-warning',
-            labelText: 'Minor warning',
-            value: 'minor-warning',
-          },
-          {
-            id: 'critical',
-            labelText: 'Critical',
-            value: 'critical',
-          },
-        ],
-      },
-    },
-    {
-      type: 'radio',
-      column: 'role',
-      props: {
-        FormGroup: {
-          legendText: 'Role',
-        },
-        RadioButtonGroup: {
-          orientation: 'vertical',
-          legend: 'Role legend',
-          name: 'role-radio-button-group',
-        },
-        RadioButton: [
-          {
-            id: 'developer',
-            labelText: 'Developer',
-            value: 'developer',
-          },
-          {
-            id: 'designer',
-            labelText: 'Designer',
-            value: 'designer',
-          },
-          {
-            id: 'researcher',
-            labelText: 'Researcher',
-            value: 'researcher',
-          },
-        ],
-      },
-    },
-    {
-      type: 'dropdown',
-      column: 'status',
-      props: {
-        Dropdown: {
-          id: 'marital-status-dropdown',
-          ariaLabel: 'Marital status dropdown',
-          items: ['relationship', 'complicated', 'single'],
-          label: 'Marital status',
-          titleText: 'Marital status',
-        },
-      },
-    },
-  ];
-
-  const datagridState = useDatagrid(
-    {
-      columns,
-      data,
-      emptyStateTitle: 'No filters match',
-      emptyStateDescription:
-        'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
-      filterProps: {
-        variation: 'flyout', // default
-        updateMethod: 'instant', // default
-        primaryActionLabel: 'Apply', // default
-        secondaryActionLabel: 'Cancel', // default
-        flyoutIconDescription: 'Open filters', // default
-        onFlyoutOpen: action('onFlyoutOpen'),
-        onFlyoutClose: action('onFlyoutClose'),
-        filters,
-      },
-      DatagridActions,
-      batchActions: true,
-      toolbarBatchActions: getBatchActions(),
-    },
-    useSelectRows,
-    useFiltering
-  );
-
-  return <Datagrid datagridState={{ ...datagridState }} />;
-};
-
 export const RadioSelect = () => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
@@ -633,7 +422,7 @@ export const SelectItemsInAllPages = () => {
     </>
   );
 };
-SelectItemsInAllPages.story = SelectAllWitHToggle;
+SelectItemsInAllPages.story = SelectAllWithToggle;
 
 export const LeftPanel = () => {
   const columns = React.useMemo(() => defaultHeader, []);

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -161,8 +161,6 @@ const DatagridToolbar = (datagridState) => {
     datagridState;
   const { filterTags, EventEmitter } = useContext(FilterContext);
 
-  console.log({ filters: state.filters });
-
   const renderFilterSummary = () =>
     state.filters.length > 0 && (
       <FilterSummary

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -161,6 +161,8 @@ const DatagridToolbar = (datagridState) => {
     datagridState;
   const { filterTags, EventEmitter } = useContext(FilterContext);
 
+  console.log({ filters: state.filters });
+
   const renderFilterSummary = () =>
     state.filters.length > 0 && (
       <FilterSummary

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/Filtering/Filtering.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/Filtering/Filtering.stories.js
@@ -1,0 +1,335 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import { Add16 } from '@carbon/icons-react';
+import { action } from '@storybook/addon-actions';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../../../global/js/utils/story-helper';
+import { Datagrid, useDatagrid, useFiltering } from '../../index';
+import styles from '../../_storybook-styles.scss';
+import mdx from '../../Datagrid.mdx';
+import { makeData } from '../../utils/makeData';
+import { ARG_TYPES } from '../../utils/getArgTypes';
+import { DatagridActions } from '../../utils/DatagridActions';
+import { StatusIcon } from '../../../StatusIcon';
+
+export default {
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/Filtering`,
+  component: Datagrid,
+  parameters: {
+    styles,
+    docs: { page: mdx },
+  },
+};
+
+const getBatchActions = () => {
+  return [
+    {
+      label: 'Duplicate',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Add',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Select all',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+      type: 'select_all',
+    },
+    {
+      label: 'Publish to catalog',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Download',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+    },
+    {
+      label: 'Delete',
+      renderIcon: Add16,
+      onClick: action('Clicked batch action button'),
+      hasDivider: true,
+      kind: 'danger',
+    },
+  ];
+};
+
+const FilteringUsage = ({ defaultGridProps }) => {
+  const { gridDescription, gridTitle, useDenseHeader, filterProps } =
+    defaultGridProps;
+
+  const headers = [
+    {
+      Header: 'Row Index',
+      accessor: (row, i) => i,
+      sticky: 'left',
+      id: 'rowIndex', // id is required when accessor is a function.
+    },
+    {
+      Header: 'First Name',
+      accessor: 'firstName',
+    },
+    {
+      Header: 'Last Name',
+      accessor: 'lastName',
+    },
+    {
+      Header: 'Age',
+      accessor: 'age',
+      width: 50,
+    },
+    {
+      Header: 'Visits',
+      accessor: 'visits',
+      filter: 'number',
+      width: 60,
+    },
+    {
+      Header: 'Status',
+      accessor: 'status',
+    },
+    // Shows the date filter example
+    {
+      Header: 'Joined',
+      accessor: 'joined',
+      filter: 'date',
+      Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
+    },
+    // Shows the checkbox filter example
+    {
+      Header: 'Password strength',
+      accessor: 'passwordStrength',
+      filter: 'checkbox',
+      Cell: ({ cell: { value } }) => {
+        const iconProps = {
+          size: 'sm',
+          theme: 'light',
+          kind: value,
+          iconDescription: value,
+        };
+
+        return (
+          <span
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <StatusIcon {...iconProps} />
+            {iconProps.iconDescription}
+          </span>
+        );
+      },
+    },
+    // Shows the checkbox filter example
+    {
+      Header: 'Role',
+      accessor: 'role',
+    },
+  ];
+
+  const columns = React.useMemo(() => headers, []);
+  const [data] = useState(makeData(20));
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      DatagridActions,
+      batchActions: true,
+      toolbarBatchActions: getBatchActions(),
+      filterProps,
+      gridTitle,
+      gridDescription,
+      useDenseHeader,
+    },
+    useFiltering
+  );
+
+  return <Datagrid datagridState={datagridState} />;
+};
+
+const FilteringTemplateWrapper = ({ ...args }) => {
+  return <FilteringUsage defaultGridProps={{ ...args }} />;
+};
+
+const filters = [
+  {
+    type: 'date',
+    column: 'joined',
+    props: {
+      DatePicker: {
+        datePickerType: 'range',
+      },
+      DatePickerInput: {
+        start: {
+          id: 'date-picker-input-id-start',
+          placeholder: 'mm/dd/yyyy',
+          labelText: 'Joined start date',
+        },
+        end: {
+          id: 'date-picker-input-id-end',
+          placeholder: 'mm/dd/yyyy',
+          labelText: 'Joined end date',
+        },
+      },
+    },
+  },
+  {
+    type: 'number',
+    column: 'visits',
+    props: {
+      NumberInput: {
+        min: 0,
+        id: 'visits-number-input',
+        invalidText: 'A valid value is required',
+        label: 'Visits',
+        placeholder: 'Type a number amount of visits',
+      },
+    },
+  },
+  {
+    type: 'checkbox',
+    column: 'passwordStrength',
+    props: {
+      FormGroup: {
+        legendText: 'Password strength',
+      },
+      Checkbox: [
+        {
+          id: 'normal',
+          labelText: 'Normal',
+          value: 'normal',
+        },
+        {
+          id: 'minor-warning',
+          labelText: 'Minor warning',
+          value: 'minor-warning',
+        },
+        {
+          id: 'critical',
+          labelText: 'Critical',
+          value: 'critical',
+        },
+      ],
+    },
+  },
+  {
+    type: 'radio',
+    column: 'role',
+    props: {
+      FormGroup: {
+        legendText: 'Role',
+      },
+      RadioButtonGroup: {
+        orientation: 'vertical',
+        legend: 'Role legend',
+        name: 'role-radio-button-group',
+      },
+      RadioButton: [
+        {
+          id: 'developer',
+          labelText: 'Developer',
+          value: 'developer',
+        },
+        {
+          id: 'designer',
+          labelText: 'Designer',
+          value: 'designer',
+        },
+        {
+          id: 'researcher',
+          labelText: 'Researcher',
+          value: 'researcher',
+        },
+      ],
+    },
+  },
+  {
+    type: 'dropdown',
+    column: 'status',
+    props: {
+      Dropdown: {
+        id: 'marital-status-dropdown',
+        ariaLabel: 'Marital status dropdown',
+        items: ['relationship', 'complicated', 'single'],
+        label: 'Marital status',
+        titleText: 'Marital status',
+      },
+    },
+  },
+];
+
+export const FilteringUsageStory = prepareStory(FilteringTemplateWrapper, {
+  storyName: 'Filter flyout - batch',
+  argTypes: {
+    gridTitle: ARG_TYPES.gridTitle,
+    gridDescription: ARG_TYPES.gridDescription,
+    useDenseHeader: ARG_TYPES.useDenseHeader,
+    filterProps: ARG_TYPES.filterProps,
+  },
+  args: {
+    gridTitle: 'Data table title',
+    gridDescription: 'Additional information if needed',
+    useDenseHeader: false,
+    emptyStateTitle: 'No filters match',
+    emptyStateDescription:
+      'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
+    filterProps: {
+      variation: 'flyout',
+      updateMethod: 'batch',
+      primaryActionLabel: 'Apply',
+      secondaryActionLabel: 'Cancel',
+      flyoutIconDescription: 'Open filters',
+      onFlyoutOpen: action('onFlyoutOpen'),
+      onFlyoutClose: action('onFlyoutClose'),
+      filters,
+    },
+  },
+});
+
+export const FilteringInstantUsageStory = prepareStory(
+  FilteringTemplateWrapper,
+  {
+    storyName: 'Filter flyout - instant',
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+      filterProps: ARG_TYPES.filterProps,
+    },
+    args: {
+      gridTitle: 'Data table title',
+      gridDescription: 'Additional information if needed',
+      useDenseHeader: false,
+      emptyStateTitle: 'No filters match',
+      emptyStateDescription:
+        'Data was not found with the current filters applied. Change filters or clear filters to see other results.',
+      filterProps: {
+        variation: 'flyout',
+        updateMethod: 'instant',
+        primaryActionLabel: 'Apply',
+        secondaryActionLabel: 'Cancel',
+        flyoutIconDescription: 'Open filters',
+        onFlyoutOpen: action('onFlyoutOpen'),
+        onFlyoutClose: action('onFlyoutClose'),
+        filters,
+      },
+    },
+  }
+);

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -17,13 +17,7 @@ import {
   ModalFooter,
   Dropdown,
 } from '@carbon/react';
-import {
-  Download,
-  Filter,
-  Add,
-  Restart,
-  ChevronDown,
-} from '@carbon/react/icons';
+import { Download, Add, Restart, ChevronDown } from '@carbon/react/icons';
 import { action } from '@storybook/addon-actions';
 import { pkg } from '../../../settings';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
@@ -49,9 +43,7 @@ export const DatagridActions = (datagridState) => {
   const refreshColumns = () => {
     alert('refreshing...');
   };
-  const leftPanelClick = () => {
-    alert('open/close left panel...');
-  };
+
   const searchForAColumn = 'Search';
   const isNothingSelected = selectedFlatRows.length === 0;
   const style = {

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -93,16 +93,6 @@ export const DatagridActions = (datagridState) => {
                 onClick={downloadCsv}
               />
             </div>
-            <div style={style}>
-              <Button
-                kind="ghost"
-                hasIconOnly
-                tooltipPosition="bottom"
-                renderIcon={Filter}
-                iconDescription={'Left panel'}
-                onClick={leftPanelClick}
-              />
-            </div>
             {renderFilterFlyout()}
             <RowSizeDropdown {...rowSizeDropdownProps} />
             <div style={style} className={`${blockClass}__toolbar-divider`}>
@@ -133,66 +123,56 @@ export const DatagridActions = (datagridState) => {
         )}
       </TableToolbarContent>
     ) : !mobileToolbar ? (
-      <>
-        <Button
-          kind="ghost"
-          hasIconOnly
-          tooltipPosition="bottom"
-          renderIcon={Filter}
-          iconDescription={'Left panel'}
-          onClick={leftPanelClick}
+      <TableToolbarContent>
+        <TableToolbarSearch
+          size="xl"
+          id="columnSearch"
+          persistent
+          placeHolderText={searchForAColumn}
+          onChange={(e) => setGlobalFilter(e.target.value)}
         />
-        <TableToolbarContent>
-          <TableToolbarSearch
-            size="xl"
-            id="columnSearch"
-            persistent
-            placeHolderText={searchForAColumn}
-            onChange={(e) => setGlobalFilter(e.target.value)}
+        {renderFilterFlyout()}
+        <RowSizeDropdown {...rowSizeDropdownProps} />
+        <div style={style}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            tooltipPosition="bottom"
+            renderIcon={Restart}
+            iconDescription={'Refresh'}
+            onClick={refreshColumns}
           />
-          {renderFilterFlyout()}
-          <RowSizeDropdown {...rowSizeDropdownProps} />
+        </div>
+        <div style={style}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            tooltipPosition="bottom"
+            renderIcon={Download}
+            iconDescription={'Download CSV'}
+            onClick={downloadCsv}
+          />
+        </div>
+        {CustomizeColumnsButton && (
           <div style={style}>
-            <Button
-              kind="ghost"
-              hasIconOnly
-              tooltipPosition="bottom"
-              renderIcon={Restart}
-              iconDescription={'Refresh'}
-              onClick={refreshColumns}
-            />
+            <CustomizeColumnsButton />
           </div>
-          <div style={style}>
-            <Button
-              kind="ghost"
-              hasIconOnly
-              tooltipPosition="bottom"
-              renderIcon={Download}
-              iconDescription={'Download CSV'}
-              onClick={downloadCsv}
-            />
-          </div>
-          {CustomizeColumnsButton && (
-            <div style={style}>
-              <CustomizeColumnsButton />
-            </div>
-          )}
-          <ButtonMenu label="Primary button" renderIcon={Add}>
-            <ButtonMenuItem
-              itemText="Option 1"
-              onClick={action(`Click on ButtonMenu Option 1`)}
-            />
-            <ButtonMenuItem
-              itemText="Option 2"
-              onClick={action(`Click on ButtonMenu Option 2`)}
-            />
-            <ButtonMenuItem
-              itemText="Option 3"
-              onClick={action(`Click on ButtonMenu Option 3`)}
-            />
-          </ButtonMenu>
-        </TableToolbarContent>
-      </>
+        )}
+        <ButtonMenu label="Primary button" renderIcon={Add}>
+          <ButtonMenuItem
+            itemText="Option 1"
+            onClick={action(`Click on ButtonMenu Option 1`)}
+          />
+          <ButtonMenuItem
+            itemText="Option 2"
+            onClick={action(`Click on ButtonMenu Option 2`)}
+          />
+          <ButtonMenuItem
+            itemText="Option 3"
+            onClick={action(`Click on ButtonMenu Option 3`)}
+          />
+        </ButtonMenu>
+      </TableToolbarContent>
     ) : (
       <TableToolbarContent>
         <TableToolbarSearch

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getArgTypes.js
@@ -80,4 +80,10 @@ export const ARG_TYPES = {
     description:
       'This is an object containing all of the props used with the column customization extension. _This value is set/passed inside of the `datagridState` object._',
   },
+  filterProps: {
+    name: 'Filter props',
+    control: 'object',
+    description:
+      'This is an object for all the props passed into the filter flyout and filter panel',
+  },
 };


### PR DESCRIPTION
Contributes to #2523 

This adds documentation for filter flyout and adds a story file for data table filtering.

#### What did you change?
- Changed filtering stories from `Datagrid.stories.js` and moved it to `Filtering.stories.js`
- Fixed typo with `SelectAllWithToggle` import and updated path to fix error
- Adds Filtering docs to `Datagrid.mdx`

