### PR TITLE
chore(Datagrid): add deprecation warning for `useInlineEdit` hook, will be renamed in v2 to `useEditableCell`

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/index.js
@@ -23,5 +23,6 @@ export { default as useSelectAllWithToggle } from './useSelectAllToggle';
 export { default as useColumnCenterAlign } from './useColumnCenterAlign';
 export { default as useColumnOrder } from './useColumnOrder';
 export { default as useInlineEdit } from './useInlineEdit';
+export { default as useEditableCell } from './useEditableCell';
 export { default as useFiltering } from './useFiltering';
 export { getAutoSizedColumnWidth } from './utils/getAutoSizedColumnWidth';

--- a/packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import useInlineEdit from './useInlineEdit';
+
+const useEditableCell = (hooks) => {
+  useInlineEdit(hooks, 'usingEditableCell');
+};
+
+export default useEditableCell;

--- a/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
@@ -1,18 +1,27 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2022
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2022, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+
+import React, { useEffect } from 'react';
 import { pkg } from '../../settings';
 import cx from 'classnames';
 import { InlineEditCell } from './Datagrid/addons/InlineEdit/InlineEditCell';
+import { warn } from '../../global/js/utils/pconsole';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const useInlineEdit = (hooks) => {
+const useInlineEdit = (hooks, usingEditableCell) => {
+  useEffect(() => {
+    if (!usingEditableCell) {
+      warn(
+        `The 'useInlineEdit' hook is being renamed in Carbon for IBM Products v2 to 'useEditableCell'. You can use this newly renamed hook now or upgrade when moving to v2.`
+      );
+    }
+  }, [usingEditableCell]);
+
   const addInlineEdit = (props, { cell, instance }) => {
     const columnInlineEditConfig = cell.column.inlineEdit;
     const inlineEditType = cell.column?.inlineEdit?.type;

--- a/packages/cloud-cognitive/src/components/index.js
+++ b/packages/cloud-cognitive/src/components/index.js
@@ -73,6 +73,7 @@ export {
   useSelectAllWithToggle,
   useColumnOrder,
   useInlineEdit,
+  useEditableCell,
   useFiltering,
   getAutoSizedColumnWidth,
 } from './Datagrid';


### PR DESCRIPTION
Contributes to #2889 

Renamed `useInlineEdit` to `useEditableCell`. Both hooks are available to use but if `useInlineEdit` is used, there is a deprecation warning that will be logged.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/index.js
packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
packages/cloud-cognitive/src/components/index.js
```
#### How did you test and verify your work?
Storybook