### PR TITLE
fix(Datagrid): resolve react hook error from datagrid row

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -193,10 +193,14 @@ export const InitialLoad = () => {
     fetchData();
   }, []);
 
+  const emptyStateTitle = 'Empty state title';
+  const emptyStateDescription = 'Description explaining why the table is empty';
   const datagridState = useDatagrid({
     columns,
     data,
     isFetching,
+    emptyStateTitle,
+    emptyStateDescription,
   });
 
   return <Datagrid datagridState={{ ...datagridState }} />;

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -6,14 +6,12 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import { DataTable, SkeletonText } from 'carbon-components-react';
 import { px } from '@carbon/layout';
 import cx from 'classnames';
 import { selectionColumnId } from '../common-column-ids';
 import { pkg, carbon } from '../../../settings';
-import { InlineEditContext } from './addons/InlineEdit/InlineEditContext/InlineEditContext';
-import { getCellIdAsObject } from './addons/InlineEdit/InlineEditContext/getCellIdAsObject';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -30,9 +28,6 @@ const rowHeights = {
 // eslint-disable-next-line react/prop-types
 const DatagridRow = (datagridState) => {
   const { row, rowSize, withNestedRows } = datagridState;
-  const { state } = useContext(InlineEditContext);
-  const { activeCellId } = state;
-  const activeCellObject = activeCellId && getCellIdAsObject(activeCellId);
 
   const getVisibleNestedRowCount = ({ isExpanded, subRows }) => {
     let size = 0;
@@ -51,8 +46,6 @@ const DatagridRow = (datagridState) => {
         [`${blockClass}__carbon-row-expanded`]: row.isExpanded,
         [`${blockClass}__carbon-row-expandable`]: row.canExpand,
         [`${carbon.prefix}--data-table--selected`]: row.isSelected,
-        [`${blockClass}__carbon-row-hover-active`]:
-          activeCellObject && row.index === activeCellObject.row,
       })}
       {...row.getRowProps()}
       key={row.id}


### PR DESCRIPTION
Contributes to #2498 

This PR resolves the React hooks error that has been observed from the Datagrid component. This was stemming from the DatagridRow component which is conditionally rendered and then uses `useContext`, so we'll have to find another way to add the `${blockClass}__carbon-row-hover-active` class (this is something that is specific to the inline editing extension, fyi @Ratheeshrajan).

<img src="https://user-images.githubusercontent.com/30137991/204570735-44c5505a-a313-4f55-952e-199ae274a7e9.png" alt="React hooks error" />

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
```
#### How did you test and verify your work?
Storybook