### PR TITLE
fix: cardfooter button icon props update

### DIFF
--- a/packages/cloud-cognitive/src/components/Card/CardFooter.js
+++ b/packages/cloud-cognitive/src/components/Card/CardFooter.js
@@ -84,7 +84,7 @@ CardFooter.propTypes = {
   primaryButtonText: PropTypes.string,
   productive: PropTypes.bool,
   secondaryButtonHref: PropTypes.string,
-  secondaryButtonIcon: PropTypes.string,
+  secondaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   secondaryButtonKind: PropTypes.oneOf(['secondary', 'ghost']),
   secondaryButtonText: PropTypes.string,
 };

--- a/packages/cloud-cognitive/src/components/Card/CardFooter.js
+++ b/packages/cloud-cognitive/src/components/Card/CardFooter.js
@@ -78,7 +78,7 @@ CardFooter.propTypes = {
   onPrimaryButtonClick: PropTypes.func,
   onSecondaryButtonClick: PropTypes.func,
   primaryButtonHref: PropTypes.string,
-  primaryButtonIcon: PropTypes.string,
+  primaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   primaryButtonKind: PropTypes.oneOf(['primary', 'ghost']),
   primaryButtonPlacement: PropTypes.oneOf(['top', 'bottom']),
   primaryButtonText: PropTypes.string,

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.stories.js
@@ -8,7 +8,7 @@
 import React from 'react';
 import cx from 'classnames';
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
-import { ArrowRight24, Cloud32 } from '@carbon/icons-react';
+import { ArrowRight24, Cloud32, Add16 } from '@carbon/icons-react';
 import { AspectRatio } from 'carbon-components-react';
 import {
   getStoryTitle,
@@ -190,5 +190,12 @@ export const WithButtonHref = prepareStory(Template, {
     secondaryButtonHref: '#',
     secondaryButtonText: 'Secondary',
     secondaryButtonKind: 'ghost',
+  },
+});
+
+export const WithButtonIcon = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+    primaryButtonIcon: Add16,
   },
 });


### PR DESCRIPTION
Contributes to #2728 

fixes small issue where `CardFooter` was using the wrong prop type for `primaryButtonIcon`