### PR TITLE
fix(create-full-page): focus modal secondary button (#2790)

### DIFF
--- a/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/CreateFullPage.js
@@ -185,6 +185,7 @@ export let CreateFullPage = React.forwardRef(
               onClick={() => {
                 setModalIsOpen(!modalIsOpen);
               }}
+              data-modal-primary-focus
             >
               {modalSecondaryButtonText}
             </Button>


### PR DESCRIPTION
Contributes to #2790 — `v2`