### PR TITLE
build(security): pin `accessibility-checker` rules

### DIFF
--- a/packages/security/achecker.js
+++ b/packages/security/achecker.js
@@ -1,8 +1,12 @@
 /**
- * Copyright IBM Corp. 2020, 2021
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = require('@carbon/ibm-cloud-cognitive-core/accessibility-checker');
+module.exports = {
+  ...require('@carbon/ibm-cloud-cognitive-core/accessibility-checker'),
+
+  ruleArchive: '09March2023', // `security` fails '31March2023' deployment.
+};


### PR DESCRIPTION
Contributes to https://github.com/carbon-design-system/ibm-cloud-cognitive/actions/runs/4599572575/jobs/8126960915?pr=2803

`security` fails recent `accessibility-checker` rule deployment — this pins to last passing until addressed.
