### PR TITLE
chore(Datagrid): make note about validation on storybook example

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -7,6 +7,7 @@
  */
 
 import React, { useState } from 'react';
+import { CodeSnippet } from 'carbon-components-react';
 import { Edit16, TrashCan16 } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
 import {
@@ -14,11 +15,14 @@ import {
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid, useInlineEdit } from '../../index';
+import { pkg } from '../../../../settings';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { getInlineEditColumns } from '../../utils/getInlineEditColumns';
+
+const storyBlockClass = `storybook-${pkg.prefix}--datagrid`;
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/InlineEdit`,
@@ -90,7 +94,38 @@ const InlineEditUsage = ({ ...args }) => {
     useInlineEdit
   );
 
-  return <Datagrid datagridState={datagridState} />;
+  return (
+    <div>
+      <Datagrid datagridState={datagridState} />
+      <p>
+        The following inline edit columns incorporate validation:
+        <CodeSnippet
+          className={`${storyBlockClass}__validation-code-snippet`}
+          type="inline"
+        >
+          first_name
+        </CodeSnippet>
+        <CodeSnippet
+          className={`${storyBlockClass}__validation-code-snippet`}
+          type="inline"
+        >
+          last_name
+        </CodeSnippet>
+        <CodeSnippet
+          className={`${storyBlockClass}__validation-code-snippet`}
+          type="inline"
+        >
+          age
+        </CodeSnippet>
+        <CodeSnippet
+          className={`${storyBlockClass}__validation-code-snippet`}
+          type="inline"
+        >
+          visits
+        </CodeSnippet>
+      </p>
+    </div>
+  );
 };
 
 const InlineEditTemplateWrapper = ({ ...args }) => {

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -102,24 +102,28 @@ const InlineEditUsage = ({ ...args }) => {
         <CodeSnippet
           className={`${storyBlockClass}__validation-code-snippet`}
           type="inline"
+          hideCopyButton
         >
           first_name
         </CodeSnippet>
         <CodeSnippet
           className={`${storyBlockClass}__validation-code-snippet`}
           type="inline"
+          hideCopyButton
         >
           last_name
         </CodeSnippet>
         <CodeSnippet
           className={`${storyBlockClass}__validation-code-snippet`}
           type="inline"
+          hideCopyButton
         >
           age
         </CodeSnippet>
         <CodeSnippet
           className={`${storyBlockClass}__validation-code-snippet`}
           type="inline"
+          hideCopyButton
         >
           visits
         </CodeSnippet>

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -104,4 +104,7 @@ $block-class: #{$pkg-prefix}--datagrid;
 
 .storybook-#{$block-class}__validation-code-snippet {
   margin-right: $spacing-03;
+  // prevent code-snippet from inheriting font-size
+  // stylelint-disable-next-line carbon/type-token-use
+  font-size: 0;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -101,3 +101,7 @@ $block-class: #{$pkg-prefix}--datagrid;
 .#{$block-class}__mobile-toolbar-modal .#{$carbon-prefix}--dropdown__wrapper {
   margin-bottom: $spacing-07;
 }
+
+.storybook-#{$block-class}__validation-code-snippet {
+  margin-right: $spacing-03;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -81,8 +81,11 @@ export const getInlineEditColumns = () => {
       accessor: 'visits',
       width: 120,
       inlineEdit: {
+        validator: (n) => n && n < 10,
         type: 'number',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid number, must be 10 or greater',
+        }, // These props are passed to the Carbon component used for inline editing
       },
     },
     {


### PR DESCRIPTION
Contributes to #2506 

Adds a note about which columns have validation on the storybook example.
![Screen Shot 2022-12-15 at 4 30 15 PM](https://user-images.githubusercontent.com/10215203/207971111-4240d388-71ca-464f-bcdb-125682a25c98.png)

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
```
#### How did you test and verify your work?
Storybook