### PR TITLE
fix: allow nodes to be passed to additional card props v11

### DIFF
--- a/packages/cloud-cognitive/src/components/Card/Card.js
+++ b/packages/cloud-cognitive/src/components/Card/Card.js
@@ -275,8 +275,16 @@ Card.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   clickZone: PropTypes.oneOf(['one', 'two', 'three']),
-  description: PropTypes.string,
-  label: PropTypes.string,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   media: PropTypes.node,
   mediaPosition: PropTypes.oneOf(['top', 'left']),
   onClick: PropTypes.func,
@@ -303,7 +311,11 @@ Card.propTypes = {
   secondaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   secondaryButtonKind: PropTypes.oneOf(['secondary', 'ghost']),
   secondaryButtonText: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   titleSize: PropTypes.oneOf(['default', 'large']),
 };
 

--- a/packages/cloud-cognitive/src/components/Card/CardHeader.js
+++ b/packages/cloud-cognitive/src/components/Card/CardHeader.js
@@ -77,7 +77,11 @@ export let CardHeader = ({
 
 CardHeader.propTypes = {
   actions: PropTypes.oneOfType([PropTypes.array, PropTypes.node]),
-  description: PropTypes.string,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   hasActions: PropTypes.bool,
   label: PropTypes.string,
   noActionIcons: PropTypes.bool,
@@ -85,7 +89,11 @@ CardHeader.propTypes = {
   primaryButtonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   primaryButtonPlacement: PropTypes.oneOf(['top', 'bottom']),
   primaryButtonText: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   titleSize: PropTypes.oneOf(['default', 'large']),
 };
 

--- a/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.js
+++ b/packages/cloud-cognitive/src/components/ExpressiveCard/ExpressiveCard.js
@@ -56,11 +56,19 @@ ExpressiveCard.propTypes = {
   /**
    * Optional header description
    */
-  description: PropTypes.string,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   /**
    * Optional label for the top of the card
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   /**
    * Optional media content like an image to be placed in the card
    */
@@ -120,7 +128,11 @@ ExpressiveCard.propTypes = {
   /**
    * Title that's displayed at the top of the card
    */
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
 };
 
 ExpressiveCard.displayName = componentName;

--- a/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
+++ b/packages/cloud-cognitive/src/components/ProductiveCard/ProductiveCard.js
@@ -79,11 +79,19 @@ ProductiveCard.propTypes = {
   /**
    * Optional header description
    */
-  description: PropTypes.string,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   /**
    * Optional label for the top of the card
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   /**
    * Provides the callback for a clickable card
    */
@@ -126,7 +134,11 @@ ProductiveCard.propTypes = {
   /**
    * Title that's displayed at the top of the card
    */
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
   /**
    * Determines title size
    */


### PR DESCRIPTION
Contributes to #2728

to add more flexibility, this PR allows `Card` to accept node and object for additional props