### PR TITLE
feat: imports all DataTable pieces from `@carbon/react` (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -11,7 +11,7 @@ import { range, makeData, newPersonWithTwoLines } from './utils/makeData';
 import { getStoryTitle } from '../../global/js/utils/story-helper';
 import { action } from '@storybook/addon-actions';
 import { Activity, Add } from '@carbon/react/icons';
-import { DataTable } from '@carbon/react';
+import { TableBatchAction, TableBatchActions } from '@carbon/react';
 import {
   Datagrid,
   useDatagrid,
@@ -110,8 +110,6 @@ const defaultHeader = [
     accessor: 'someone7',
   },
 ];
-
-const { TableBatchAction, TableBatchActions } = DataTable;
 
 export const BasicUsage = () => {
   const columns = React.useMemo(

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -32,7 +32,8 @@ import {
 } from '.';
 
 import {
-  TableToolbarContent, TableToolbarSearch,
+  TableToolbarContent,
+  TableToolbarSearch,
   Button,
   Pagination,
   TableBatchActions,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -32,7 +32,7 @@ import {
 } from '.';
 
 import {
-  DataTable,
+  TableToolbarContent, TableToolbarSearch,
   Button,
   Pagination,
   TableBatchActions,
@@ -162,7 +162,6 @@ const DatagridActions = (datagridState) => {
   const downloadCsv = () => {
     alert('Downloading...');
   };
-  const { TableToolbarContent, TableToolbarSearch } = DataTable;
 
   const refreshColumns = () => {
     alert('refreshing...');

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridContent.js
@@ -8,7 +8,7 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
-import { DataTable } from '@carbon/react';
+import { Table, TableContainer } from '@carbon/react';
 import { px } from '@carbon/layout';
 import DatagridHead from './DatagridHead';
 import DatagridBody from './DatagridBody';
@@ -19,8 +19,6 @@ import { InlineEditContext } from './addons/InlineEdit/InlineEditContext';
 import { handleGridFocus } from './addons/InlineEdit/handleGridFocus';
 import { useClickOutside } from '../../../global/js/hooks';
 import { useMultipleKeyTracking } from '../../DataSpreadsheet/hooks';
-
-const { TableContainer, Table } = DataTable;
 
 const blockClass = `${pkg.prefix}--datagrid`;
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridEmptyBody.js
@@ -7,12 +7,10 @@
  */
 import React from 'react';
 import { pkg } from '../../../settings';
-import { DataTable } from '@carbon/react';
+import { TableBody, TableRow, TableCell } from '@carbon/react';
 import { NoDataEmptyState, ErrorEmptyState } from '../../EmptyStates';
 
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const { TableBody, TableRow, TableCell } = DataTable;
 
 const DatagridEmptyBody = (datagridState) => {
   const {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridHead.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridHead.js
@@ -6,9 +6,7 @@
  */
 
 import React from 'react';
-import { DataTable } from '@carbon/react';
-
-const { TableHead } = DataTable;
+import { TableHead } from '@carbon/react';
 
 const DatagridHead = (datagridState) => {
   const { headerGroups = [], headRef, HeaderRow } = datagridState;

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridHeaderRow.js
@@ -8,7 +8,7 @@
 // @flow
 import React from 'react';
 import cx from 'classnames';
-import { DataTable } from '@carbon/react';
+import { TableHeader, TableRow } from '@carbon/react';
 import { selectionColumnId } from '../common-column-ids';
 import { pkg } from '../../../settings';
 
@@ -56,8 +56,6 @@ const HeaderRow = (datagridState, headRef, headerGroup) => (
       })}
   </TableRow>
 );
-
-const { TableHeader, TableRow } = DataTable;
 
 const useHeaderRow = (hooks) => {
   const useInstance = (instance) => {

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridRow.js
@@ -7,15 +7,13 @@
  */
 // @flow
 import React from 'react';
-import { DataTable, SkeletonText } from '@carbon/react';
+import { TableRow, TableCell, SkeletonText } from '@carbon/react';
 import { px } from '@carbon/layout';
 import { selectionColumnId } from '../common-column-ids';
 import cx from 'classnames';
 import { pkg, carbon } from '../../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const { TableRow, TableCell } = DataTable;
 
 const rowHeights = {
   xs: 24,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAll.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAll.js
@@ -7,7 +7,7 @@
  */
 // @flow
 import React from 'react';
-import { DataTable } from '@carbon/react';
+import { TableSelectAll } from '@carbon/react';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
 
@@ -60,7 +60,5 @@ const SelectAll = (datagridState) => {
     </div>
   );
 };
-
-const { TableSelectAll } = DataTable;
 
 export { SelectAll };

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSimpleBody.js
@@ -6,13 +6,11 @@
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import React from 'react';
-import { DataTable } from '@carbon/react';
+import { TableBody } from '@carbon/react';
 import cx from 'classnames';
 import { pkg } from '../../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const { TableBody } = DataTable;
 
 const DatagridSimpleBody = (datagridState) => {
   const { getTableBodyProps, rows, prepareRow } = datagridState;

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -7,7 +7,11 @@
 
 import React, { useEffect, useState, useContext } from 'react';
 import { Add, OverflowMenuVertical } from '@carbon/react/icons';
-import { DataTable, TableBatchActions, TableBatchAction } from '@carbon/react';
+import {
+  TableToolbar,
+  TableBatchActions,
+  TableBatchAction,
+} from '@carbon/react';
 import { useResizeDetector } from 'react-resize-detector';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
 import { pkg, carbon } from '../../../settings';
@@ -17,8 +21,6 @@ import { FilterContext } from './addons/Filtering/FilterProvider';
 import { CLEAR_FILTERS } from './addons/Filtering/constants';
 
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const { TableToolbar } = DataTable;
 
 const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
   const [displayAllInMenu, setDisplayAllInMenu] = useState(false);

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -7,14 +7,12 @@
  */
 import React, { useEffect } from 'react';
 import { VariableSizeList } from 'react-window';
-import { DataTable } from '@carbon/react';
+import { TableBody } from '@carbon/react';
 import { pkg } from '../../../settings';
 import DatagridHead from './DatagridHead';
 import { px } from '@carbon/layout';
 
 const blockClass = `${pkg.prefix}--datagrid`;
-
-const { TableBody } = DataTable;
 
 const rowSizeMap = {
   xs: 24,

--- a/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
@@ -8,11 +8,10 @@
 // @flow
 import React from 'react';
 import cx from 'classnames';
-import { DataTable } from '@carbon/react';
+import { TableSelectRow } from '@carbon/react';
 import { SelectAll } from './Datagrid/DatagridSelectAll';
 import { selectionColumnId } from './common-column-ids';
 import { pkg, carbon } from '../../settings';
-const { TableSelectRow } = DataTable;
 
 const blockClass = `${pkg.prefix}--datagrid`;
 

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -7,7 +7,8 @@
 
 import React, { useLayoutEffect, useState } from 'react';
 import {
-  DataTable,
+  TableToolbarContent,
+  TableToolbarSearch,
   Button,
   OverflowMenu,
   OverflowMenuItem,
@@ -38,8 +39,6 @@ export const DatagridActions = (datagridState) => {
   const downloadCsv = () => {
     alert('Downloading...');
   };
-  const { TableToolbarContent, TableToolbarSearch } = DataTable;
-
   const refreshColumns = () => {
     alert('refreshing...');
   };


### PR DESCRIPTION
Contributes to #2610 

Should fix the DatagridContent invalid import bug? Not really sure but someone hinted that this might be a fix.

#### What did you change?
All files that destructure from `Datatable` 

