### PR TITLE
fix(options-tile): use layer

### DIFF
--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.js
@@ -18,7 +18,7 @@ import { pkg } from '../../settings';
 import { useControllableState } from '../../global/js/hooks';
 
 // Carbon and package components we use.
-import { Toggle } from '@carbon/react';
+import { Layer, Toggle } from '@carbon/react';
 import {
   ChevronDown,
   Locked,
@@ -279,13 +279,15 @@ export let OptionsTile = React.forwardRef(
             </summary>
 
             <div className={`${blockClass}__content`} ref={contentRef}>
-              {isLocked && (
-                <p className={`${blockClass}__locked-text`}>
-                  <Locked size={16} />
-                  {lockedText}
-                </p>
-              )}
-              {children}
+              <Layer>
+                {isLocked && (
+                  <p className={`${blockClass}__locked-text`}>
+                    <Locked size={16} />
+                    {lockedText}
+                  </p>
+                )}
+                {children}
+              </Layer>
             </div>
           </details>
         ) : (

--- a/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
+++ b/packages/cloud-cognitive/src/components/OptionsTile/OptionsTile.stories.js
@@ -107,7 +107,6 @@ const Template = (args) => {
           warn={isWarn}
           warnText="A language change requires a restart of the application"
           disabled={disableControls}
-          light
         />
         <Dropdown
           id={`${id}-locale`}
@@ -116,7 +115,6 @@ const Template = (args) => {
           items={locales}
           initialSelectedItem={locales[0]}
           disabled={disableControls}
-          light
         />
       </FormGroup>
     </OptionsTile>


### PR DESCRIPTION
Closes to #2329 

(v11 only change)

#### What did you change?
- Wrap OptionsTile content in `<Layer>`
- Remove `props.light` from demo components in storybook

#### How did you test and verify your work?
Storybook
