### PR TITLE
feat(SidePanel): expose tooltip props

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -817,17 +817,8 @@ SidePanel.propTypes = {
           'danger',
           'primary',
         ]),
-        tooltipPosition: PropTypes.oneOf([
-          'top',
-          'right',
-          'bottom',
-          'left',
-        ]),
-        tooltipAlignment: PropTypes.oneOf([
-          'start',
-          'center',
-          'end',
-        ]),
+        tooltipPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+        tooltipAlignment: PropTypes.oneOf(['start', 'center', 'end']),
         label: PropTypes.string,
         loading: PropTypes.bool,
         // we duplicate this Button prop to improve the DocGen here

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -624,6 +624,8 @@ export let SidePanel = React.forwardRef(
                 label,
                 kind,
                 icon,
+                tooltipPosition,
+                tooltipAlignment,
                 leading,
                 disabled,
                 className,
@@ -637,8 +639,8 @@ export let SidePanel = React.forwardRef(
                   size="small"
                   renderIcon={icon}
                   iconDescription={label}
-                  tooltipPosition="bottom"
-                  tooltipAlignment="center"
+                  tooltipPosition={tooltipPosition || 'bottom'}
+                  tooltipAlignment={tooltipAlignment || 'center'}
                   hasIconOnly={!leading}
                   disabled={disabled}
                   className={cx([
@@ -782,6 +784,8 @@ SidePanel.propTypes = {
       icon: PropTypes.object,
       onClick: PropTypes.func,
       kind: PropTypes.oneOf(['ghost', 'tertiary', 'secondary', 'primary']),
+      tooltipAlignment: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+      tooltipPosition: PropTypes.oneOf(['start', 'center', 'end']),
     })
   ),
 
@@ -789,7 +793,10 @@ SidePanel.propTypes = {
    * The primary actions to be shown in the side panel. Each action is
    * specified as an object with optional fields: 'label' to supply the button
    * label, 'kind' to select the button kind (must be 'primary', 'secondary' or
-   * 'ghost'), 'loading' to display a loading indicator, and 'onClick' to
+   * 'ghost'), 'tooltipPosition' to select where the tooltip is placed around
+   * the button (must be 'top', 'right', 'bottom', or 'left'), 'tooltipAlignment'
+   * to select how the tooltip is aligned with the button (must be 'start',
+   * 'center', or 'end', 'loading' to display a loading indicator, and 'onClick' to
    * receive notifications when the button is clicked. Additional fields in the
    * object will be passed to the Button component, and these can include
    * 'disabled', 'ref', 'className', and any other Button props. Any other
@@ -809,6 +816,17 @@ SidePanel.propTypes = {
           'secondary',
           'danger',
           'primary',
+        ]),
+        tooltipPosition: PropTypes.oneOf([
+          'top',
+          'right',
+          'bottom',
+          'left',
+        ]),
+        tooltipAlignment: PropTypes.oneOf([
+          'start',
+          'center',
+          'end',
         ]),
         label: PropTypes.string,
         loading: PropTypes.bool,


### PR DESCRIPTION
Contributes to #2485

Exposes the `tooltipPosition` and `tooltipAlignment` props for the SidePanel action toolbar buttons. Users will no longer be locked into bottom, centered tooltips for action toolbar buttons and can change them for their uses.

#### What did you change?
`tooltipPosition` and `tooltipAlignment` are now exposed props under `actionToolbarButtons`

#### How did you test and verify your work?
So far I have tested by setting the props' values in `actionToolbarButtons` and see the correct change in Storybook.

I also tested with `yarn test:c4p` and it passed all tests.