### PR TITLE
fix(ButtonMenu): menu size

### DIFF
--- a/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
+++ b/packages/cloud-cognitive/src/components/ButtonMenu/ButtonMenu.js
@@ -68,6 +68,7 @@ export let ButtonMenu = React.forwardRef(
         )}
         ariaLabel={menuAriaLabel}
         menuOptionsClass={cx(`${blockClass}__options`, menuOptionsClass)}
+        size={size}
         renderIcon={() => (
           <div
             className={cx([
@@ -151,8 +152,8 @@ ButtonMenu.propTypes = {
   renderIcon: Button.propTypes.renderIcon,
 
   /**
-   * The size of the button for the menu trigger. The values can be any valid
-   * value for the carbon Button component 'size' prop.
+   * The size of the button for the menu trigger.
+   * The menu button supports: sm, md, lg
    */
-  size: Button.propTypes.size,
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };


### PR DESCRIPTION
Pass `size` to OverflowMenu so that menu items match the button size, as shown in the [design guidance](https://pages.github.ibm.com/cdai-design/pal/components/button-guidance/menu-and-combo-buttons/).

Contributes to #2508

#### What did you change?
`ButtonMenu.js`

#### How did you test and verify your work?
Storybook