### PR TITLE
fix(Datagrid): column customization styles v11

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DraggableElement.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DraggableElement.js
@@ -142,7 +142,7 @@ const DraggableElement = ({
       {isDragging && !isOver ? (
         <div
           ref={preview}
-          className="${blockClass}__draggable-handleHolder-droppable"
+          className={`${blockClass}__draggable-handleHolder-droppable ${blockClass}__draggable-handleHolder-droppable--origin`}
         >
           {content}
         </div>

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -164,7 +164,7 @@ const sharedDatagridProps = {
       primaryButtonTextLabel: 'Save',
       secondaryButtonTextLabel: 'Cancel',
       instructionsLabel:
-        'Deselect columns to hide them. Click and drag the white box to reorder the columns. These specifications will be saved and persist if you leave and return to the data table.',
+        'Deselect columns to hide them. Drag rows to change column order. These specifications will be saved if you leave and return to the data table.',
       iconTooltipLabel: 'Customize columns',
       assistiveTextInstructionsLabel:
         'Press space bar to toggle drag drop mode, use arrow keys to move selected elements.',

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_draggableElement.scss
@@ -57,6 +57,8 @@
   display: flex;
   width: 100%;
   align-items: center;
+  /* stylelint-disable-next-line carbon/type-token-use */
+  line-height: 1; // center align text within row
 }
 
 .#{variables.$block-class}__draggable-handleHolder-grabbed {

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_draggableElement.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_draggableElement.scss
@@ -7,6 +7,8 @@
 
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/colors';
+@use '@carbon/styles/scss/motion' as *;
 @use './variables';
 
 .#{variables.$block-class}__draggable-handleStyle {
@@ -27,7 +29,6 @@
 .#{variables.$block-class}__draggable-handleHolder {
   display: flex;
   height: $spacing-09;
-  padding-left: $spacing-05;
   border-bottom: 1px solid $layer-active;
   background-color: $layer;
 }
@@ -39,7 +40,6 @@
 .#{variables.$block-class}__draggable-handleHolder-selected {
   display: flex;
   height: $spacing-09;
-  padding-left: $spacing-05;
   border-bottom: 1px solid $layer-active;
   background-color: $layer-selected;
 }
@@ -50,15 +50,23 @@
 
 .#{variables.$block-class}__draggable-handleHolder-isOver {
   border: 2px dashed $focus;
-  background-color: $layer-selected-hover-01;
+  /* stylelint-disable-next-line carbon/theme-token-use */
+  background-color: colors.$blue-10;
 }
 
 .#{variables.$block-class}__draggable-handleHolder-droppable {
   display: flex;
   width: 100%;
   align-items: center;
+  padding-left: $spacing-05;
   /* stylelint-disable-next-line carbon/type-token-use */
   line-height: 1; // center align text within row
+  transition-property: opacity;
+}
+
+.#{variables.$block-class}__draggable-handleHolder-droppable.#{variables.$block-class}__draggable-handleHolder-droppable--origin {
+  opacity: 0.5;
+  transition: opacity $duration-moderate-01 motion(entrance, productive);
 }
 
 .#{variables.$block-class}__draggable-handleHolder-grabbed {

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -31,7 +31,11 @@
 .#{variables.$block-class}__customize-columns-checkbox-wrapper {
   display: flex;
   justify-content: center;
-  padding-left: $spacing-03;
+  padding-left: $spacing-02;
+}
+
+.#{variables.$block-class}__customize-columns-column-list
+  .#{variables.$block-class}__customize-columns-checkbox-wrapper.#{c4p-settings.$carbon-prefix}--form-item {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Contributes to #2504

Includes spacing and styling fixes from design review and fixes to draggable styles styles based on drag and drop guidance.

To keep review manageable, excluded the enhancement for fixed columns in column customization from this PR.

#### What did you change?
Fix tokens and spacing from design review plus broken classnames and specificity for drag and drop.
Some minor styling differences from v10 since we already use `$icon-disabled` in v11, decided not to switch to `$icon-on-color-disabled` based on the color usage descriptions.

#### How did you test and verify your work?
Storybook