### PR TITLE
fix(Tearsheet): prevent description breaking

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1428,7 +1428,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   letter-spacing: var(--cds-body-short-01-letter-spacing, 0.16px);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-  word-break: break-all;
+  word-break: break-word;
 }
 @media (min-width: 42rem) {
   .c4p--tearsheet .c4p--tearsheet__header-description {

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -203,7 +203,7 @@
         max-width: 60%;
       }
 
-      word-break: break-all;
+      word-break: break-word;
     }
 
     &.#{$block-class}--wide .#{$block-class}__header-description {


### PR DESCRIPTION
Contributes to #2637 

Fix wrapping of text mid-word in tearsheet descriptions.

#### What did you change?
Replaces `word-break: break-all` in 

```
packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
```

#### How did you test and verify your work?
Storybook