### PR TITLE
feat: Rename inline edit (V1)

### DIFF
--- a/packages/cloud-cognitive/src/components/EditInPlace/EditInPlace.js
+++ b/packages/cloud-cognitive/src/components/EditInPlace/EditInPlace.js
@@ -14,8 +14,6 @@ import { InlineEditV2 } from '../InlineEditV2';
 /**
  * this is a wrapper component that will allow us to support the rename of InlineEdit to EditInPlace
  *
- * if ComponentRename.InlineEdit.Editable is not enabled via a feature flag then
- * this wrapper log
  * if the user passes in the v2 feature flag the v2 version of the component will be rendered
  * since this is a temporary solution the named export should just remain InlineEdit unlike how
  * Card works as a base layer for Productive and Expressive cards.

--- a/packages/cloud-cognitive/src/components/EditInPlace/EditInPlace.js
+++ b/packages/cloud-cognitive/src/components/EditInPlace/EditInPlace.js
@@ -12,15 +12,18 @@ import { InlineEditV1 } from '../InlineEditV1';
 import { InlineEditV2 } from '../InlineEditV2';
 
 /**
- * this is a wrapper component that will allow us to support v1 and v2 versions of InlineEdit
+ * this is a wrapper component that will allow us to support the rename of InlineEdit to EditInPlace
+ *
+ * if ComponentRename.InlineEdit.Editable is not enabled via a feature flag then
+ * this wrapper log
  * if the user passes in the v2 feature flag the v2 version of the component will be rendered
  * since this is a temporary solution the named export should just remain InlineEdit unlike how
  * Card works as a base layer for Productive and Expressive cards.
  */
 
-const componentName = 'InlineEdit';
+const componentName = 'EditInPlace';
 
-export let InlineEdit = forwardRef(({ v2, ...rest }, ref) => {
+export let EditInPlace = forwardRef(({ v2, ...rest }, ref) => {
   const props = {
     ...rest,
     ref,
@@ -32,14 +35,10 @@ export let InlineEdit = forwardRef(({ v2, ...rest }, ref) => {
   return <InlineEditV1 {...props} />;
 });
 
-InlineEdit.deprecated = {
-  details: `The InlineEdit component is being renamed to EditInPlace in the next major version of @carbon/ibm-products. You can prepare by updating your usage of InlineEdit to EditInPlace.`,
-  level: 'warn',
-};
+EditInPlace = pkg.checkComponentEnabled(EditInPlace, componentName);
 
-InlineEdit.displayName = componentName;
-InlineEdit = pkg.checkComponentEnabled(InlineEdit, componentName);
+EditInPlace.displayName = componentName;
 
-InlineEdit.propTypes = {
+EditInPlace.propTypes = {
   v2: PropTypes.bool,
 };

--- a/packages/cloud-cognitive/src/components/EditInPlace/EditInPlaceV1.stories.js
+++ b/packages/cloud-cognitive/src/components/EditInPlace/EditInPlaceV1.stories.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+import { DisplayBox } from '../../global/js/utils/DisplayBox';
+
+import { EditInPlace } from '.';
+
+import mdx from '../InlineEditV1//InlineEditV1.mdx';
+
+import styles from '../InlineEditV1/_storybook-styles.scss';
+
+const storyClass = 'inline-edit-stories';
+
+const validationOptions = {
+  'Default, no validation change': {},
+  'On change or save invalid if empty': { onChangeInvalidIfEmpty: true },
+  'On change or save includes ABC invalid': { onChangeInvalidWithABC: true },
+  'On save invalid if empty': { onSaveInvalidIfEmpty: true },
+  'On save includes ABC invalid': { onSaveInvalidWithABC: true },
+};
+
+const buttonTooltipAlignmentOptions = {
+  'Default / undefined': undefined,
+  'All start': 'start',
+  'All center': 'center',
+  'All end': 'end',
+  'Edit start, Cancel center, save end': {
+    edit: 'start',
+    cancel: 'center',
+    save: 'end',
+  },
+};
+
+const buttonTooltipPositionOptions = {
+  'Default / undefined': undefined,
+  'All top': 'top',
+  'All right': 'right',
+  'All bottom': 'bottom',
+  'All left': 'left',
+  'Edit and save right, cancel left': {
+    edit: 'right',
+    cancel: 'left',
+    save: 'right',
+  },
+};
+
+export default {
+  title: getStoryTitle(EditInPlace.displayName),
+  component: EditInPlace,
+  argTypes: {
+    buttonTooltipAlignment: {
+      control: {
+        type: 'select',
+        labels: Object.keys(buttonTooltipAlignmentOptions),
+      },
+      options: Object.values(buttonTooltipAlignmentOptions).map((_k, i) => i),
+      mapping: Object.values(buttonTooltipAlignmentOptions),
+    },
+    buttonTooltipPosition: {
+      control: {
+        type: 'select',
+        labels: Object.keys(buttonTooltipPositionOptions),
+      },
+      options: Object.values(buttonTooltipPositionOptions).map((_k, i) => i),
+      mapping: Object.values(buttonTooltipPositionOptions),
+    },
+    containerWidth: {
+      control: { type: 'range', min: 20, max: 800, step: 10 },
+      description:
+        'Controls containing element width. Used for demonstration purposes, not property of the component.',
+    },
+    EditInPlaceFullWidth: {
+      control: { type: 'boolean' },
+      description:
+        'Sets component width `100%`. Used for demonstration purposes, not property of the component.',
+    },
+    validation: {
+      control: {
+        type: 'select',
+        labels: Object.keys(validationOptions),
+      },
+      options: Object.values(validationOptions).map((_k, i) => i),
+      mapping: Object.values(validationOptions),
+      defaultValue: 0,
+    },
+  },
+  parameters: {
+    styles,
+    layout: 'padded',
+    docs: {
+      page: mdx,
+    },
+  },
+  decorators: [
+    (story) => (
+      <DisplayBox className={`${storyClass}__viewport`}>{story()}</DisplayBox>
+    ),
+  ],
+};
+
+const actionSave = action('save');
+const actionRejectSave = action('rejected save');
+const actionChange = action('change');
+const actionRejectChange = action('rejected change');
+const actionCancel = action('cancel');
+
+/**
+ * TODO: Declare template(s) for one or more scenarios.
+ */
+const Template = ({
+  containerWidth,
+  EditInPlaceFullWidth,
+  invalid,
+  invalidText,
+  editDescription,
+  cancelDescription,
+  saveDescription,
+  validation,
+  value: initialValue,
+  ...rest
+}) => {
+  const [value, setValue] = useState(initialValue);
+  const [liveInvalid, setLiveInvalid] = useState(invalid);
+  const [liveInvalidText, setLiveInvalidText] = useState(invalidText);
+
+  useEffect(() => {
+    setLiveInvalid(invalid);
+  }, [invalid]);
+
+  const handleValidation = (val, change, save) => {
+    let newInvalid = false;
+    let invalidText = '';
+    let updateValidation = false;
+
+    const zeroLength = val.length === 0;
+    const hasABC = /ABC/.test(val);
+
+    if (
+      (change && validation?.onChangeInvalidIfEmpty) ||
+      (save && validation?.onSaveInvalidIfEmpty)
+    ) {
+      newInvalid = zeroLength;
+      invalidText = newInvalid ? 'This field cannot be empty' : '';
+      updateValidation = true;
+    } else if (
+      (change && validation?.onChangeInvalidWithABC) ||
+      (save && validation?.onSaveInvalidWithABC)
+    ) {
+      newInvalid = hasABC;
+      invalidText = newInvalid ? 'Cannot contain ABC in the entry' : '';
+      updateValidation = true;
+    }
+
+    if (updateValidation) {
+      setLiveInvalid(newInvalid);
+      setLiveInvalidText(invalidText);
+    }
+    return updateValidation && newInvalid;
+  };
+
+  const onSave = (val) => {
+    const reject = handleValidation(val, false, true);
+
+    if (reject) {
+      actionRejectSave(val);
+    } else {
+      setValue(val);
+      actionSave(val);
+    }
+  };
+  const onChange = (val) => {
+    const reject = handleValidation(val, true, false);
+
+    if (reject) {
+      actionRejectChange(val);
+    } else {
+      actionChange(val);
+    }
+  };
+  const onCancel = actionCancel;
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  return (
+    <div
+      style={{ width: containerWidth }}
+      className={EditInPlaceFullWidth ? 'component-full-width' : ''}
+    >
+      <EditInPlace
+        {...rest}
+        {...{
+          editDescription,
+          invalid: liveInvalid,
+          invalidText: liveInvalidText,
+          onSave,
+          onChange,
+          onCancel,
+          cancelDescription,
+          saveDescription,
+          value,
+        }}
+      />
+    </div>
+  );
+};
+
+export const Version1 = prepareStory(Template, {
+  args: {
+    containerWidth: 300,
+    EditInPlaceFullWidth: true,
+    editDescription: 'Edit',
+    id: 'edit button',
+    labelText: 'Inline edit',
+    cancelDescription: 'Cancel',
+    saveDescription: 'Save',
+    value: 'hello, world',
+    placeholder: 'placeholder text',
+  },
+});

--- a/packages/cloud-cognitive/src/components/EditInPlace/EditInPlaceV2.stories.js
+++ b/packages/cloud-cognitive/src/components/EditInPlace/EditInPlaceV2.stories.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  getStoryTitle,
+  prepareStory,
+} from '../../global/js/utils/story-helper';
+import { action } from '@storybook/addon-actions';
+import { EditInPlace } from '.';
+import mdx from '../InlineEditV2/InlineEditV2.mdx';
+import styles from '../InlineEditV2/_storybook-styles.scss';
+
+export default {
+  title: getStoryTitle(EditInPlace.displayName),
+  component: EditInPlace,
+  parameters: {
+    styles,
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const actionSave = action('save');
+const actionChange = action('change');
+const actionCancel = action('cancel');
+
+const defaultProps = {
+  cancelLabel: 'Cancel',
+  editLabel: 'Edit',
+  id: 'story-id',
+  invalid: false,
+  invalidLabel: 'This field is required',
+  labelText: 'Label text',
+  onCancel: () => {},
+  onChange: () => {},
+  onSave: () => {},
+  // readOnly: false,
+  // readOnlyLabel: 'This value is read only',
+  saveLabel: 'Save',
+  v2: true,
+  value: 'default',
+};
+
+const Template = (args) => {
+  const [value, setValue] = useState(defaultProps.value);
+
+  const onChange = (val) => {
+    setValue(val);
+    actionChange(val);
+  };
+
+  const onSave = () => {
+    console.log('saved!', value);
+    actionSave(value);
+  };
+
+  const onCancel = (initialVal) => {
+    setValue(initialVal);
+    actionCancel(initialVal);
+  };
+
+  const props = {
+    ...args,
+    value,
+    onChange,
+    onSave,
+    onCancel,
+  };
+
+  return <EditInPlace {...props} className="inline-edit-v2-example" />;
+};
+
+export const Version2 = prepareStory(Template, {
+  args: {
+    ...defaultProps,
+  },
+});
+
+// export const ReadOnly = prepareStory(Template, {
+//   args: {
+//     ...defaultProps,
+//     readOnly: true,
+//   },
+// });

--- a/packages/cloud-cognitive/src/components/EditInPlace/index.js
+++ b/packages/cloud-cognitive/src/components/EditInPlace/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { EditInPlace } from './EditInPlace';

--- a/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/InlineEditV1.js
@@ -13,7 +13,6 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
-import pconsole from '../../global/js/utils/pconsole';
 import { pkg, carbon } from '../../settings';
 
 // Carbon and package components we use.
@@ -81,10 +80,6 @@ export let InlineEditV1 = React.forwardRef(
     const showValidation = invalid; // || warn;
     const validationText = invalidText; // || warnText;
     const validationIcon = showValidation ? <WarningFilled16 /> : null;
-
-    pconsole.warn(
-      `${componentName}: the v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.`
-    );
 
     // sanitize the tooltip values
     const alignIsObject = typeof buttonTooltipAlignment === 'object';
@@ -375,6 +370,12 @@ export let InlineEditV1 = React.forwardRef(
 // The display name of the component, used by React. Note that displayName
 // is used in preference to relying on function.name.
 InlineEditV1.displayName = componentName;
+
+InlineEditV1.deprecated = {
+  level: 'warn',
+  details: `The v1 version of this component is being deprecated. please switch to the v2 component as soon as possible.`,
+};
+pkg.logDeprecated(InlineEditV1, componentName);
 
 // The types and DocGen commentary for the component props,
 // in alphabetical order (for consistency).

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -38,6 +38,7 @@ export let InlineEditV2 = forwardRef(
       // readOnlyLabel,
       saveLabel,
       value,
+
       ...rest
     },
     ref

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -82,4 +82,5 @@ export { EditFullPage } from './EditFullPage';
 export { EditUpdateCards } from './EditUpdateCards';
 
 export { InlineEdit } from './InlineEdit';
+export { EditInPlace } from './EditInPlace';
 export { NonLinearReading } from './NonLinearReading';

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -24,6 +24,7 @@ const defaults = {
     CreateTearsheet: true,
     CreateTearsheetStep: true,
     CreateTearsheetDivider: true,
+    EditInPlace: true,
     EmptyState: true,
     ErrorEmptyState: true,
     ExportModal: true,

--- a/packages/cloud-cognitive/src/settings.js
+++ b/packages/cloud-cognitive/src/settings.js
@@ -4,6 +4,7 @@ import pkgSettings from './global/js/package-settings';
 import { settings as carbonSettings } from 'carbon-components';
 import React from 'react';
 import { themes } from '@carbon/themes';
+import pconsole from './global/js/utils/pconsole';
 
 export const carbon = {
   get prefix() {
@@ -17,12 +18,28 @@ export const carbon = {
   },
 };
 
+const componentDeprecatedWarning = (name, details) =>
+  `Carbon for IBM Products (WARNING): Component "${name}" is deprecated. ${details}`;
+
+pkgSettings.logDeprecated = (component, name) => {
+  if (component?.deprecated) {
+    const { level, details } = component.deprecated;
+    const logUsing = pconsole?.[level] ?? pconsole.error;
+
+    logUsing(
+      componentDeprecatedWarning(name || component.displayName, details)
+    );
+  }
+};
+
 // Check that a component is enabled. This function returns a stub which checks
 // the component status on first use and then renders as the component or as
 // a Canary placeholder initialized with the name of the replaced component.
 // Note that the returned stub carries any other properties which had already
 // been assigned (eg propTypes, displayName, etc).
 pkgSettings.checkComponentEnabled = (component, name) => {
+  pkgSettings.logDeprecated(component, name);
+
   if (component.render) {
     // The component is a forward-ref, so make a stub forward-ref.
     const forward = React.forwardRef((props, ref) =>

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -77,6 +77,7 @@ const s = [
           {
             n: 'Edit and update',
             s: [
+              'c/EditInPlace',
               {
                 n: 'Inline edit',
                 s: [


### PR DESCRIPTION
Contributes to #2866 

Allows V1 users to switch to V1

#### What did you change?

- Added Editable field and stories. 
- Changed some of the messaging around deprecation of 'InlineEditV1' to be consistent with other message. 
- Added deprecation message regarding switch to EditableField

#### How did you test and verify your work?

Viewed in Storybook.
Not yet tested.
