### PR TITLE
chore: add detail on ES modules v11

### DIFF
--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -56,6 +56,7 @@ rules: [
     type: 'javascript/auto',
   },
 ],
+```
 
 ### Peer dependencies
 

--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -41,6 +41,22 @@ Then you can import the component styles in your `index.js`.
 import '@carbon/ibm-products/css/index.min.css';
 ```
 
+### Webpack 4
+
+Our package requires support for ES modules (see
+[#2378](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2378#issuecomment-1319276192)).
+In Webpack 5, these are supported by default. In Webpack 4, you will need to add
+the [following rule](https://stackoverflow.com/a/72149467) to your config.
+
+```js
+rules: [
+  {
+    test: /\.mjs$/,
+    include: /node_modules/,
+    type: 'javascript/auto',
+  },
+],
+
 ### Peer dependencies
 
 `@carbon/ibm-products` is built on top of Carbon components and has a number of
@@ -127,21 +143,6 @@ To build all the packages, run the following command.
 
 ```shell
 yarn build
-```
-
-Our package does require support for ES modules (see
-[#2378](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2378#issuecomment-1319276192)).
-In Webpack 5, these are supported by default. In Webpack 4, you will need to add
-the [following rule](https://stackoverflow.com/a/72149467) to your config.
-
-```js
-rules: [
-  {
-    test: /\.mjs$/,
-    include: /node_modules/,
-    type: 'javascript/auto',
-  },
-],
 ```
 
 ## Browser support

--- a/packages/cloud-cognitive/README.md
+++ b/packages/cloud-cognitive/README.md
@@ -129,6 +129,21 @@ To build all the packages, run the following command.
 yarn build
 ```
 
+Our package does require support for ES modules (see
+[#2378](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2378#issuecomment-1319276192)).
+In Webpack 5, these are supported by default. In Webpack 4, you will need to add
+the [following rule](https://stackoverflow.com/a/72149467) to your config.
+
+```js
+rules: [
+  {
+    test: /\.mjs$/,
+    include: /node_modules/,
+    type: 'javascript/auto',
+  },
+],
+```
+
 ## Browser support
 
 This library supports the latest versions of:


### PR DESCRIPTION
Contributes to #2378 

Add documentation on adding support for ESM in Webpack 4. (Commonly asked with relation to `AnimatePresence` in `framer-motion`).

@lee-chase Not sure if you think there’s a better spot for this (maybe its own section?), but added to package-specific README under the building locally section.

#### What did you change?
README within `ibm-cloud-cognitive` package.


#### How did you test and verify your work?
Markdown Preview