### PR TITLE
chore(Datagrid): pass event to `onRowClick` callback (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -286,7 +286,8 @@ const ClickableRowWithPanel = ({ ...args }) => {
     {
       columns,
       data,
-      onRowClick: (row) => {
+      onRowClick: (row, event) => {
+        action()(event);
         setOpenSidePanel(true);
         setRowData(row);
       },

--- a/packages/cloud-cognitive/src/components/Datagrid/useOnRowClick.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useOnRowClick.js
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 5724-Q36
- * (c) Copyright IBM Corp. 2020
+ * (c) Copyright IBM Corp. 2020, 2023
  * US Government Users Restricted Rights - Use, duplication or disclosure
  * restricted by GSA ADP Schedule Contract with IBM Corp.
  */
@@ -12,9 +12,9 @@ const useOnRowClick = (hooks) => {
     const getRowProps = (props, datagridState) => {
       const { isFetching, row, instance } = datagridState;
       const { id, toggleRowSelected } = row;
-      const onClick = () => {
+      const onClick = (event) => {
         if (!isFetching && onRowClick) {
-          onRowClick(row);
+          onRowClick(row, event);
           instance.selectedFlatRows &&
             instance.selectedFlatRows.map((toggleRow) =>
               toggleRow.toggleRowSelected(false)


### PR DESCRIPTION
Contributes to #2843 

Pass click event to `onRowClick` callback to allow consumers to prevent row click behaviors for cells with interactive elements.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Extensions/ClickableRow/ClickableRow.stories.js
packages/cloud-cognitive/src/components/Datagrid/useOnRowClick.js
```
#### How did you test and verify your work?
Storybook