### PR TITLE
feat(Datagrid): add auto size column support (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -773,6 +773,27 @@ filterProps: {
   />
 </Canvas>
 
+## Auto size column to fit content
+
+The `getAutoSizedColumnWidth` utility function can be used to auto size columns
+based on it's content. The width will be set to that of the largest cell in the
+column or the column header, whichever is greater. If this is not used, the
+width will be set to the default column width (150px) or the value passed to the
+`width` property in the column definition. See example below:
+
+```jsx
+  import { Datagrid, useDatagrid, getAutoSizedColumnWidth } from '@carbon/ibm-products';
+  ...
+  const myColumns = [
+    {
+      Header: 'Column 1',
+      accessor: 'column_1',
+      width: getAutoSizedColumnWidth(rows, 'column_1', 'Column 1'),
+    }
+  ]
+  ...
+```
+
 ## Code sample
 
 <CodesandboxLink exampleDirectory="Datagrid" />

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -24,6 +24,7 @@ import {
   useStickyColumn,
   useActionsColumn,
   useFiltering,
+  getAutoSizedColumnWidth,
 } from '.';
 
 import { SelectAllWithToggle } from './Datagrid.stories/index';
@@ -47,74 +48,80 @@ export default {
   },
 };
 
-const defaultHeader = [
-  {
-    Header: 'Row Index',
-    accessor: (row, i) => i,
-    sticky: 'left',
-    id: 'rowIndex', // id is required when accessor is a function.
-  },
-  {
-    Header: 'First Name',
-    accessor: 'firstName',
-  },
-  {
-    Header: 'Last Name',
-    accessor: 'lastName',
-  },
-  {
-    Header: 'Age',
-    accessor: 'age',
-    width: 50,
-  },
-  {
-    Header: 'Visits',
-    accessor: 'visits',
-    width: 60,
-  },
-  {
-    Header: 'Status',
-    accessor: 'status',
-  },
-  {
-    Header: 'Joined',
-    accessor: 'joined',
-    Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
-  },
-  {
-    Header: 'Someone 1',
-    accessor: 'someone1',
-  },
-  {
-    Header: 'Someone 2',
-    accessor: 'someone2',
-  },
-  {
-    Header: 'Someone 3',
-    accessor: 'someone3',
-  },
-  {
-    Header: 'Someone 4',
-    accessor: 'someone4',
-  },
-  {
-    Header: 'Someone 5',
-    accessor: 'someone5',
-  },
-  {
-    Header: 'Someone 6',
-    accessor: 'someone6',
-  },
-  {
-    Header: 'Someone 7',
-    accessor: 'someone7',
-  },
-];
+const getColumns = (rows) => {
+  return [
+    {
+      Header: 'Row Index',
+      accessor: (row, i) => i,
+      sticky: 'left',
+      id: 'rowIndex', // id is required when accessor is a function.
+      width: getAutoSizedColumnWidth(rows, 'rowIndex', 'Row Index'),
+    },
+    {
+      Header: 'First Name',
+      accessor: 'firstName',
+    },
+    {
+      Header: 'Last Name',
+      accessor: 'lastName',
+      width: getAutoSizedColumnWidth(rows, 'lastName', 'Last name'),
+    },
+    {
+      Header: 'Age',
+      accessor: 'age',
+      width: getAutoSizedColumnWidth(rows, 'age', 'Age'),
+    },
+    {
+      Header: 'Visits',
+      accessor: 'visits',
+      width: getAutoSizedColumnWidth(rows, 'visits', 'Visits'),
+    },
+    {
+      Header: 'Status',
+      accessor: 'status',
+      width: getAutoSizedColumnWidth(rows, 'status', 'Status'),
+    },
+    {
+      Header: 'Joined',
+      accessor: 'joined',
+      Cell: ({ cell: { value } }) => <span>{value.toLocaleDateString()}</span>,
+    },
+    {
+      Header: 'Someone 1',
+      accessor: 'someone1',
+    },
+    {
+      Header: 'Someone 2',
+      accessor: 'someone2',
+    },
+    {
+      Header: 'Someone 3',
+      accessor: 'someone3',
+    },
+    {
+      Header: 'Someone 4',
+      accessor: 'someone4',
+    },
+    {
+      Header: 'Someone 5',
+      accessor: 'someone5',
+    },
+    {
+      Header: 'Someone 6',
+      accessor: 'someone6',
+    },
+    {
+      Header: 'Someone 7',
+      accessor: 'someone7',
+    },
+  ];
+};
 
 export const BasicUsage = () => {
+  const [data] = useState(makeData(10));
   const columns = React.useMemo(
     () => [
-      ...defaultHeader,
+      ...getColumns(data),
       {
         Header: 'Someone 11',
         accessor: 'someone11',
@@ -123,7 +130,6 @@ export const BasicUsage = () => {
     ],
     []
   );
-  const [data] = useState(makeData(10));
   const rows = React.useMemo(() => data, [data]);
 
   const datagridState = useDatagrid({
@@ -136,8 +142,8 @@ export const BasicUsage = () => {
 };
 
 export const EmptyState = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(0));
+  const columns = React.useMemo(() => getColumns(data), []);
   const emptyStateTitle = 'Empty state title';
   const emptyStateDescription = 'Description explaining why the table is empty';
   const emptyStateSize = 'lg';
@@ -171,8 +177,8 @@ export const EmptyState = () => {
 };
 
 export const InitialLoad = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data, setData] = useState(makeData(0));
+  const columns = React.useMemo(() => getColumns(data), []);
 
   const [isFetching, setIsFetching] = useState(false);
   const fetchData = () =>
@@ -202,8 +208,8 @@ export const InitialLoad = () => {
 };
 
 export const InfiniteScroll = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data, setData] = useState(makeData(0));
+  const columns = React.useMemo(() => getColumns(data), []);
 
   const [isFetching, setIsFetching] = useState(false);
   const fetchData = () =>
@@ -247,8 +253,8 @@ InfiniteScroll.args = {
 };
 
 export const TenThousandEntries = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10000));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -261,8 +267,8 @@ export const TenThousandEntries = () => {
 };
 
 export const WithPagination = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(100));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid({
     columns,
     data,
@@ -277,6 +283,7 @@ export const WithPagination = () => {
 };
 
 export const IsHoverOnRow = () => {
+  const [data] = useState(makeData(10));
   const Cell = ({ row }) => {
     if (row.isMouseOver) {
       return 'yes hovering!';
@@ -285,7 +292,7 @@ export const IsHoverOnRow = () => {
   };
   const columns = React.useMemo(
     () => [
-      ...defaultHeader.slice(0, 3),
+      ...getColumns(data).slice(0, 3),
       {
         Header: 'Is hover on row?',
         id: 'isHoveringColumn',
@@ -295,7 +302,6 @@ export const IsHoverOnRow = () => {
     ],
     []
   );
-  const [data] = useState(makeData(10));
   const datagridState = useDatagrid(
     {
       columns,
@@ -308,8 +314,8 @@ export const IsHoverOnRow = () => {
 };
 
 export const SelectableRow = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const emptyStateTitle = 'Empty state title';
   const emptyStateDescription = 'Description explaining why the table is empty';
   const datagridState = useDatagrid(
@@ -330,8 +336,8 @@ export const SelectableRow = () => {
 };
 
 export const RadioSelect = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -353,8 +359,8 @@ export const RadioSelect = () => {
 };
 
 export const HideSelectAll = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -368,8 +374,8 @@ export const HideSelectAll = () => {
 };
 
 export const SortableColumns = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -382,8 +388,8 @@ export const SortableColumns = () => {
 };
 
 export const ActionsDropdown = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -410,8 +416,8 @@ export const ActionsDropdown = () => {
 };
 
 export const SelectItemsInAllPages = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(100));
+  const columns = React.useMemo(() => getColumns(data), []);
   const [areAllSelected, setAreAllSelected] = useState(false);
   const datagridState = useDatagrid(
     {
@@ -748,8 +754,8 @@ const getBatchActions = () => {
 };
 
 export const BatchActions = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -767,8 +773,8 @@ export const BatchActions = () => {
 };
 
 export const DisableSelectRow = () => {
-  const columns = React.useMemo(() => defaultHeader, []);
   const [data] = useState(makeData(10));
+  const columns = React.useMemo(() => getColumns(data), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -789,8 +795,8 @@ const makeDataWithTwoLines = (length) =>
   range(length).map(() => newPersonWithTwoLines());
 
 export const TopAlignment = () => {
-  const columns = React.useMemo(() => defaultHeader.slice(0, 3), []);
   const [data] = useState(makeDataWithTwoLines(10));
+  const columns = React.useMemo(() => getColumns(data).slice(0, 3), []);
   const datagridState = useDatagrid(
     {
       columns,
@@ -822,9 +828,10 @@ export const TopAlignment = () => {
 };
 
 export const FrozenColumns = () => {
+  const [data] = useState(makeData(10));
   const columns = React.useMemo(
     () => [
-      ...defaultHeader,
+      ...getColumns(data),
       {
         Header: '',
         accessor: 'actions',
@@ -834,7 +841,6 @@ export const FrozenColumns = () => {
     ],
     []
   );
-  const [data] = useState(makeData(10));
   const [msg, setMsg] = useState('');
   const onActionClick = (actionId, row) => {
     const { original } = row;

--- a/packages/cloud-cognitive/src/components/Datagrid/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/index.js
@@ -1,10 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2020
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 export { Datagrid } from './Datagrid';
 export { default as useDatagrid } from './useDatagrid';
 export { default as useInfiniteScroll } from './useInfiniteScroll';
@@ -24,3 +24,4 @@ export { default as useColumnCenterAlign } from './useColumnCenterAlign';
 export { default as useColumnOrder } from './useColumnOrder';
 export { default as useInlineEdit } from './useInlineEdit';
 export { default as useFiltering } from './useFiltering';
+export { getAutoSizedColumnWidth } from './utils/getAutoSizedColumnWidth';

--- a/packages/cloud-cognitive/src/components/Datagrid/utils/getAutoSizedColumnWidth.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/utils/getAutoSizedColumnWidth.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Calculates the auto sized width of a column
+ * @param {Array<object>} rows - The datagrid rows
+ * @param {string} accessor - The accessor for the column
+ * @param {string} headerText - The header text for the column
+ */
+
+export const getAutoSizedColumnWidth = (rows, accessor, headerText) => {
+  const maxWidth = 400;
+  const minWidth = 58;
+  const letterSpacing = 10;
+  const cellLength = Math.max(
+    ...rows.map((row) => (`${row[accessor]}` || '').length),
+    headerText.length
+  );
+  if (cellLength <= 3) {
+    return minWidth;
+  }
+  return Math.min(maxWidth, cellLength * letterSpacing + 16);
+};

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -75,6 +75,7 @@ export {
   useColumnOrder,
   useInlineEdit,
   useFiltering,
+  getAutoSizedColumnWidth,
 } from './Datagrid';
 export { EditTearsheet } from './EditTearsheet';
 export { EditTearsheetNarrow } from './EditTearsheetNarrow';


### PR DESCRIPTION
Contributes to #2045 

Added an auto size utility function that will be exported for consumers to use on columns they wish to be auto sized and not receive a custom width or the default column width of 150px. Added some usage docs to the Datagrid.mdx file as well.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/index.js
packages/cloud-cognitive/src/components/Datagrid/utils/getAutoSizedColumnWidth.js
packages/cloud-cognitive/src/components/index.js
```
#### How did you test and verify your work?
Storybook