### PR TITLE
feat(storybook): new fn getSelectedCarbonTheme

### DIFF
--- a/packages/cloud-cognitive/src/global/js/utils/story-helper.js
+++ b/packages/cloud-cognitive/src/global/js/utils/story-helper.js
@@ -84,3 +84,14 @@ CodesandboxLink.propTypes = {
    */
   exampleDirectory: PropTypes.string,
 };
+
+/**
+ * A helper function that finds the designated theme on the Storybook canvas.
+ * @returns "dark" or "light"
+ */
+export const getSelectedCarbonTheme = () => {
+  const themeId = document
+    .querySelector('html')
+    .getAttribute('storybook-carbon-theme');
+  return themeId === 'g90' || themeId === 'g100' ? 'dark' : 'light';
+};


### PR DESCRIPTION
# New Storybook helper function getSelectedCarbonTheme()

## Brief description

Allow the user to change the Storybook Carbon theme selector to change both the Carbon theme and the component's theme at the same time.

### Issue

Some components have specific needs when switching between "light" and "dark" themes. These components typically look like `<Welcome theme={'light'} />`.

The current Storybook setup offers separate controls for changing a component's theme property _and_ the environment's Carbon theme.

Currently, both controls must be changed to effect a "dark mode" look:

- **Control** tab > `theme` prop > **(o) dark**
- **Carbon theme** tab > select **g90** or **g100**

_Example component theme control_

<img src="https://user-images.githubusercontent.com/52505287/227609333-77117be4-39f2-4917-aa41-3f8536116487.jpg" width="500" />

_Example Carbon selector_

<img src="https://user-images.githubusercontent.com/52505287/227609404-25b2ba50-080e-4652-b110-dc8c66a759dc.jpg" width="500" />

### Optional solution

This new helper function is an option that can be used to couple the component's light/dark theme to the various Carbon theme selections.

## Typical `Welcome.stories.js` setup

_`theme` control setup (optional; expanded here for clarity)_

```jsx
export default {
  argTypes: {
    theme: {
      control: {
        type: "radio"
      },
      options: ["light", "dark"]
    }
  }
};
```

_Template_

```jsx
const Template = (args) => {
  return <Welcome {...args} />;
};
```

## Updated `Welcome.stories.js` setup

_Import the helper function._

```jsx
import { getSelectedCarbonTheme } from "../../global/js/utils/story-helper";
```

_`theme` control update (required)._

Hide the `theme's` radio buttons, since using `getSelectedCarbonTheme()` in this way renders the default radio buttons non-functional.

```jsx
export default {
  argTypes: {
    theme: {
      control: { type: null }
    }
  }
};
```

_Updated template_

When any control is changed, Storybook re-renders the component. The updated Carbon theme can be retrieved and applied at that point and passed directly to the component.

```jsx
const Template = (args) => {
  const theme = getSelectedCarbonTheme();
  return <Welcome {...args} theme={theme} />;
};
```

## Updated controls

Now only the **Carbon theme** selector needs be changed to effect a "dark mode" look:

- **Carbon theme** tab > select **g90** or **g100** to update both the component _and_ Carbon themes.

The component's `theme` is still listed as a property, but its control is removed

_(I tried **really hard** to find a way to replace the controls with a simple message like "Use the Carbon theme selector", but no such luck.)_

<img src="https://user-images.githubusercontent.com/52505287/227609465-27f2a19d-3a86-4169-a512-233ddf2ef9c1.jpg" width="500" />

The same Carbon selector will now update the Carbon theme and the component's theme

<img src="https://user-images.githubusercontent.com/52505287/227609512-7251411e-0b33-42df-a5bb-839f03813416.jpg" width="500" />

## Tasks

Before starting work on this epic, please review and complete the following.

- [x] Initial review of design/existing code

### Working in Carbon for IBM Products package

- [x] Have you reviewed our
      [contribution guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/.github/CONTRIBUTING.md)?
- [x] Have you noted our
      [code guidelines](https://github.com/carbon-design-system/ibm-cloud-cognitive/blob/master/docs/CODE_GUIDELINES.md)?
