### PR TITLE
fix(Datagrid): export useColumnCenterAlign

### DIFF
--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -74,7 +74,6 @@ export {
   useColumnOrder,
   useInlineEdit,
   useFiltering,
-  FilterFlyout,
 } from './Datagrid';
 export { EditTearsheet } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2020, 2021
+// Copyright IBM Corp. 2020, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -64,6 +64,7 @@ export {
   useOnRowClick,
   useSortableColumns,
   useRowIsMouseOver,
+  useColumnCenterAlign,
   useColumnRightAlign,
   useDisableSelectRows,
   useStickyColumn,

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -74,6 +74,7 @@ export {
   useColumnOrder,
   useInlineEdit,
   useFiltering,
+  FilterFlyout,
 } from './Datagrid';
 export { EditTearsheet } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';


### PR DESCRIPTION
Contributes to #2630 

Fix missing export from Datagrid extensions.

#### What did you change?
Add `useColumnCenterAlign`
```
packages/cloud-cognitive/src/components/index.js
```

#### How did you test and verify your work?
