### PR TITLE
fix(Datagrid): hide columns with no header title

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -38,7 +38,8 @@ const CustomizeColumnsTearsheet = ({
   const [columnObjects, setColumnObjects] = useState(
     columnDefinitions
       // hide the columns without Header, e.g the sticky actions, spacer
-      .filter((colDef) => !!colDef.Header.props && !colDef.isAction)
+      .filter((colDef) => !!colDef.Header.props && !!colDef.Header.props.title)
+      .filter((colDef) => !colDef.isAction)
       // only sort the hidden column to the end when modal reopen
       .sort((defA, defB) => {
         const isVisibleA = isColumnVisible(defA);

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ColumnCustomization/ColumnCustomization.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -47,7 +47,6 @@ const defaultHeader = [
   {
     Header: 'Row Index',
     accessor: (row, i) => i,
-    sticky: 'left',
     id: 'rowIndex', // id is required when accessor is a function.
   },
   {
@@ -241,9 +240,17 @@ export const ColumnCustomizationUsageStory = prepareStory(
 );
 
 const ColumnCustomizationWithFixedColumn = ({ ...args }) => {
+  const stickyHeaders = defaultHeader.slice(1, 15);
+
   const columns = React.useMemo(
     () => [
-      ...defaultHeader,
+      {
+        Header: 'Row Index',
+        accessor: (row, i) => i,
+        sticky: 'left',
+        id: 'rowIndex', // id is required when accessor is a function.
+      },
+      ...stickyHeaders,
       {
         Header: '',
         accessor: 'actions',


### PR DESCRIPTION
Contributes to #2716 #2504 

Fix issue with empty headers added to customize columns tearsheet.
Clean up customize columns stories with unnecessary use of `sticky`.

#### What did you change?
Check for empty title and clean up customize columns story using sticky where not necessary.

#### How did you test and verify your work?
Storybook, ran tests