### PR TITLE
fix(Datagrid): tooltip placement change for row height settings

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -109,6 +109,8 @@
     "tearsheets",
     "textbox",
     "timeframe",
+    "toggletip",
+    "toggletipbutton",
     "treegrid",
     "treeview",
     "uuidv",

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.test.js
@@ -1689,8 +1689,7 @@ describe(componentName, () => {
     fireEvent.click(rowHeightButton);
 
     expect(
-      screen.getByText('Row height', { selector: 'span' }).parentElement
-        .previousSibling
+      screen.getByLabelText('Row height', { selector: 'button' })
     ).toHaveClass(`c4p--datagrid__row-size-button--open`);
     expect(
       document.getElementsByClassName('c4p--datagrid__row-size-dropdown')

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
@@ -8,48 +8,70 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Settings } from '@carbon/react/icons';
-import { IconButton, Popover, PopoverContent } from '@carbon/react';
+import {
+  IconButton,
+  Toggletip,
+  ToggletipContent,
+  ToggletipButton,
+} from '@carbon/react';
 import cx from 'classnames';
 import RowSizeRadioGroup from './RowSizeRadioGroup';
 import { pkg } from '../../../../../settings';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const RowSizeDropdown = ({ legendText = 'Row height', ...props }) => {
+const RowSizeDropdown = ({
+  align = 'bottom',
+  legendText = 'Row height',
+  ...props
+}) => {
   const [isOpen, setIsOpen] = React.useState(false);
   return (
-    <Popover
-      align="bottom-right"
-      caret={false}
-      dropShadow={false}
-      open={isOpen}
-      className={`${blockClass}__row-height-settings-popover`}
-    >
-      <IconButton
-        kind="ghost"
-        align="left"
-        onClick={() => setIsOpen((prevOpen) => !prevOpen)}
-        label={legendText}
-        className={cx(`${blockClass}__row-size-button`, {
-          [`${blockClass}__row-size-button--open`]: isOpen,
-        })}
-      >
-        <Settings size={16} />
-      </IconButton>
-      <PopoverContent>
-        <RowSizeRadioGroup
-          {...props}
-          legendText={legendText}
-          hideRadioGroup={() => {
-            setIsOpen(false);
-          }}
-        />
-      </PopoverContent>
-    </Popover>
+    <>
+      {!isOpen && (
+        <IconButton
+          kind="ghost"
+          align={align}
+          onClick={() => setIsOpen((prevOpen) => !prevOpen)}
+          label={legendText}
+          className={cx(`${blockClass}__row-size-button`)}
+        >
+          <Settings size={16} />
+        </IconButton>
+      )}
+      {isOpen && (
+        <Toggletip
+          defaultOpen={true}
+          className={`${blockClass}__row-size-toggle-tip`}
+        >
+          <ToggletipButton
+            className={cx(
+              `${blockClass}__row-size-toggle-tip-button`,
+              `${blockClass}__row-size-button--open`
+            )}
+            label={legendText}
+          >
+            <Settings size={16} />
+          </ToggletipButton>
+          <ToggletipContent
+            className={`${blockClass}__row-size-toggle-tip-content`}
+          >
+            <RowSizeRadioGroup
+              {...props}
+              legendText={legendText}
+              hideRadioGroup={() => {
+                setIsOpen(false);
+              }}
+            />
+          </ToggletipContent>
+        </Toggletip>
+      )}
+    </>
   );
 };
 
 RowSizeDropdown.propTypes = {
+  align: IconButton.propTypes.align,
   datagridName: PropTypes.string,
   legendText: PropTypes.string,
   light: PropTypes.bool,

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeRadioGroup.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeRadioGroup.js
@@ -68,6 +68,7 @@ const RowSizeRadioGroup = ({
             }
             return (
               <RadioButton
+                className={`${blockClass}__row-size-radio-button`}
                 key={option.value}
                 labelText={labelText}
                 value={option.value}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
@@ -11,17 +11,22 @@
 @use '../../../../global/styles/project-settings' as c4p-settings;
 @use '../variables';
 
-.#{variables.$block-class}__row-size-dropdown {
-  padding: $spacing-05;
+.#{variables.$block-class}
+  .#{variables.$block-class}__row-size-toggle-tip-content {
   background-color: $layer-02;
-
   box-shadow: 1px 4px 8px -3px $overlay, -1px 6px 8px -5px $overlay;
 }
 
-.#{c4p-settings.$carbon-prefix}--btn--ghost.#{variables.$block-class}__row-size-button--open {
-  background-color: $layer-02;
+.#{variables.$block-class}
+  .#{variables.$block-class}__row-size-radio-button
+  .#{c4p-settings.$carbon-prefix}--radio-button__label {
+  color: $text-primary;
+}
 
-  box-shadow: 1px 4px 8px -3px $overlay, -1px 6px 8px -5px $overlay;
+.#{variables.$block-class}
+  .#{variables.$block-class}__row-size-toggle-tip
+  .#{c4p-settings.$carbon-prefix}--popover-caret {
+  background-color: $layer-02;
 }
 
 .#{variables.$block-class}
@@ -30,4 +35,11 @@
   // Used to fix layout issue with IconButton caret inside of Popover component
   /* stylelint-disable-next-line carbon/layout-token-use */
   left: -4px;
+}
+
+.#{variables.$block-class}__row-size-toggle-tip-button.#{c4p-settings.$carbon-prefix}--toggletip-button {
+  display: flex;
+  width: $spacing-09;
+  height: $spacing-09;
+  justify-content: center;
 }


### PR DESCRIPTION
Contributes to #2868 

The tooltip for the row height settings was previously displayed incorrectly, now it is aligned `bottom` by default. I did some refactoring to `RowSizeDropdown` to use `ToggleTip` from Carbon since this tooltip has interactive elements inside of it, so this will help with a11y too.

#### What did you change?
```
cspell.json
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeDropdown.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/RowSize/RowSizeRadioGroup.js
packages/cloud-cognitive/src/components/Datagrid/styles/addons/_RowSizeDropdown.scss
```
#### How did you test and verify your work?
Storybook