### PR TITLE
fix(Tearsheet): Correct Tearsheet description width

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1391,6 +1391,9 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   border-bottom: 1px solid var(--cds-ui-03, #e0e0e0);
   margin: 0;
 }
+.c4p--tearsheet.c4p--tearsheet--narrow .c4p--tearsheet__header-description {
+  max-width: 80%;
+}
 .c4p--tearsheet.c4p--tearsheet--wide .c4p--tearsheet__header--with-close-icon {
   padding-right: var(--cds-spacing-10, 4rem);
 }
@@ -1432,7 +1435,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 @media (min-width: 42rem) {
   .c4p--tearsheet .c4p--tearsheet__header-description {
-    max-width: 60%;
+    max-width: 80%;
   }
 }
 .c4p--tearsheet.c4p--tearsheet--wide .c4p--tearsheet__header-description {

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -200,7 +200,7 @@
       -webkit-line-clamp: 2;
 
       @include carbon--breakpoint-up('md') {
-        max-width: 60%;
+        max-width: 80%;
       }
 
       word-break: break-word;

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -204,7 +204,7 @@
       -webkit-line-clamp: 2;
 
       @include carbon--breakpoint-up('md') {
-        max-width: 80%;
+        max-width: 60%;
       }
 
       word-break: break-word;

--- a/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Tearsheet/_tearsheet.scss
@@ -155,6 +155,10 @@
       margin: 0;
     }
 
+    &.#{$block-class}--narrow .#{$block-class}__header-description {
+      max-width: 80%;
+    }
+
     &.#{$block-class}--wide .#{$block-class}__header--with-close-icon {
       padding-right: $spacing-10;
     }


### PR DESCRIPTION
Contributes to #
Description width for wide tearsheet is now 60% while narrow is 80%

#### What did you change?
Changed the description width from 80% to 60%

#### How did you test and verify your work?
