### PR TITLE
fix: Replace `react-highlighter`

### DIFF
--- a/packages/cdai/package.json
+++ b/packages/cdai/package.json
@@ -47,7 +47,6 @@
     "@babel/runtime": "^7.20.13",
     "focus-trap-react": "^10.0.2",
     "pluralize": "^8.0.0",
-    "react-highlighter": "^0.4.3",
     "react-select": "^5.7.0",
     "uuid": "^9.0.0"
   },

--- a/packages/cdai/src/components/IdeFilter/IdeFilter.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.js
@@ -16,13 +16,17 @@ import { idePrefix } from '../../globals/js/settings';
 
 const Highlight = React.memo(({ children, search }) => {
   if (
-    typeof children !== 'string' || // We accept arbitrary React nodes but we can't highlight them
+    // We accept arbitrary React nodes but we can't highlight them
+    typeof children !== "string" ||
     !search
   ) {
     return children;
   }
 
-  const searchRegExp = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'ig');
+  const searchRegExp = new RegExp(
+    search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+    "ig"
+  );
   const newChildren = [];
   let result;
   let index = 0;
@@ -47,11 +51,11 @@ const Highlight = React.memo(({ children, search }) => {
   return newChildren;
 });
 
-Highlight.displayName = 'Highlight';
+Highlight.displayName = "Highlight";
 
 Highlight.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  search: PropTypes.string
+  search: PropTypes.string,
 };
 
 // custom styling

--- a/packages/cdai/src/components/IdeFilter/IdeFilter.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.js
@@ -44,11 +44,7 @@ const Highlight = React.memo(({ children, search }) => {
   // Remainder of string did not match (could be empty)
   newChildren.push(children.substring(index));
 
-  return (
-    <>
-      {newChildren}
-    </>
-  );
+  return newChildren;
 });
 
 Highlight.displayName = 'Highlight';

--- a/packages/cdai/src/components/IdeFilter/IdeFilter.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.js
@@ -7,13 +7,57 @@
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Highlight from 'react-highlighter';
 import pluralize from 'pluralize';
 import CreatableSelect from 'react-select/creatable';
 import { Tag } from 'carbon-components-react';
 import { Close16, Search16 } from '@carbon/icons-react';
 
 import { idePrefix } from '../../globals/js/settings';
+
+const Highlight = React.memo(({ children, search }) => {
+  if (
+    typeof children !== 'string' || // We accept arbitrary React nodes but we can't highlight them
+    !search
+  ) {
+    return children;
+  }
+
+  const searchRegExp = new RegExp(search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'ig');
+  const newChildren = [];
+  let result;
+  let index = 0;
+
+  while ((result = searchRegExp.exec(children)) !== null) {
+    newChildren.push(
+      // Non-matching substring (could be empty)
+      children.substring(index, result.index),
+
+      // Matching substring (can't be empty)
+      <mark key={newChildren.length}>
+        {children.substring(result.index, searchRegExp.lastIndex)}
+      </mark>
+    );
+
+    index = searchRegExp.lastIndex;
+  }
+
+  // Remainder of string did not match (could be empty)
+  newChildren.push(children.substring(index));
+
+  return (
+    <>
+      {newChildren}
+    </>
+  );
+});
+
+Highlight.displayName = 'Highlight';
+
+Highlight.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  search: PropTypes.string
+};
+
 // custom styling
 const customStyles = {
   multiValueLabel: (provided) => ({

--- a/packages/cdai/src/components/IdeFilter/IdeFilter.js
+++ b/packages/cdai/src/components/IdeFilter/IdeFilter.js
@@ -17,15 +17,15 @@ import { idePrefix } from '../../globals/js/settings';
 const Highlight = React.memo(({ children, search }) => {
   if (
     // We accept arbitrary React nodes but we can't highlight them
-    typeof children !== "string" ||
+    typeof children !== 'string' ||
     !search
   ) {
     return children;
   }
 
   const searchRegExp = new RegExp(
-    search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
-    "ig"
+    search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    'ig'
   );
   const newChildren = [];
   let result;
@@ -51,7 +51,7 @@ const Highlight = React.memo(({ children, search }) => {
   return newChildren;
 });
 
-Highlight.displayName = "Highlight";
+Highlight.displayName = 'Highlight';
 
 Highlight.propTypes = {
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,7 +1727,6 @@ __metadata:
     node-sass: ^8.0.0
     npm-check-updates: ^16.6.3
     pluralize: ^8.0.0
-    react-highlighter: ^0.4.3
     react-select: ^5.7.0
     rimraf: ~3 || > 4.1
     sinon: ^15.0.1
@@ -8857,13 +8856,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"blacklist@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "blacklist@npm:1.1.4"
-  checksum: d8ce2b31ed009faf1438b5795a1fb98a50c3cb8d2cfc59eb3ee358060c41a76333d20e72519de6e0624f4a755603b1f9b7eb387d218880e8e22907def877df95
-  languageName: node
-  linkType: hard
-
 "bluebird@npm:3.7.2, bluebird@npm:^3.5.5":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
@@ -10976,16 +10968,6 @@ __metadata:
     safe-buffer: ^5.0.1
     sha.js: ^2.4.8
   checksum: ba12bb2257b585a0396108c72830e85f882ab659c3320c83584b1037f8ab72415095167ced80dc4ce8e446a8ecc4b2acf36d87befe0707d73b26cf9dc77440ed
-  languageName: node
-  linkType: hard
-
-"create-react-class@npm:^15.6.2":
-  version: 15.7.0
-  resolution: "create-react-class@npm:15.7.0"
-  dependencies:
-    loose-envify: ^1.3.1
-    object-assign: ^4.1.1
-  checksum: 0c5f43da705fa9f67ec289051dd5780792652d440dfa17cd2c7d8423c1f604609596f895dabf46fda1960ddd93ee96fe1b61ef4d55a94fc4271b07d515486714
   languageName: node
   linkType: hard
 
@@ -22994,20 +22976,6 @@ __metadata:
     react: ^16.6.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
   checksum: 7ca7e47f8af14ea186688b512a87ab912bf6041312b297f92516341b140b3f0f8aedf5a44d226d99e69ed067b0cc106e38aeb9c9b738ffcc63d10721c844db90
-  languageName: node
-  linkType: hard
-
-"react-highlighter@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "react-highlighter@npm:0.4.3"
-  dependencies:
-    blacklist: ^1.1.4
-    create-react-class: ^15.6.2
-    escape-string-regexp: ^1.0.5
-    prop-types: ^15.6.0
-  peerDependencies:
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: e0c23fea7c23b73b752feb1decba6b61a08638ccc811b1f516cef29be537e12f7e95f3ef63347f5a2052ffa18f4ebc8225236948acd99d13011026890ac229de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #2695

#### What did you change?

Removed `react-highlighter` as a dependency, replacing it with a very small inline component `<Highlight>` which fulfills all of the functionality we use.

#### How did you test and verify your work?

I'm relying on CI to do this... this code has also worked locally for us.