### PR TITLE
feat: add a custom onClick function and other props in IdeEmptyState …

### DIFF
--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
@@ -225,6 +225,11 @@ IdeEmptyState.propTypes = {
        * The target prop to apply to the anchor link
        */
       target: PropTypes.string,
+      /**
+       * The onClick prop to apply a custom function
+       * when the button is clicked
+       */
+      onClick: PropTypes.func,
     }),
     /**
      * An array of links objects.

--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
@@ -58,12 +58,12 @@ const IdeEmptyState = ({ body, button, format, image, links, title }) => {
     const finalLinks = Array.isArray(links) ? links : [links];
     return (
       <ul>
-        {finalLinks.map(({ text, url, target = '_top' }) => (
+        {finalLinks.map(({ text, url, target = '_top', onClick, ...other }) => (
           <li
             {...{ className: `${prefix}__link`, key: `${text}:${url}` }}
             key={`${text}:${url}`}
           >
-            <CarbonLink href={url} target={target}>
+            <CarbonLink href={url} target={target} onClick={(e) => onClick(e)} {...other}>
               {text}
             </CarbonLink>
             {target === '_blank' && (

--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.js
@@ -63,7 +63,12 @@ const IdeEmptyState = ({ body, button, format, image, links, title }) => {
             {...{ className: `${prefix}__link`, key: `${text}:${url}` }}
             key={`${text}:${url}`}
           >
-            <CarbonLink href={url} target={target} onClick={(e) => onClick(e)} {...other}>
+            <CarbonLink
+              href={url}
+              target={target}
+              onClick={(e) => (onClick ? onClick(e) : false)}
+              {...other}
+            >
               {text}
             </CarbonLink>
             {target === '_blank' && (

--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.spec.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.spec.js
@@ -79,4 +79,15 @@ describe('IdeEmptyState', () => {
     ],
     'an array of objects'
   );
+  rendersWhenPropIsDefined(
+    'links',
+    [
+      {
+        text: 'Custom link 1',
+        url: '#',
+        onClick: () => console.log('custom function'),
+      },
+    ],
+    'an object'
+  );
 });

--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.stories.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.stories.js
@@ -86,4 +86,18 @@ storiesOf(getComponentLabel('IdeEmptyState'), module)
         ),
       }}
     />
+  ))
+  .add('Custom links: function', () => (
+    <IdeEmptyState
+      {...{
+      links: object('links', [
+          { 
+          text: 'Custom link whith a function', 
+          url: '#', 
+          onClick: () => console.log("This link has a custom function") 
+        },
+          { text: 'Custom link whithout a function', url: '#'},
+        ]),
+      }}
+    />
   ));

--- a/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.stories.js
+++ b/packages/cdai/src/components/IdeEmptyState/IdeEmptyState.stories.js
@@ -90,13 +90,13 @@ storiesOf(getComponentLabel('IdeEmptyState'), module)
   .add('Custom links: function', () => (
     <IdeEmptyState
       {...{
-      links: object('links', [
-          { 
-          text: 'Custom link whith a function', 
-          url: '#', 
-          onClick: () => console.log("This link has a custom function") 
-        },
-          { text: 'Custom link whithout a function', url: '#'},
+        links: object('links', [
+          {
+            text: 'Custom link whith a function',
+            url: '#',
+            onClick: () => console.log('This link has a custom function'),
+          },
+          { text: 'Custom link whithout a function', url: '#' },
         ]),
       }}
     />

--- a/packages/cdai/src/components/IdeEmptyState/README.md
+++ b/packages/cdai/src/components/IdeEmptyState/README.md
@@ -171,10 +171,12 @@ An array of links objects.
   {
     text: '...', (String, required)
     url: '...', (String, required)
+    onClick: () => ..., (Function, optional)
   },
   {
     text: '...', (String, required)
     url: '...', (String, required)
+    onClick: () => ..., (Function, optional)
   },
 ]
 ```
@@ -186,6 +188,10 @@ The text to display when rendering the link. Must be pre-translated.
 ##### url: String (Required)
 
 The link's destination.
+
+##### onClick: Function (Optional)
+
+The event handler for when the button is clicked.
 
 ## Remaining items to implement/designed
 

--- a/packages/cdai/src/components/IdeEmptyState/README.md
+++ b/packages/cdai/src/components/IdeEmptyState/README.md
@@ -176,7 +176,6 @@ An array of links objects.
   {
     text: '...', (String, required)
     url: '...', (String, required)
-    onClick: () => ..., (Function, optional)
   },
 ]
 ```
@@ -191,7 +190,7 @@ The link's destination.
 
 ##### onClick: Function (Optional)
 
-The event handler for when the button is clicked.
+The optional event handler for when the button is clicked.
 
 ## Remaining items to implement/designed
 

--- a/packages/cdai/src/components/IdeEmptyState/__snapshots__/IdeEmptyState.spec.js.snap
+++ b/packages/cdai/src/components/IdeEmptyState/__snapshots__/IdeEmptyState.spec.js.snap
@@ -224,6 +224,27 @@ exports[`IdeEmptyState renders when the links prop is defined as an object 1`] =
 ]
 `;
 
+exports[`IdeEmptyState renders when the links prop is defined as an object 2`] = `
+[
+  <IdeEmptyState
+    body={null}
+    button={null}
+    format="lg"
+    image="default"
+    links={
+      [
+        {
+          "onClick": [Function],
+          "text": "Custom link 1",
+          "url": "#",
+        },
+      ]
+    }
+    title="CHANGE ME"
+  />,
+]
+`;
+
 exports[`IdeEmptyState renders when the title prop is defined as a string 1`] = `
 [
   <IdeEmptyState


### PR DESCRIPTION
While working with `IdeEmptyState` component, I found out that the `links` prop does not support the onClick function. 

{{short description}}

#### What did you change?
Add support to pass down a custom function for the onClick function for `IdeEmptyState links`.
Add support to pass down any other props for `IdeEmptyState links`.

#### How did you test and verify your work?
storybook