### PR TITLE
fix(TagSet): prevent text from getting cut off

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1432,7 +1432,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 @media (min-width: 42rem) {
   .c4p--tearsheet .c4p--tearsheet__header-description {
-    max-width: 60%;
+    max-width: 80%;
   }
 }
 .c4p--tearsheet.c4p--tearsheet--wide .c4p--tearsheet__header-description {
@@ -3719,6 +3719,10 @@ button.c4p--add-select__global-filter-toggle--open {
   height: var(--cds-spacing-07, 2rem);
   background: linear-gradient(to bottom, transparent, var(--cds-ui-01, #f4f4f4));
   content: "";
+}
+
+.c4p--tag-set-overflow__tooltip .c4p--tag-set-overflow__tag-item .bx--tag {
+  border-radius: 0;
 }
 
 .c4p--tag-set-overflow__tooltip.c4p--tag-set-overflow__tooltip {

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -114,6 +114,12 @@ $block-class-modal: #{$block-class}-modal;
     }
   }
 
+  .#{$block-class-overflow}__tooltip
+    .#{$block-class-overflow}__tag-item
+    .#{$carbon-prefix}--tag {
+    border-radius: 0;
+  }
+
   @include block-wrap('#{$block-class-overflow}__tooltip') {
     &.#{$block-class-overflow}__tooltip {
       // removes the min width in Carbon

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -200,7 +200,7 @@
       -webkit-line-clamp: 2;
 
       @include carbon--breakpoint-up('md') {
-        max-width: 60%;
+        max-width: 80%;
       }
 
       word-break: break-word;


### PR DESCRIPTION
Contributes to #2557 
Descenders were being cut off due to border-radius

#### What did you change?
I created an override to remove the border-radius

#### How did you test and verify your work?
