### PR TITLE
fix(DataGrid): dense header alignment fix v11

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -445,7 +445,9 @@
   }
 
   .#{$block-class}__table-toolbar {
+    display: flex;
     flex: 1 0 auto;
+    align-items: flex-end;
   }
 
   .#{c4p-settings.$carbon-prefix}--table-toolbar {
@@ -454,10 +456,6 @@
 
   .#{c4p-settings.$carbon-prefix}__table-container {
     flex: 1 1 100%;
-  }
-
-  .#{c4p-settings.$carbon-prefix}--table-toolbar {
-    padding-top: $spacing-07;
   }
 
   .#{$block-class}__toolbar-divider {


### PR DESCRIPTION
Contributes to #2710 

Datagrid title alignment is off if there is only grid title supplied.

#### What did you change?
`styles/_datagrid.scss`
#### How did you test and verify your work?
Storybook

Check `useDenseHeader` true
Remove value from `gridDescription`
