### PR TITLE
fix(Datagrid): fix how `RowSizeDropdown` open state value is set (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
@@ -1,10 +1,8 @@
-// @flow
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2021
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2021, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import * as React from 'react';
@@ -30,7 +28,7 @@ const RowSizeDropdown = ({ legendText = 'Row height', ...props }) => {
       <IconButton
         kind="ghost"
         align="left"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => setIsOpen((prevOpen) => !prevOpen)}
         label={legendText}
         className={cx(`${blockClass}__row-size-button`, {
           [`${blockClass}__row-size-button--open`]: isOpen,


### PR DESCRIPTION
Contributes to #2856 

When using row height settings with customize columns the open value for the `RowSizeDropdown` component does not update (see this [code sandbox](https://codesandbox.io/s/epic-fire-q8c41o?file=/src/Example/Example.js)), this prevents the overflow menu from opening at all. I think setting it with a function that gives us a reliable previous state value will help to fix this.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
```
#### How did you test and verify your work?
Storybook