### PR TITLE
fix: styling issues found in 2830

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6307,9 +6307,6 @@ button.c4p--add-select__global-filter-toggle--open {
 .c4p--action-bar .c4p--action-bar__displayed-items--right {
   justify-content: flex-end;
 }
-.c4p--action-bar .c4p--action-bar-overflow-items {
-  display: inline-block;
-}
 .c4p--action-bar .c4p--action-bar__hidden-sizing-items {
   position: absolute;
   top: -100vh;
@@ -7049,7 +7046,7 @@ button.c4p--add-select__global-filter-toggle--open {
 .c4p--page-header .c4p--page-header__navigation-row .cds--content-switcher-btn {
   background-color: var(--cds-background, #ffffff);
 }
-.c4p--page-header .cds--btn.cds--btn--icon-only.c4p--page-header__collapse-expand-toggle {
+.c4p--page-header .c4p--page-header__collapse-expand-toggle {
   position: absolute;
   z-index: 100;
   right: 0;
@@ -7058,7 +7055,7 @@ button.c4p--add-select__global-filter-toggle--open {
 .c4p--page-header .c4p--page-header__collapse-expand-toggle .cds--btn__icon {
   transition: all 400ms cubic-bezier(0.2, 0, 0.38, 0.9);
 }
-.c4p--page-header .c4p--page-header__collapse-expand-toggle--collapsed .cds--btn__icon {
+.c4p--page-header .c4p--page-header__collapse-expand-toggle--collapsed svg {
   transform: scaleY(-1);
 }
 

--- a/packages/cloud-cognitive/src/components/ActionBar/_action-bar.scss
+++ b/packages/cloud-cognitive/src/components/ActionBar/_action-bar.scss
@@ -28,10 +28,6 @@ $block-class-overflow-items: #{$_block-class}-overflow-items;
     justify-content: flex-end;
   }
 
-  .#{$block-class-overflow-items} {
-    display: inline-block;
-  }
-
   .#{$_block-class}__hidden-sizing-items {
     // This breadcrumb container is used to measure the width of all displayable breadcrumbs
     @include measuring-container;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -706,26 +706,29 @@ export let PageHeader = React.forwardRef(
             }
           </FlexGrid>
           {hasCollapseButton ? (
-            <Button
+            <div
               className={cx(`${blockClass}__collapse-expand-toggle`, {
                 [`${blockClass}__collapse-expand-toggle--collapsed`]:
                   fullyCollapsed,
               })}
-              hasIconOnly={true}
-              iconDescription={
-                /* istanbul ignore next */
-                fullyCollapsed
-                  ? expandHeaderIconDescription
-                  : collapseHeaderIconDescription
-              }
-              kind="ghost"
-              onClick={handleCollapseToggle}
-              renderIcon={(props) => <ChevronUp size={16} {...props} />}
-              size="md"
-              tooltipPosition="bottom"
-              tooltipAlignment="end"
-              type="button"
-            />
+            >
+              <Button
+                hasIconOnly={true}
+                iconDescription={
+                  /* istanbul ignore next */
+                  fullyCollapsed
+                    ? expandHeaderIconDescription
+                    : collapseHeaderIconDescription
+                }
+                kind="ghost"
+                onClick={handleCollapseToggle}
+                renderIcon={(props) => <ChevronUp size={16} {...props} />}
+                size="md"
+                tooltipPosition="bottom"
+                tooltipAlignment="end"
+                type="button"
+              />
+            </div>
           ) : null}
         </section>
       </>

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -265,7 +265,7 @@ const pageActions = {
   ],
   'User defined page actions': {
     content: (
-      <Button type="button" size="lg" style={{ maxWidth: '100%' }}>
+      <Button type="button" size="md" style={{ maxWidth: '100%' }}>
         <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
           Custom component
         </span>
@@ -278,7 +278,7 @@ const pageActions = {
     content: (
       <Button
         type="button"
-        size="lg"
+        size="md"
         style={{ maxWidth: '100%' }}
         title="Custom component with long content"
       >

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -616,7 +616,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     background-color: $background;
   }
 
-  .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$block-class}__collapse-expand-toggle {
+  .#{$block-class}__collapse-expand-toggle {
     position: absolute;
     z-index: $raised-z-index + 1;
     right: 0;
@@ -628,8 +628,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     transition: all $duration-slow-01 motion(standard, productive);
   }
 
-  .#{$block-class}__collapse-expand-toggle--collapsed
-    .#{$carbon-prefix}--btn__icon {
+  .#{$block-class}__collapse-expand-toggle--collapsed svg {
     // transform: rotate(90deg);
     transform: scaleY(-1);
   }


### PR DESCRIPTION
Fixes #2830

Previous changes addressed size of icon buttons.
This change addresses remaining issues identified in 2830

#### What did you change?

- Fix collapse button location/styling (Carbon breaking change of IconButton).
- Fix incorrect conversion from 'field' to 'lg' in action bar story.
- Remove styling no longer needed in action bar causing icon to not be centered.

#### How did you test and verify your work?

- Storybook
- Ran tests