### PR TITLE
fix(create-full-page): focus modal secondary button

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2021, 2022
+ * Copyright IBM Corp. 2021, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -187,6 +187,7 @@ export let CreateFullPage = React.forwardRef(
               onClick={() => {
                 setModalIsOpen(!modalIsOpen);
               }}
+              data-modal-primary-focus
             >
               {modalSecondaryButtonText}
             </Button>


### PR DESCRIPTION
Contributes to #2784

**Not a regression** as doesn't exist in `v1`.