### PR TITLE
fix(Datagrid): filter action columns from `Columns` component to prevent ordering issues

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
@@ -116,6 +116,11 @@ const Columns = ({
             />
           </div>
           {columns
+            // hide the columns without Header, e.g the sticky actions, spacer
+            .filter(
+              (colDef) => !!colDef.Header.props && !!colDef.Header.props.title
+            )
+            .filter((colDef) => !colDef.isAction)
             .filter(
               (colDef) =>
                 filterString.length === 0 ||

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -37,9 +37,6 @@ const CustomizeColumnsTearsheet = ({
   const [searchText, setSearchText] = useState('');
   const [columnObjects, setColumnObjects] = useState(
     columnDefinitions
-      // hide the columns without Header, e.g the sticky actions, spacer
-      .filter((colDef) => !!colDef.Header.props && !!colDef.Header.props.title)
-      .filter((colDef) => !colDef.isAction)
       // only sort the hidden column to the end when modal reopen
       .sort((defA, defB) => {
         const isVisibleA = isColumnVisible(defA);


### PR DESCRIPTION
Contributes to #2820 

Addresses issue where the checkbox to select a row was getting re-ordered in the incorrect place after customizing the column ordering. The filtering of the action columns needs to happen in the `<Columns />` component otherwise the row selection column gets placed as the last column instead of the first, see @youngjunekoh's screenshots in #2820.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
```
#### How did you test and verify your work?
Storybook