### PR TITLE
fix(Datagrid): row height settings style fixes v11

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/RowHeightSettings/RowHeightSettings.stories.js
@@ -107,20 +107,24 @@ const sharedDatagridProps = {
   rowSize: 'lg',
   rowSizes: [
     {
-      value: 'xl',
-      labelText: 'Extra large',
+      value: 'xs',
+      labelText: 'Extra small',
     },
     {
-      value: 'lg',
-      labelText: 'Large',
+      value: 'sm',
+      labelText: 'Small',
     },
     {
       value: 'md',
       labelText: 'Medium',
     },
     {
-      value: 'xs',
-      labelText: 'Small',
+      value: 'lg',
+      labelText: 'Large',
+    },
+    {
+      value: 'xl',
+      labelText: 'Extra large',
     },
   ],
   onRowSizeChange: (value) => {
@@ -145,17 +149,7 @@ const sharedDatagridProps = {
 };
 
 const BasicUsage = ({ ...args }) => {
-  const columns = React.useMemo(
-    () => [
-      ...defaultHeader,
-      {
-        Header: 'Someone 11',
-        accessor: 'someone11',
-        multiLineWrap: true,
-      },
-    ],
-    []
-  );
+  const columns = React.useMemo(() => [...defaultHeader], []);
   const [data] = useState(makeData(10));
   const rows = React.useMemo(() => data, [data]);
 

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -445,8 +445,9 @@
   }
 
   .#{$block-class}__table-toolbar {
-    flex: 0 0 auto;
+    flex: 1 0 auto;
   }
+
   .#{c4p-settings.$carbon-prefix}--table-toolbar {
     background: transparent;
   }

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
@@ -13,13 +13,13 @@
 
 .#{variables.$block-class}__row-size-dropdown {
   padding: $spacing-05;
-  background-color: $background;
+  background-color: $layer-02;
 
   box-shadow: 1px 4px 8px -3px $overlay, -1px 6px 8px -5px $overlay;
 }
 
-.#{variables.$block-class}__row-size-button--open {
-  background-color: $background;
+.#{c4p-settings.$carbon-prefix}--btn--ghost.#{variables.$block-class}__row-size-button--open {
+  background-color: $layer-02;
 
   box-shadow: 1px 4px 8px -3px $overlay, -1px 6px 8px -5px $overlay;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/DatagridActions.js
@@ -110,18 +110,17 @@ export const DatagridActions = (datagridState) => {
               />
             </div>
             {renderFilterFlyout()}
+            {CustomizeColumnsButton && (
+              <div style={style}>
+                <CustomizeColumnsButton />
+              </div>
+            )}
             <RowSizeDropdown {...rowSizeDropdownProps} />
             <div style={style} className={`${blockClass}__toolbar-divider`}>
               <Button kind="ghost" renderIcon={Add} iconDescription={'Action'}>
                 Ghost button
               </Button>
             </div>
-
-            {CustomizeColumnsButton && (
-              <div style={style}>
-                <CustomizeColumnsButton />
-              </div>
-            )}
           </>
         ) : (
           <OverflowMenu ariaLabel="Tools" size="md" flipped>
@@ -149,7 +148,6 @@ export const DatagridActions = (datagridState) => {
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
         {renderFilterFlyout()}
-        <RowSizeDropdown {...rowSizeDropdownProps} />
         <div style={style}>
           <Button
             kind="ghost"
@@ -175,6 +173,7 @@ export const DatagridActions = (datagridState) => {
             <CustomizeColumnsButton />
           </div>
         )}
+        <RowSizeDropdown {...rowSizeDropdownProps} />
         <ButtonMenu
           label="Primary button"
           renderIcon={ChevronDown}


### PR DESCRIPTION
Contributes to #2503

Design review fixes for row height settings. v11 version.

#### What did you change?
- Reorder and add row height options from smallest to largest, including`xs` through `xl`
- Fix settings button color on activate/open menu
- Move row height settings button to first icon left of any CTAs

#### How did you test and verify your work?
Storybook and ci checks