### PR TITLE
fix: tagset overflow first open

### DIFF
--- a/packages/cloud-cognitive/src/components/TagSet/TagSetOverflow.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSetOverflow.js
@@ -47,7 +47,9 @@ export const TagSetOverflow = React.forwardRef(
     const overflowTagContent = useRef(null);
 
     const handleChange = (ev, { open }) => {
-      setTipOpen(open);
+      if (ev.type === 'click') {
+        setTipOpen(() => open);
+      }
     };
 
     const handleShowAllTagsClick = (ev) => {


### PR DESCRIPTION
Fixes to #1677 Focus Issue in TagSet component when tooltip is opened for first time

#### What did you change?

Updates the handleChange method to check the event type as indicated in the related Carbon issue.

#### How did you test and verify your work?

1. In storybook change looking at the many tags story for TagSet. 
2. Change the width of the container until there are fewer than 10 items in the overflow.
3. Click the over flow.

Previously the tip only opened if the overflow already had focus (before the click). It should now correctly open and close as expected.