### PR TITLE
fix(ButtonMenu): update lg size

### DIFF
--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
@@ -24,7 +24,7 @@ const componentName = 'ButtonMenu';
 
 // Default values for props
 const defaults = {
-  size: 'default',
+  size: 'lg',
   kind: 'primary',
 };
 

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
@@ -53,41 +53,46 @@ export let ButtonMenu = React.forwardRef(
       ...rest
     },
     ref
-  ) => (
-    <OverflowMenu
-      {
-        // Pass through any other property values as HTML attributes.
-        ...rest
-      }
-      className={cx(
-        blockClass, // Apply the block class to the main HTML element
-        className // Apply any supplied class names to the main HTML element.
-      )}
-      menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
-      renderIcon={() => (
-        <div
-          className={cx([
-            `${blockClass}__trigger`,
-            `${carbon.prefix}--btn`,
-            `${carbon.prefix}--btn--${kind}`,
-            `${carbon.prefix}--btn--${size}`,
-          ])}
-        >
-          {label}
-          {Icon && (
-            <Icon
-              aria-hidden="true"
-              aria-label={iconDescription}
-              className={`${carbon.prefix}--btn__icon`}
-            />
-          )}
-        </div>
-      )}
-      innerRef={ref}
-    >
-      {children}
-    </OverflowMenu>
-  )
+  ) => {
+    const buttonSize = size === 'lg' ? 'default' : size;
+
+    return (
+      <OverflowMenu
+        {
+          // Pass through any other property values as HTML attributes.
+          ...rest
+        }
+        className={cx(
+          blockClass, // Apply the block class to the main HTML element
+          className // Apply any supplied class names to the main HTML element.
+        )}
+        menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
+        size={size}
+        renderIcon={() => (
+          <div
+            className={cx([
+              `${blockClass}__trigger`,
+              `${carbon.prefix}--btn`,
+              `${carbon.prefix}--btn--${kind}`,
+              `${carbon.prefix}--btn--${buttonSize}`,
+            ])}
+          >
+            {label}
+            {Icon && (
+              <Icon
+                aria-hidden="true"
+                aria-label={iconDescription}
+                className={`${carbon.prefix}--btn__icon`}
+              />
+            )}
+          </div>
+        )}
+        innerRef={ref}
+      >
+        {children}
+      </OverflowMenu>
+    );
+  }
 );
 
 // Return a placeholder if not released and not enabled by feature flag

--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.test.js
@@ -81,8 +81,8 @@ describe(componentName, () => {
   });
 
   it('renders size prop', () => {
-    renderMenu({ size: 'lg' });
-    expect(screen.getByText(label)).toHaveClass(`${carbon.prefix}--btn--lg`);
+    renderMenu({ size: 'md' });
+    expect(screen.getByText(label)).toHaveClass(`${carbon.prefix}--btn--md`);
   });
 
   it('adds additional props to the containing node', () => {


### PR DESCRIPTION
Contributes to #2508

Current version of `ButtonMenu` uses the incorrect prop for Carbon buttons.
The `lg` props maps to 64px height button in v10, but our designs use the 48px button (`default`).
Since the `lg` prop will map to the correct 48px in v11, we accept `lg` and map it to `default` in v10.

This also allows us to pass `size` to OverflowMenu so that the item sizes match the button size, as shown in the [design guidance](https://pages.github.ibm.com/cdai-design/pal/components/button-guidance/menu-and-combo-buttons/).

Have not opened a v11 PR since ButtonMenu is out of sync on v11 — FYI @qbi11y 


#### What did you change?
`ButtonMenu.js`
- Map `lg` to `default` for v10
- Pass `size` to OverflowMenu

`ButtonMenu.test.js`
- Change the checked prop from `lg` to `md` since that behaves consistently

#### How did you test and verify your work?
- Storybook