### PR TITLE
fix(sidepanel toolbar): tooltip truncate issue fix

### DIFF
--- a/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
+++ b/packages/cloud-cognitive/src/components/SidePanel/_side-panel.scss
@@ -303,7 +303,7 @@ $action-set-block-class: #{c4p-settings.$pkg-prefix}--action-set;
     margin-bottom: $spacing-05;
   }
   .#{$block-class}__action-toolbar {
-    position: sticky;
+    position: fixed;
     z-index: 4;
     /* stylelint-disable-next-line carbon/layout-token-use */
     top: var(--#{$block-class}--title-height);


### PR DESCRIPTION
Contributes to #2485 

Sidepanel toolbar's icon tooltip truncate issue fixed

#### What did you change?
position property changed from sticky to fixed

#### How did you test and verify your work?
storybook
