### PR TITLE
chore: fix example gallery tests

### DIFF
--- a/examples/carbon-for-ibm-products/.babelrc
+++ b/examples/carbon-for-ibm-products/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": [
+        "@babel/preset-react"
+    ]
+}

--- a/examples/carbon-for-ibm-products/gallery-examples.test.js
+++ b/examples/carbon-for-ibm-products/gallery-examples.test.js
@@ -53,16 +53,8 @@ describe('All examples', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  /* ** SKIP TEST **, reason: 'Test currently fails due to XYZ.' */
-  it.skip('AboutModal renders', () => {
+  it('AboutModal renders', () => {
     render(<AboutModalExample />);
-    // expect no errors int the console
-    expect(console.error).not.toHaveBeenCalled();
-  });
-
-  /* ** SKIP TEST **, reason: 'Carbon v11 not supported in v1 repo.' */
-  it.skip('CarbonV11Template renders', () => {
-    render(<CarbonV11TemplateExample />);
     // expect no errors int the console
     expect(console.error).not.toHaveBeenCalled();
   });

--- a/scripts/example-gallery-builder/gallery-config.js
+++ b/scripts/example-gallery-builder/gallery-config.js
@@ -198,11 +198,13 @@ import { init } from './test-common';
       ? `  /* ** SKIP TEST **, reason: '${skipReason}' */\n`
       : '';
 
-    tests.push(`${skipTestReason}  it${skipTestString}('${sanitizedDir} renders', () => {
+    if (!skipImport) {
+      tests.push(`${skipTestReason}  it${skipTestString}('${sanitizedDir} renders', () => {
     render(<${sanitizedDir}Example />);
     // expect no errors int the console
     expect(console.error).not.toHaveBeenCalled();
   });`);
+    }
   });
 
   const preTest = `


### PR DESCRIPTION
Add a `.babelrc` to examples/carbon-for-ibm-products for `gallery-examples.test.js` as well.
Remove skipped test for CarbonV11Template since the import gets skipped (so it’s undefined in the test even if skipped).

There might be a better approach, but this seemed simplest for now. This should still allow skipped tests if we need but not create tests for skipped imports.

#### What did you change?
`examples/carbon-for-ibm-products/.babelrc`
`scripts/example-gallery-builder/gallery-config.js`

`examples/carbon-for-ibm-products/gallery-examples.test.js` (generated in precommit)

#### How did you test and verify your work?
During commit/precommit 😅 