### PR TITLE
chore: fix v10 examples

### DIFF
--- a/examples/carbon-for-ibm-products/example-gallery/package.json
+++ b/examples/carbon-for-ibm-products/example-gallery/package.json
@@ -14,7 +14,6 @@
     "@carbon/elements": "^10",
     "@carbon/ibm-products": "^1",
     "@carbon/icons-react": "^10",
-    "babel-preset-ibm-cloud-cognitive": "^0.14.24",
     "carbon-components": "^10",
     "carbon-components-react": "^7",
     "carbon-icons": "latest",

--- a/examples/carbon-for-ibm-products/prefix-example/src/Example/Example.js
+++ b/examples/carbon-for-ibm-products/prefix-example/src/Example/Example.js
@@ -14,8 +14,6 @@ import './_example.scss';
 // but which we want to use in their 'canary' form. Note that that has to
 // be done in an import so that it happens before all component imports.
 
-import '../config'; // must come before @carbon/ibm-products component instance created
-
 export const Example = () => {
   const [isOpen, setIsOpen] = useState(true);
   const handleOpenModalClick = () => {


### PR DESCRIPTION
Corrects package.json in the `example-gallery` and location of prefix in `prefix-example`;

Built and ran examples locally.