### PR TITLE
fix(DataGrid): filter summary add heights options

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -161,7 +161,7 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
 
 const DatagridToolbar = (datagridState) => {
   const { width, ref } = useResizeDetector();
-  const { DatagridActions, DatagridBatchActions, batchActions, state } =
+  const { DatagridActions, DatagridBatchActions, batchActions, state, rowSize } =
     datagridState;
   const { filterTags, EventEmitter } = useContext(FilterContext);
 
@@ -173,8 +173,10 @@ const DatagridToolbar = (datagridState) => {
       />
     );
 
+  const getRowHeight = rowSize ? rowSize : 'lg';
+  
   return batchActions && DatagridActions ? (
-    <div ref={ref} className={`${blockClass}__table-toolbar`}>
+    <div ref={ref} className={cx(`${blockClass}__table-toolbar`, `${blockClass}__table-toolbar--${getRowHeight}`)}>
       <TableToolbar>
         {DatagridActions && DatagridActions(datagridState)}
         {DatagridBatchActionsToolbar &&

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -161,8 +161,13 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
 
 const DatagridToolbar = (datagridState) => {
   const { width, ref } = useResizeDetector();
-  const { DatagridActions, DatagridBatchActions, batchActions, state, rowSize } =
-    datagridState;
+  const {
+    DatagridActions,
+    DatagridBatchActions,
+    batchActions,
+    state,
+    rowSize,
+  } = datagridState;
   const { filterTags, EventEmitter } = useContext(FilterContext);
 
   const renderFilterSummary = () =>
@@ -174,9 +179,15 @@ const DatagridToolbar = (datagridState) => {
     );
 
   const getRowHeight = rowSize ? rowSize : 'lg';
-  
+
   return batchActions && DatagridActions ? (
-    <div ref={ref} className={cx(`${blockClass}__table-toolbar`, `${blockClass}__table-toolbar--${getRowHeight}`)}>
+    <div
+      ref={ref}
+      className={cx(
+        `${blockClass}__table-toolbar`,
+        `${blockClass}__table-toolbar--${getRowHeight}`
+      )}
+    >
       <TableToolbar>
         {DatagridActions && DatagridActions(datagridState)}
         {DatagridBatchActionsToolbar &&

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -589,3 +589,9 @@
 .#{$block-class} .#{$carbon-prefix}--modal {
   width: 100%;
 }
+
+.#{$block-class}__table-toolbar--sm, .#{$block-class}__table-toolbar--xs {
+  .#{$pkg-prefix}--filter-summary {
+    padding: 0 $spacing-03;
+  }
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -590,7 +590,8 @@
   width: 100%;
 }
 
-.#{$block-class}__table-toolbar--sm, .#{$block-class}__table-toolbar--xs {
+.#{$block-class}__table-toolbar--sm,
+.#{$block-class}__table-toolbar--xs {
   .#{$pkg-prefix}--filter-summary {
     padding: 0 $spacing-03;
   }


### PR DESCRIPTION
Contributes to #2585 

The filter summary has two height options. The 48 px height should be used with the medium, large, and extra large row heights. The 32px height should be used with extra small and small row heights. 

#### What did you change?

`styles/_datagrid.scss`
`DatagridToolbar.js`

#### How did you test and verify your work?
Storybook