### PR TITLE
feat(Datagrid): Custom hook to handle `ActionSet` disabled state for `FilterPanel` & `FilterFlyout `(v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -39,6 +39,7 @@ import {
 import {
   useInitialStateFromFilters,
   useSubscribeToEventEmitter,
+  useShouldDisableButtons,
 } from './hooks';
 import { getInitialStateFromFilters } from './utils';
 
@@ -73,6 +74,14 @@ const FilterFlyout = ({
   const prevFiltersRef = useRef(JSON.stringify(filtersState));
   const prevFiltersObjectArrayRef = useRef(JSON.stringify(filtersObjectArray));
 
+  /** State from hooks */
+  const [shouldDisableButtons, setShouldDisableButtons] =
+    useShouldDisableButtons({
+      initialValue: true,
+      filtersState,
+      prevFiltersRef,
+    });
+
   /** Memos */
   const showActionSet = updateMethod === BATCH;
   const carbonPrefix = usePrefix();
@@ -92,6 +101,8 @@ const FilterFlyout = ({
     closeFlyout();
     // From the user
     onApply();
+    // When the user clicks apply, the action set buttons should be disabled again
+    setShouldDisableButtons(true);
 
     // updates the ref so next time the flyout opens we have records of the previous filters
     prevFiltersRef.current = JSON.stringify(filtersState);
@@ -342,6 +353,7 @@ const FilterFlyout = ({
               label: primaryActionLabel,
               onClick: apply,
               isExpressive: false,
+              disabled: shouldDisableButtons,
             },
             {
               key: 3,
@@ -349,6 +361,7 @@ const FilterFlyout = ({
               label: secondaryActionLabel,
               onClick: cancel,
               isExpressive: false,
+              disabled: shouldDisableButtons,
             },
           ]}
           size="md"

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterFlyout.js
@@ -1,11 +1,11 @@
 // @flow
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2022
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2022, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 import { Filter } from '@carbon/react/icons';
 import {
   Button,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2022, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable react/jsx-key */
 
 import React, { useRef, useMemo, useContext, useState, useEffect } from 'react';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/FilterPanel.js
@@ -43,9 +43,9 @@ import { FilterContext } from '.';
 import {
   useInitialStateFromFilters,
   useSubscribeToEventEmitter,
+  useShouldDisableButtons,
 } from './hooks';
 import { getInitialStateFromFilters } from './utils';
-import isEqual from 'lodash/isEqual';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 const componentClass = `${blockClass}-filter-panel`;
@@ -53,7 +53,7 @@ const componentClass = `${blockClass}-filter-panel`;
 const MotionActionSet = motion(ActionSet);
 
 const FilterPanel = ({
-  title,
+  title = 'Filter',
   closeIconDescription = 'Close filter panel',
   updateMethod = BATCH,
   filterSections,
@@ -75,7 +75,6 @@ const FilterPanel = ({
     PANEL
   );
   const [filtersObjectArray, setFiltersObjectArray] = useState([]);
-  const [shouldDisableButtons, setShouldDisableButtons] = useState(true);
   const [showDividerLine, setShowDividerLine] = useState(false);
 
   /** Refs */
@@ -86,6 +85,14 @@ const FilterPanel = ({
   // When using batch actions we have to store the filters to then apply them later
   const prevFiltersRef = useRef(JSON.stringify(filtersState));
   const prevFiltersObjectArrayRef = useRef(JSON.stringify(filtersObjectArray));
+
+  /** State from hooks */
+  const [shouldDisableButtons, setShouldDisableButtons] =
+    useShouldDisableButtons({
+      initialValue: true,
+      filtersState,
+      prevFiltersRef,
+    });
 
   /** Memos */
   const showActionSet = useMemo(() => updateMethod === BATCH, [updateMethod]);
@@ -133,7 +140,9 @@ const FilterPanel = ({
 
   const apply = () => {
     setAllFilters(filtersObjectArray);
+    // From the user
     onApply();
+    // When the user clicks apply, the action set buttons should be disabled again
     setShouldDisableButtons(true);
 
     // updates the ref so next time the flyout opens we have records of the previous filters
@@ -397,15 +406,6 @@ const FilterPanel = ({
       );
     },
     [filterPanelMinHeight]
-  );
-
-  useEffect(
-    function updateDisabledButtonsState() {
-      setShouldDisableButtons(
-        isEqual(filtersState, JSON.parse(prevFiltersRef.current))
-      );
-    },
-    [filtersState]
   );
 
   useSubscribeToEventEmitter(CLEAR_FILTERS, reset);

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useInitialStateFromFilters } from './useInitialStateFromFilters';
 export { default as useSubscribeToEventEmitter } from './useSubscribeToEventEmitter';
+export { default as useShouldDisableButtons } from './useShouldDisableButtons';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/index.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright IBM Corp. 2022, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export { default as useInitialStateFromFilters } from './useInitialStateFromFilters';
 export { default as useSubscribeToEventEmitter } from './useSubscribeToEventEmitter';
 export { default as useShouldDisableButtons } from './useShouldDisableButtons';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-param-names */
 /*
  * Licensed Materials - Property of IBM
  * 5724-Q36

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
@@ -1,11 +1,10 @@
-/* eslint-disable jsdoc/check-param-names */
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2023
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+/* eslint-disable jsdoc/check-param-names */
 
 import { useState, useEffect } from 'react';
 import isEqual from 'lodash/isEqual';

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useShouldDisableButtons.js
@@ -1,0 +1,39 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 5724-Q36
+ * (c) Copyright IBM Corp. 2023
+ * US Government Users Restricted Rights - Use, duplication or disclosure
+ * restricted by GSA ADP Schedule Contract with IBM Corp.
+ */
+
+import { useState, useEffect } from 'react';
+import isEqual from 'lodash/isEqual';
+
+/**
+ * Keeps track of the button disabled state
+ * @param  {string} initialValue - the initial value if the buttons should be enabled or disabled
+ * @param  {object} filtersState - the filter state from the filter panel or flyout
+ * @param  {object} prevFiltersRef - reference of the prev filterState
+ * @returns {Array} returns a tuple of the state and setter function
+ */
+const useShouldDisableButtons = ({
+  initialValue = true, // initially the buttons should be disabled
+  filtersState,
+  prevFiltersRef,
+}) => {
+  const [shouldDisableButtons, setShouldDisableButtons] =
+    useState(initialValue);
+
+  useEffect(
+    function updateDisabledButtonsState() {
+      setShouldDisableButtons(
+        isEqual(filtersState, JSON.parse(prevFiltersRef.current))
+      );
+    },
+    [filtersState, prevFiltersRef]
+  );
+
+  return [shouldDisableButtons, setShouldDisableButtons];
+};
+
+export default useShouldDisableButtons;


### PR DESCRIPTION
Simple PR, all it does is it encapsulates the logic for disabling the ActionSet buttons into a custom hook and uses it for FilterFlyout too.
