### PR TITLE
fix(Datagrid): sortable and customizable columns work together now (v11)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
@@ -31,6 +31,7 @@ const CustomizeColumnsTearsheet = ({
   assistiveTextInstructionsLabel = 'Press space bar to toggle drag drop mode, use arrow keys to move selected elements.',
   assistiveTextDisabledInstructionsLabel = 'Reordering columns are disabled because they are filtered currently.',
   selectAllLabel = 'Column name',
+  isTableSortable,
 }) => {
   const [visibleColumnsCount, setVisibleColumnsCount] = useState('');
   const [totalColumns, setTotalColumns] = useState('');
@@ -144,6 +145,7 @@ const CustomizeColumnsTearsheet = ({
             setDirty();
           }}
           selectAllLabel={selectAllLabel}
+          isTableSortable={isTableSortable}
         />
       )}
     </TearsheetNarrow>
@@ -158,6 +160,7 @@ CustomizeColumnsTearsheet.propTypes = {
   findColumnPlaceholderLabel: PropTypes.string,
   instructionsLabel: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
+  isTableSortable: PropTypes.bool.isRequired,
   onSaveColumnPrefs: PropTypes.func.isRequired,
   originalColumnDefinitions: PropTypes.array.isRequired,
   primaryButtonTextLabel: PropTypes.string,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Checkbox } from '@carbon/react';
+import { isColumnVisible } from './common';
+import DraggableElement from '../../DraggableElement';
+import { pkg } from '../../../../../settings';
+
+const blockClass = `${pkg.prefix}--datagrid`;
+
+export const DraggableItemsList = ({
+  columns,
+  filterString,
+  focusIndex,
+  getNextIndex,
+  isTableSortable,
+  moveElement,
+  onSelectColumn,
+  setAriaRegionText,
+  setColumnsObject,
+  setFocusIndex,
+}) => {
+  return (
+    <>
+      {columns
+        // hide the columns without Header, e.g the sticky actions, spacer
+        .filter((colDef) => {
+          const sortableTitle =
+            isTableSortable && colDef.Header().props.children.props?.title;
+          return (
+            (!!colDef.Header.props && !!colDef.Header.props?.title) ||
+            (isTableSortable && !!sortableTitle)
+          );
+        })
+        .filter((colDef) => !colDef.isAction)
+        .filter((colDef) => {
+          const sortableTitle =
+            isTableSortable && colDef.Header().props.children.props?.title;
+          return (
+            filterString.length === 0 ||
+            ((isTableSortable
+              ? sortableTitle?.toLowerCase().includes(filterString)
+              : colDef.Header.props?.title
+                  ?.toLowerCase()
+                  .includes(filterString)) &&
+              colDef.id !== 'spacer')
+          );
+        })
+        .map((colDef, i) => {
+          const isSortableColumn = !!colDef.canSort && !!isTableSortable;
+          const sortableTitle =
+            isTableSortable && colDef.Header().props.children.props?.title;
+          const searchString = new RegExp('(' + filterString + ')');
+          const res = filterString.length
+            ? isSortableColumn
+              ? sortableTitle.toLowerCase().split(searchString)
+              : colDef.Header.props.title.toLowerCase().split(searchString)
+            : null;
+          const firstWord =
+            res !== null
+              ? res[0] === ''
+                ? res[1].charAt(0).toUpperCase() + res[1].substring(1)
+                : res[0].charAt(0).toUpperCase() + res[0].substring(1)
+              : null;
+          const highlightedText =
+            res !== null
+              ? res[0] === ''
+                ? `<strong>${firstWord}</strong>` + res[2]
+                : firstWord + `<strong>${res[1]}</strong>` + res[2]
+              : isSortableColumn
+              ? sortableTitle
+              : colDef.Header.props?.title;
+          const isFrozenColumn = !!colDef.sticky;
+          const listContents = (
+            <>
+              <Checkbox
+                wrapperClassName={`${blockClass}__customize-columns-checkbox-wrapper`}
+                checked={isColumnVisible(colDef)}
+                disabled={isFrozenColumn}
+                onChange={(_, { checked }) => onSelectColumn(colDef, checked)}
+                id={`${blockClass}__customization-column-${colDef.id}`}
+                labelText={
+                  isSortableColumn ? sortableTitle : colDef.Header.props?.title
+                }
+                title={
+                  isSortableColumn ? sortableTitle : colDef.Header.props?.title
+                }
+                className={`${blockClass}__customize-columns-checkbox`}
+                hideLabel
+              />
+              {
+                <div
+                  dangerouslySetInnerHTML={{ __html: highlightedText }}
+                  className={`${blockClass}__customize-columns-checkbox-visible-label`}
+                ></div>
+              }
+            </>
+          );
+
+          return (
+            <DraggableElement
+              key={colDef.id}
+              index={i}
+              listData={columns}
+              setListData={setColumnsObject}
+              id={`dnd-datagrid-columns-${colDef.id}`}
+              type="column-customization"
+              disabled={filterString.length > 0 || isFrozenColumn}
+              ariaLabel={
+                isSortableColumn ? sortableTitle : colDef.Header.props?.title
+              }
+              onGrab={setAriaRegionText}
+              isFocused={focusIndex === i}
+              moveElement={moveElement}
+              onArrowKeyDown={(e, isGrabbed, currentIndex) => {
+                if (isGrabbed) {
+                  const nextIndex = getNextIndex(columns, currentIndex, e.key);
+                  e.preventDefault();
+                  e.stopPropagation();
+
+                  if (nextIndex >= 0 && !columns[nextIndex]?.sticky) {
+                    setFocusIndex(nextIndex);
+                    moveElement(currentIndex, nextIndex);
+                    e.target.scrollIntoView({
+                      block: 'center',
+                    });
+                  }
+                }
+              }}
+              isSticky={isFrozenColumn}
+              selected={isColumnVisible(colDef)}
+            >
+              {listContents}
+            </DraggableElement>
+          );
+        })}
+    </>
+  );
+};
+
+DraggableItemsList.propTypes = {
+  columns: PropTypes.array.isRequired,
+  filterString: PropTypes.string.isRequired,
+  focusIndex: PropTypes.number.isRequired,
+  getNextIndex: PropTypes.func.isRequired,
+  isTableSortable: PropTypes.bool,
+  moveElement: PropTypes.func.isRequired,
+  onSelectColumn: PropTypes.func.isRequired,
+  setAriaRegionText: PropTypes.func.isRequired,
+  setColumnsObject: PropTypes.func.isRequired,
+  setFocusIndex: PropTypes.func.isRequired,
+};

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
@@ -21,6 +21,7 @@ const TearsheetWrapper = ({ instance }) => {
       {...rest}
       {...labels}
       isOpen={isTearsheetOpen}
+      isTableSortable={instance?.isTableSortable}
       setIsTearsheetOpen={setIsTearsheetOpen}
       columnDefinitions={instance.allColumns}
       originalColumnDefinitions={instance.columns}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -29,7 +29,6 @@
   border-bottom: 1px solid $background-active;
 }
 
-// .#{variables.$block-class}__customize-columns-checkbox-wrapper {
 .#{c4p-settings.$carbon-prefix}--form-item.#{c4p-settings.$carbon-prefix}--checkbox-wrapper.#{variables.$block-class}__customize-columns-checkbox {
   display: flex;
   flex: initial;

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/type' as *;
 @use '@carbon/type/scss/font-family';
 @use '@carbon/layout' as *;
+@use '@carbon/layout/scss/convert';
 
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
@@ -28,10 +29,19 @@
   border-bottom: 1px solid $background-active;
 }
 
-.#{variables.$block-class}__customize-columns-checkbox-wrapper {
+// .#{variables.$block-class}__customize-columns-checkbox-wrapper {
+.#{c4p-settings.$carbon-prefix}--form-item.#{c4p-settings.$carbon-prefix}--checkbox-wrapper.#{variables.$block-class}__customize-columns-checkbox {
   display: flex;
+  flex: initial;
+  align-items: center;
   justify-content: center;
-  padding-left: $spacing-02;
+}
+
+.#{variables.$block-class}__customize-columns-column-list
+  .#{variables.$block-class}__customize-columns-checkbox-visible-label {
+  // Disabling linter only to match the spacing that Carbon uses for the Checkbox label
+  /* stylelint-disable-next-line */
+  padding-left: convert.rem(6px);
 }
 
 .#{variables.$block-class}__customize-columns-column-list
@@ -42,6 +52,10 @@
 .#{variables.$block-class}__customize-columns-column-list {
   position: relative; // needed for the react-dnd, otherwise the drag preview will not work correctly
   overflow: auto;
+}
+
+.#{variables.$block-class}__customize-columns-select-all {
+  align-items: center;
 }
 
 .#{variables.$block-class}__customize-columns-select-all,

--- a/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
@@ -32,7 +32,7 @@ const useSortableColumns = (hooks) => {
     };
     const sortableColumns = visibleColumns.map((column) => {
       const icon = (col, props) => {
-        if (col.isSorted) {
+        if (col?.isSorted) {
           switch (col.isSortedDesc) {
             case false:
               return (
@@ -73,16 +73,16 @@ const useSortableColumns = (hooks) => {
           column.Header
         ) : (
           <Button
-            onClick={() => onSortClick(headerProp.column)}
+            onClick={() => onSortClick(headerProp?.column)}
             kind="ghost"
-            renderIcon={(props) => icon(headerProp.column, props)}
+            renderIcon={(props) => icon(headerProp?.column, props)}
             className={cx(
               `${carbon.prefix}--table-sort ${blockClass}--table-sort`,
               {
                 [`${blockClass}--table-sort--desc`]:
-                  headerProp.column.isSortedDesc,
+                  headerProp?.column.isSortedDesc,
                 [`${blockClass}--table-sort--asc`]:
-                  headerProp.column.isSortedDesc === false,
+                  headerProp?.column.isSortedDesc === false,
               }
             )}
           >
@@ -95,7 +95,9 @@ const useSortableColumns = (hooks) => {
         minWidth: column.disableSortBy === true ? 0 : 90,
       };
     });
-    return [...sortableColumns];
+    return instance.customizeColumnsProps?.isTearsheetOpen
+      ? visibleColumns
+      : [...sortableColumns];
   };
 
   const sortInstanceProps = (instance) => {


### PR DESCRIPTION
Contributes to #2837 

Fixes issue when using `useSortableColumns` and `useCustomizeColumns` together there were issues with the customize columns tearsheet.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/Columns.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/CustomizeColumnsTearsheet.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/DraggableItemsList.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/CustomizeColumns/TearsheetWrapper.js
packages/cloud-cognitive/src/components/Datagrid/styles/addons/_CustomizeColumnsTearsheet.scss
packages/cloud-cognitive/src/components/Datagrid/useSortableColumns.js
```
#### How did you test and verify your work?
Storybook