### PR TITLE
Fix for Issue #2716

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -137,6 +137,24 @@ const columns = [
   },
 ];
 ```
+To hide a column from customization, add a `hideFromCustomizeColumn` property to the
+column.
+
+```jsx
+const columns = [
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+    hideFromCustomizeColumn: true,
+    width: 120,
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+    width: 180,
+  },
+];
+```
 
 ## Empty
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -118,8 +118,8 @@ const Columns = ({
           {columns
             .filter(
               (colDef) =>
-                filterString.length === 0 ||
-                colDef.Header.props.title.toLowerCase().includes(filterString)
+              (filterString.length === 0 ||
+                colDef.Header.props.title.toLowerCase().includes(filterString)) && !colDef.hideFromCustomizeColumn
             )
             .map((colDef, i) => {
               const searchString = new RegExp('(' + filterString + ')');

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -55,8 +55,9 @@ const defaultHeader = [
     accessor: 'firstName',
   },
   {
-    Header: 'Last Name',
+    Header: '',
     accessor: 'lastName',
+    hideFromCustomizeColumn: true
   },
   {
     Header: 'Age',


### PR DESCRIPTION
Contributes to #

The fix is related to the below issue 
[https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2716](url)
This Fix Gives an option in Datagrid to restrict a column from being customized based on a prop

#### What did you change?

A new boolean prop `hideFromCustomizeColumn` has been created which will be used as a check in the `Columns.js` files

#### How did you test and verify your work?

Have the made the changes in `ColumnCustomization.stories.js` so that people can view the same and also added the props details in `Datagrid.mdx`
