### PR TITLE
chore: use sync workflow on test branch

### DIFF
--- a/.github/workflows/sync-commit.yml
+++ b/.github/workflows/sync-commit.yml
@@ -2,7 +2,7 @@ name: Sync commits across versions
 
 on:
   pull_request:
-    branches: [main]
+    branches: [sync-commit] # TODO: Rename to branch `main` after token issue resolved.
     types: [closed]
 
 jobs:
@@ -19,11 +19,12 @@ jobs:
       # https://git-scm.com/docs/git-cherry-pick#_options
       - name: Cherry pick
 
+        # TODO: Rename to branch `main` after token issue resolved.
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git fetch origin main
+          git fetch origin sync-commit
           git cherry-pick -xX theirs --keep-redundant-commits ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Create PR


### PR DESCRIPTION
Contributes to #2726

Use a test branch to resolve [issue where token triggered from forked repo is not passed](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).