### PR TITLE
chore: add select column coverage

### DIFF
--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelect.js
@@ -70,7 +70,7 @@ AddSelect.propTypes = {
       options: PropTypes.array,
     }),
     sortBy: PropTypes.array,
-    filterBy: PropTypes.array,
+    filterBy: PropTypes.string,
     entries: PropTypes.arrayOf(
       PropTypes.shape({
         avatar: PropTypes.shape({

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.js
@@ -360,7 +360,7 @@ AddSelectBody.propTypes = {
       options: PropTypes.array,
     }),
     sortBy: PropTypes.array,
-    filterBy: PropTypes.array,
+    filterBy: PropTypes.string,
     entries: PropTypes.arrayOf(
       PropTypes.shape({
         avatar: PropTypes.shape({

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectBody.test.js
@@ -65,6 +65,7 @@ const singleProps = {
 };
 
 const hierarchyItems = {
+  filterBy: 'title',
   entries: [
     ...defaultItems.entries,
     {
@@ -462,5 +463,11 @@ describe(componentName, () => {
     const globalSearch = screen.getByPlaceholderText('Find business terms');
     fireEvent.change(globalSearch, { target: { value: 'florida' } });
     fireEvent.change(globalSearch, { target: { value: '' } });
+    const filterBy = document.querySelector(
+      '.c4p--add-select__column-overflow'
+    );
+    expect(filterBy).toBeVisible();
+    // there appears to be an issue with overflow menu and testing
+    // fireEvent.click(filterBy);
   });
 });

--- a/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
+++ b/packages/cloud-cognitive/src/components/AddSelect/AddSelectColumn.js
@@ -95,7 +95,6 @@ export let AddSelectColumn = ({
     if (filters.length === 0) {
       return true;
     }
-    const { filterBy } = item;
     const filterByValue = item[filterBy];
     return filters.some((filter) => filter === filterByValue);
   };
@@ -150,6 +149,7 @@ export let AddSelectColumn = ({
                       className={`${carbon.prefix}--overflow-menu-options__btn`}
                     >
                       <Checkbox
+                        className={`${colClass}-filter-checkbox`}
                         id={opt}
                         labelText={opt}
                         onChange={(checked) => filterHandler(checked, opt)}

--- a/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
+++ b/packages/cloud-cognitive/src/components/MultiAddSelect/MultiAddSelect.stories.js
@@ -139,6 +139,7 @@ export const WithHierarchy = prepareStory(Template, {
     globalSortBy: ['title'],
     items: {
       sortBy: ['title'],
+      filterBy: 'title',
       entries: [
         {
           id: '1',


### PR DESCRIPTION
fixes a small bug in `AddSelectColumn`. also attempts to add additional coverage, but unfortunately it looks like tests are failing due to carbons `OverflowMenu`

<img width="1792" alt="Screenshot 2023-02-07 at 2 40 11 PM" src="https://user-images.githubusercontent.com/6370760/217360683-151399eb-a6d8-410c-8a1c-9a7f5bb272f0.png">
