### PR TITLE
fix(Datagrid): add background to virtual body header, fix svg scoping

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -1,16 +1,17 @@
 /*
  * Licensed Materials - Property of IBM
  * 5724-Q36
- * (c) Copyright IBM Corp. 2020 - 2021
+ * (c) Copyright IBM Corp. 2020 - 2023
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 import React, { useEffect } from 'react';
 import { VariableSizeList } from 'react-window';
 import { DataTable } from 'carbon-components-react';
+import { px } from '@carbon/layout';
+import { useResizeDetector } from 'react-resize-detector';
 import { pkg } from '../../../settings';
 import DatagridHead from './DatagridHead';
-import { px } from '@carbon/layout';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -48,12 +49,19 @@ const DatagridVirtualBody = (datagridState) => {
     gridRef,
   } = datagridState;
 
+  const handleVirtualGridResize = () => {
+    const gridRefElement = gridRef?.current;
+    gridRefElement.style.width = gridRefElement?.clientWidth;
+  };
+
+  useResizeDetector({ onResize: handleVirtualGridResize, targetRef: gridRef });
+
   const syncScroll = (e) => {
     const virtualBody = e.target;
-    document.querySelector(`.${blockClass}__head-warp`).scrollLeft =
+    document.querySelector(`.${blockClass}__head-wrap`).scrollLeft =
       virtualBody.scrollLeft;
     const spacerColumn = document.querySelector(
-      `.${blockClass}__head-warp thead th:last-child`
+      `.${blockClass}__head-wrap thead th:last-child`
     );
     spacerColumn.style.width = px(
       32 + (virtualBody.offsetWidth - virtualBody.clientWidth)
@@ -72,7 +80,7 @@ const DatagridVirtualBody = (datagridState) => {
   return (
     <>
       <div
-        className={`${blockClass}__head-warp`}
+        className={`${blockClass}__head-wrap`}
         style={{ width: gridRef.current?.clientWidth, overflow: 'hidden' }}
       >
         <DatagridHead {...datagridState} />

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
@@ -613,3 +613,7 @@
     padding: 0 $spacing-03;
   }
 }
+
+.#{$block-class} .#{$pkg-prefix}--datagrid__head-wrap {
+  background-color: $ui-03;
+}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useSortableColumns.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useSortableColumns.scss
@@ -21,7 +21,7 @@
   .#{$carbon-prefix}--table-header-label .#{$carbon-prefix}--table-sort:active,
   .#{$carbon-prefix}--table-header-label
     .#{$carbon-prefix}--table-sort:focus
-    svg {
+    .#{$block-class}__sortable-icon {
     /* stylelint-disable-next-line declaration-no-important */
     background: none !important;
     /* stylelint-disable-next-line declaration-no-important */
@@ -44,7 +44,9 @@
     color: $text-01 !important;
     font: inherit;
   }
-  .#{$carbon-prefix}--table-header-label .#{$carbon-prefix}--table-sort svg {
+  .#{$carbon-prefix}--table-header-label
+    .#{$carbon-prefix}--table-sort
+    .#{$block-class}__sortable-icon {
     fill: $text-01;
     opacity: 0;
     transition: transform $duration--fast-02 motion(standard, productive);
@@ -60,12 +62,14 @@
 .#{$block-class}__sortableColumn:hover,
 .#{$block-class}__sortableColumn:focus-within,
 .#{$block-class}__sortableColumn.#{$block-class}__isSorted {
-  .#{$carbon-prefix}--table-header-label svg {
+  .#{$carbon-prefix}--table-header-label .#{$block-class}__sortable-icon {
     opacity: 1;
     visibility: visible;
   }
 }
 
-.#{$block-class}__sortableColumn .#{$block-class}--table-sort--desc svg {
+.#{$block-class}__sortableColumn
+  .#{$block-class}--table-sort--desc
+  .#{$block-class}__sortable-icon {
   transform: rotate(180deg);
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
@@ -35,14 +35,30 @@ const useSortableColumns = (hooks) => {
         if (col.isSorted) {
           switch (col.isSortedDesc) {
             case false:
-              return ArrowUp16;
+              return () => (
+                <ArrowUp16
+                  className={`${blockClass}__sortable-icon ${carbon.prefix}--btn__icon`}
+                />
+              );
             case true:
-              return ArrowUp16;
+              return () => (
+                <ArrowUp16
+                  className={`${blockClass}__sortable-icon ${carbon.prefix}--btn__icon`}
+                />
+              );
             default:
-              return Arrows16;
+              return () => (
+                <Arrows16
+                  className={`${blockClass}__sortable-icon ${carbon.prefix}--btn__icon`}
+                />
+              );
           }
         }
-        return Arrows16;
+        return () => (
+          <Arrows16
+            className={`${blockClass}__sortable-icon ${carbon.prefix}--btn__icon`}
+          />
+        );
       };
       const Header = (headerProp) =>
         column.disableSortBy === true ? (


### PR DESCRIPTION
Contributes to #2825 

This PR includes some styling fixes for virtual data grids (can be seen when using infinite scroll option), as well as an issue where the width of the grid was not updating if the window resized at all.

Width issue can be seen below (this only occurs with the virtual data grid)
_Before_
![after_virtual_datagrid_width_issue](https://user-images.githubusercontent.com/10215203/230408771-7671127d-fcf5-49c4-8f9d-8a360aa4fd5f.gif)

_After_
![before_virtual_datagrid_width_issue](https://user-images.githubusercontent.com/10215203/230408704-6dad05a4-90e9-4f32-97c8-a61d49238063.gif)

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
packages/cloud-cognitive/src/components/Datagrid/styles/_datagrid.scss
packages/cloud-cognitive/src/components/Datagrid/styles/_useSortableColumns.scss
packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
```
#### How did you test and verify your work?
Storybook