### PR TITLE
build: update lock file after bumping package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "upgrade:dependencies:yarn": "yarn set version latest",
     "upgrade:automatic": "run-s -s 'upgrade:dependencies:*'",
     "upgrade:carbon": "npm-check-updates -u --dep dev,peer,prod --packageFile '{package.json,{config/**,packages/**}/package.json}' --filter '/carbon/' --target minor",
-    "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh"
+    "upgrade:manual": "sh ./scripts/monorepo-npm-upgrade.sh",
+    "version": "yarn && git add yarn.lock"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
Contributes to #2792 — update lock file after bumping package versions during publishing.