### PR TITLE
feat(Datagrid): rename `useInlineEdit` to `useEditableCell` in v2

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -51,6 +51,7 @@ import {
   useColumnCenterAlign,
   useColumnOrder,
   useInlineEdit,
+  useEditableCell,
 } from '@carbon/ibm-products';
 ```
 
@@ -276,11 +277,13 @@ const App = () => {
 
 ## Inline editing
 
-The `Datagrid` supports inline editing when used with the `useInlineEdit` hook
-and columns are provided the required configuration. The four data types
-supported are strings, numbers, dates, and selection (dropdown).
+The `Datagrid` supports inline editing when used with the `useEditableCell` hook
+(previously named `useInlineEdit` in v1) and columns are provided the required
+configuration. The four data types supported are strings, numbers, dates, and
+selection (dropdown).
 
-Below are example column configuration for the support inline edit data types:
+Below are example column configurations for the supported inline edit data
+types:
 
 Default/string:
 
@@ -378,11 +381,11 @@ Selection:
 ```
 
 Using the column structure outlined above, along with the use of the
-`useInlineEdit` hook, the Datagrid will support inline editing. See example
-below:
+`useEditableCell` hook (previously named `useInlineEdit` in v1), the Datagrid
+will support inline editing. See example below:
 
 ```jsx
-import { Datagrid, useDatagrid, useInlineEdit } from '@carbon/ibm-products';
+import { Datagrid, useDatagrid, useEditableCell } from '@carbon/ibm-products';
 const App = () => {
   const [data, setData] = useState(makeData(10));
   const columns = React.useMemo(() => getInlineEditColumns(), []); // These columns follow the inline edit column configuration detailed above
@@ -392,7 +395,7 @@ const App = () => {
       data,
       onDataUpdate: setData,
     },
-    useInlineEdit
+    useEditableCell
   );
   return <Datagrid datagridState={datagridState} />;
 };
@@ -402,8 +405,8 @@ const App = () => {
   <Story
     id={getStoryId(
       Datagrid.displayName,
-      'inline-edit-usage-story',
-      '/Extensions/InlineEdit'
+      'editable-cell-usage-story',
+      '/Extensions/EditableCell'
     )}
   />
 </Canvas>

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -13,7 +13,12 @@ import {
   getStoryTitle,
   prepareStory,
 } from '../../../../global/js/utils/story-helper';
-import { Datagrid, useDatagrid, useInlineEdit } from '../../index';
+import {
+  Datagrid,
+  useDatagrid,
+  useInlineEdit,
+  useEditableCell,
+} from '../../index';
 import { pkg } from '../../../../settings';
 import styles from '../../_storybook-styles.scss';
 import mdx from '../../Datagrid.mdx';
@@ -25,7 +30,7 @@ const blockClass = `${pkg.prefix}--datagrid`;
 const storybookBlockClass = `storybook-${blockClass}__validation-code-snippet`;
 
 export default {
-  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/InlineEdit`,
+  title: `${getStoryTitle(Datagrid.displayName)}/Extensions/EditableCell`,
   component: Datagrid,
   parameters: {
     styles,
@@ -115,12 +120,60 @@ const InlineEditTemplateWrapper = ({ ...args }) => {
   return <InlineEditUsage defaultGridProps={{ ...args }} />;
 };
 
+const EditableCellUsage = ({ ...args }) => {
+  const [data, setData] = useState(makeData(10));
+  const columns = React.useMemo(() => getInlineEditColumns(), []);
+
+  const datagridState = useDatagrid(
+    {
+      columns,
+      data,
+      onDataUpdate: setData,
+      ...args.defaultGridProps,
+    },
+    useEditableCell
+  );
+
+  return (
+    <div>
+      <Datagrid datagridState={datagridState} />
+      <p>
+        The following inline edit columns incorporate validation:
+        <code className={storybookBlockClass}>{'first_name'}</code>
+        <code className={storybookBlockClass}>{'last_name'}</code>
+        <code className={storybookBlockClass}>{'age'}</code>
+        <code className={storybookBlockClass}>{'visits'}</code>
+      </p>
+    </div>
+  );
+};
+
+const EditableCellTemplateWrapper = ({ ...args }) => {
+  return <EditableCellUsage defaultGridProps={{ ...args }} />;
+};
+
 const inlineEditUsageControlProps = {
   gridTitle: sharedDatagridProps.gridTitle,
   gridDescription: sharedDatagridProps.gridDescription,
   useDenseHeader: sharedDatagridProps.useDenseHeader,
 };
-const basicUsageStoryName = 'With inline edit';
+
+export const EditableCellUsageStory = prepareStory(
+  EditableCellTemplateWrapper,
+  {
+    storyName: 'Using useEditableCell hook',
+    argTypes: {
+      gridTitle: ARG_TYPES.gridTitle,
+      gridDescription: ARG_TYPES.gridDescription,
+      useDenseHeader: ARG_TYPES.useDenseHeader,
+    },
+    args: {
+      ...inlineEditUsageControlProps,
+    },
+  }
+);
+
+const basicUsageStoryName = 'Using deprecated useInlineEdit hook';
 export const InlineEditUsageStory = prepareStory(InlineEditTemplateWrapper, {
   storyName: basicUsageStoryName,
   argTypes: {
@@ -130,5 +183,6 @@ export const InlineEditUsageStory = prepareStory(InlineEditTemplateWrapper, {
   },
   args: {
     ...inlineEditUsageControlProps,
+    featureFlags: ['Datagrid.useInlineEdit'],
   },
 });

--- a/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
@@ -83,6 +83,9 @@ const sharedDatagridProps = {
 const InlineEditUsage = ({ ...args }) => {
   const [data, setData] = useState(makeData(10));
   const columns = React.useMemo(() => getInlineEditColumns(), []);
+  pkg._silenceWarnings(false); // warnings are ordinarily silenced in storybook, add this to test.
+  pkg.feature['Datagrid.useInlineEdit'] = true;
+  pkg._silenceWarnings(true);
 
   const datagridState = useDatagrid(
     {

--- a/packages/cloud-cognitive/src/components/Datagrid/index.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/index.js
@@ -23,5 +23,6 @@ export { default as useSelectAllWithToggle } from './useSelectAllToggle';
 export { default as useColumnCenterAlign } from './useColumnCenterAlign';
 export { default as useColumnOrder } from './useColumnOrder';
 export { default as useInlineEdit } from './useInlineEdit';
+export { default as useEditableCell } from './useEditableCell';
 export { default as useFiltering } from './useFiltering';
 export { getAutoSizedColumnWidth } from './utils/getAutoSizedColumnWidth';

--- a/packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import useInlineEdit from './useInlineEdit';
+
+const useEditableCell = (hooks) => {
+  useInlineEdit(hooks, 'usingEditableCell');
+};
+
+export default useEditableCell;

--- a/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React, { useEffect } from 'react';
 import { pkg } from '../../settings';
 import cx from 'classnames';
@@ -11,11 +12,12 @@ import { InlineEditCell } from './Datagrid/addons/InlineEdit/InlineEditCell';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
-const useInlineEdit = (hooks) => {
-
+const useInlineEdit = (hooks, usingEditableCell) => {
   useEffect(() => {
-    pkg.checkReportFeatureEnabled('Datagrid.useInlineEdit');
-  }, []);
+    if (!usingEditableCell) {
+      pkg.checkReportFeatureEnabled('Datagrid.useInlineEdit');
+    }
+  }, [usingEditableCell]);
 
   const addInlineEdit = (props, { cell, instance }) => {
     const columnInlineEditConfig = cell.column.inlineEdit;
@@ -44,14 +46,20 @@ const useInlineEdit = (hooks) => {
         },
       ];
     }
+
     return [
       props,
       {
         className: cx(`${blockClass}__cell`, {
-          [`${blockClass}__cell-inline-edit`]: pkg.isFeatureEnabled('Datagrid.useInlineEdit') ? true : '',
+          [`${blockClass}__cell-inline-edit`]:
+            !!usingEditableCell ||
+            pkg.isFeatureEnabled('Datagrid.useInlineEdit')
+              ? true
+              : '',
         }),
         role: 'gridcell',
-        children: pkg.isFeatureEnabled('Datagrid.useInlineEdit') && (
+        children: (!!usingEditableCell ||
+          pkg.isFeatureEnabled('Datagrid.useInlineEdit')) && (
           <>
             {inlineEditType === 'text' &&
               renderInlineEditComponent(inlineEditType)}
@@ -83,7 +91,10 @@ const useInlineEdit = (hooks) => {
   hooks.getCellProps.push(addInlineEdit);
   hooks.useInstance.push((instance) => {
     Object.assign(instance, {
-      withInlineEdit: pkg.isFeatureEnabled('Datagrid.useInlineEdit') ? true : false,
+      withInlineEdit:
+        !!usingEditableCell || pkg.isFeatureEnabled('Datagrid.useInlineEdit')
+          ? true
+          : false,
     });
   });
 };

--- a/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
@@ -1,11 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2022
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2022, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { pkg } from '../../settings';
 import cx from 'classnames';
 import { InlineEditCell } from './Datagrid/addons/InlineEdit/InlineEditCell';
@@ -13,6 +12,11 @@ import { InlineEditCell } from './Datagrid/addons/InlineEdit/InlineEditCell';
 const blockClass = `${pkg.prefix}--datagrid`;
 
 const useInlineEdit = (hooks) => {
+
+  useEffect(() => {
+    pkg.checkReportFeatureEnabled('Datagrid.useInlineEdit');
+  }, []);
+
   const addInlineEdit = (props, { cell, instance }) => {
     const columnInlineEditConfig = cell.column.inlineEdit;
     const inlineEditType = cell.column?.inlineEdit?.type;
@@ -44,10 +48,10 @@ const useInlineEdit = (hooks) => {
       props,
       {
         className: cx(`${blockClass}__cell`, {
-          [`${blockClass}__cell-inline-edit`]: true,
+          [`${blockClass}__cell-inline-edit`]: pkg.isFeatureEnabled('Datagrid.useInlineEdit') ? true : '',
         }),
         role: 'gridcell',
-        children: (
+        children: pkg.isFeatureEnabled('Datagrid.useInlineEdit') && (
           <>
             {inlineEditType === 'text' &&
               renderInlineEditComponent(inlineEditType)}
@@ -79,7 +83,7 @@ const useInlineEdit = (hooks) => {
   hooks.getCellProps.push(addInlineEdit);
   hooks.useInstance.push((instance) => {
     Object.assign(instance, {
-      withInlineEdit: true,
+      withInlineEdit: pkg.isFeatureEnabled('Datagrid.useInlineEdit') ? true : false,
     });
   });
 };

--- a/packages/cloud-cognitive/src/global/js/package-settings.js
+++ b/packages/cloud-cognitive/src/global/js/package-settings.js
@@ -79,6 +79,7 @@ const defaults = {
     'a-new-feature': false,
     'default-portal-target-body': true,
     'Datagrid.useInfiniteScroll': false,
+    'Datagrid.useInlineEdit': false,
   },
 };
 

--- a/packages/core/story-structure.js
+++ b/packages/core/story-structure.js
@@ -52,7 +52,7 @@ const s = [
               'c/Datagrid/Extensions/NestedRows',
               'c/Datagrid/Extensions/ColumnAlignment',
               'c/Datagrid/Extensions/ClickableRow',
-              'c/Datagrid/Extensions/InlineEdit',
+              'c/Datagrid/Extensions/EditableCell',
               'c/Datagrid/Extensions/ColumnCustomization',
             ],
           },


### PR DESCRIPTION
Contributes to #2889 

This PR renames the `useInlineEdit` hook to `useEditableCell` in v2. It is still possible to use `useInlineEdit`, but enabling via a feature flag is now required. I renamed the `InlineEdit` storybook directory to `EditableCell` to reflect this change as well.

Feature flag usage:
```jsx
import React from 'react';
import { Datagrid, useDatagrid, useInlineEdit, pkg } from '@carbon/ibm-products';

const MyInlineEditDatagrid = () => {
  pkg.feature['Datagrid.useInlineEdit'] = true;
  const datagridState = useDatagrid(
    {
      columns,
      data,
      onDataUpdate: setData,
    },
    useInlineEdit
  );
  return <Datagrid datagridState={datagridState} />
}
```

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
packages/cloud-cognitive/src/components/Datagrid/Extensions/InlineEdit/InlineEdit.stories.js
packages/cloud-cognitive/src/components/Datagrid/index.js
packages/cloud-cognitive/src/components/Datagrid/useEditableCell.js
packages/cloud-cognitive/src/components/Datagrid/useInlineEdit.js
packages/cloud-cognitive/src/global/js/package-settings.js
packages/core/story-structure.js
```
#### How did you test and verify your work?
Storybook