### PR TITLE
chore(Datagrid): fix actions dropdown styles

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -377,7 +377,7 @@ export const SortableColumns = () => {
   return <Datagrid datagridState={{ ...datagridState }} />;
 };
 
-export const DatagridActionsToolbar = () => {
+export const ActionsDropdown = () => {
   const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
   const datagridState = useDatagrid(

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -167,7 +167,12 @@ export const DatagridActions = (datagridState) => {
             <CustomizeColumnsButton />
           </div>
         )}
-        <ButtonMenu label="Primary button" renderIcon={Add16}>
+        <ButtonMenu
+          label="Primary button"
+          size="lg"
+          light
+          renderIcon={ChevronDown16}
+        >
           <ButtonMenuItem
             itemText="Option 1"
             onClick={action(`Click on ButtonMenu Option 1`)}


### PR DESCRIPTION
Contributes to #2508

Fixes for datagrid actions dropdown.

#### What did you change?
- Use `ChevronDown16` instead of `Add16` in examples
- Add `size` prop `lg` so menu matches button size
- Add `light` prop for consistent menu color with other menus
- Update story name to ActionsDropdown for easier discovery

#### How did you test and verify your work?
Storybook