### PR TITLE
fix(Datagrid): filtering number empty tag bug

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -132,7 +132,6 @@ const useFilters = ({
         filtersObjectArrayCopy.splice(index, 1);
       }
     } else if (type === NUMBER) {
-      console.log('using number', { value, filtersObjectArrayCopy });
       // If the value is empty remove it from the filtersObjectArray
       if (value === '') {
         // Find the column that uses number and displays an empty string

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js
@@ -131,6 +131,18 @@ const useFilters = ({
         // Remove it from the filters array
         filtersObjectArrayCopy.splice(index, 1);
       }
+    } else if (type === NUMBER) {
+      console.log('using number', { value, filtersObjectArrayCopy });
+      // If the value is empty remove it from the filtersObjectArray
+      if (value === '') {
+        // Find the column that uses number and displays an empty string
+        const index = filtersObjectArrayCopy.findIndex(
+          (filter) => filter.id === column
+        );
+
+        // Remove it from the filters array
+        filtersObjectArrayCopy.splice(index, 1);
+      }
     }
 
     setFiltersObjectArray(filtersObjectArrayCopy);


### PR DESCRIPTION
Contributes to #2677 

Before when you clear the number input the empty string would still render an empty tag. This fix removes it from the filter's list and doesn't render the empty tag anymore.

#### What did you change?
`packages/cloud-cognitive/src/components/Datagrid/Datagrid/addons/Filtering/hooks/useFilters.js`

#### How did you test and verify your work?
1. Go to Filtering > Filter flyout - instant
2. Add a number in the visits filter, and remove it. The tag should disappear
