### PR TITLE
fix(create-full-page): revert `max` grid regression

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -1996,6 +1996,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   padding-bottom: 2rem;
 }
 
+.c4p--create-full-page__step .cds--css-grid {
+  margin-left: 0;
+}
+
 .c4p--create-full-page .cds--side-nav--ux {
   top: 0;
   height: min-content;

--- a/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
+++ b/packages/cloud-cognitive/src/components/CreateFullPage/_create-full-page.scss
@@ -1,5 +1,5 @@
 //
-// Copyright IBM Corp. 2021, 2021
+// Copyright IBM Corp. 2021, 2023
 //
 // This source code is licensed under the Apache-2.0 license found in the
 // LICENSE file in the root directory of this source tree.
@@ -102,6 +102,10 @@ $step-block-class: #{c4p-settings.$pkg-prefix}--create-full-page__step;
 .#{$block-class} .#{$block-class}__step {
   position: relative;
   padding-bottom: $spacing-07;
+}
+
+.#{$block-class}__step .#{c4p-settings.$carbon-prefix}--css-grid {
+  margin-left: 0;
 }
 
 .#{$block-class} .#{c4p-settings.$carbon-prefix}--side-nav--ux {


### PR DESCRIPTION
Contributes to #2784

Removed grid margin override in #2807 causing `CreateFullPage` regression at `max` breakpoint — this reverts that.
