### PR TITLE
chore(Datagrid): provide context for columns using validation (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -14,11 +14,15 @@ import {
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
 import { Datagrid, useDatagrid, useInlineEdit } from '../../index';
+import { pkg } from '../../../../settings';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
 import { makeData } from '../../utils/makeData';
 import { ARG_TYPES } from '../../utils/getArgTypes';
 import { getInlineEditColumns } from '../../utils/getInlineEditColumns';
+
+const blockClass = `${pkg.prefix}--datagrid`;
+const storybookBlockClass = `storybook-${blockClass}__validation-code-snippet`;
 
 export default {
   title: `${getStoryTitle(Datagrid.displayName)}/Extensions/InlineEdit`,
@@ -90,7 +94,18 @@ const InlineEditUsage = ({ ...args }) => {
     useInlineEdit
   );
 
-  return <Datagrid datagridState={datagridState} />;
+  return (
+    <div>
+      <Datagrid datagridState={datagridState} />
+      <p>
+        The following inline edit columns incorporate validation:
+        <code className={storybookBlockClass}>{'first_name'}</code>
+        <code className={storybookBlockClass}>{'last_name'}</code>
+        <code className={storybookBlockClass}>{'age'}</code>
+        <code className={storybookBlockClass}>{'visits'}</code>
+      </p>
+    </div>
+  );
 };
 
 const InlineEditTemplateWrapper = ({ ...args }) => {

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -105,10 +105,12 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
 
 .storybook-#{$block-class}__validation-code-snippet {
   @include type.font-family($name: mono);
-  @include type.type-style('body-compact-01');
+  @include type.type-style('code-01');
 
-  padding: 0 $spacing-02;
+  display: inline-block;
+  padding: 0 $spacing-03;
   margin-right: $spacing-03;
   background-color: $field-01;
+  border: 2px solid transparent;
   border-radius: $spacing-02;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -102,3 +102,13 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
   .#{c4p-settings.$carbon-prefix}--dropdown__wrapper {
   margin-bottom: $spacing-07;
 }
+
+.storybook-#{$block-class}__validation-code-snippet {
+  @include type.font-family($name: mono);
+  @include type.type-style('body-compact-01');
+
+  padding: 0 $spacing-02;
+  margin-right: $spacing-03;
+  background-color: $field-01;
+  border-radius: $spacing-02;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
@@ -109,8 +109,8 @@ $block-class: #{c4p-settings.$pkg-prefix}--datagrid;
 
   display: inline-block;
   padding: 0 $spacing-03;
+  border: 2px solid transparent;
   margin-right: $spacing-03;
   background-color: $field-01;
-  border: 2px solid transparent;
   border-radius: $spacing-02;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
@@ -82,8 +82,11 @@ export const getInlineEditColumns = () => {
       accessor: 'visits',
       width: 120,
       inlineEdit: {
+        validator: (n) => n && n < 10,
         type: 'number',
-        inputProps: {}, // These props are passed to the Carbon component used for inline editing
+        inputProps: {
+          invalidText: 'Invalid number, must be 10 or greater',
+        }, // These props are passed to the Carbon component used for inline editing
       },
     },
     {


### PR DESCRIPTION
Contributes to #2506 

Adds a note about which columns have validation on the storybook example.
![Screen Shot 2022-12-15 at 4 30 15 PM](https://user-images.githubusercontent.com/10215203/207971111-4240d388-71ca-464f-bcdb-125682a25c98.png)

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
packages/cloud-cognitive/src/components/Datagrid/_storybook-styles.scss
packages/cloud-cognitive/src/components/Datagrid/utils/getInlineEditColumns.js
```
#### How did you test and verify your work?
Storybook