### PR TITLE
fix(TagSet): remove tag radius in overflow

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6511,6 +6511,7 @@ button.c4p--add-select__global-filter-toggle--open {
   padding: 0;
   margin: 0;
   background-color: inherit;
+  border-radius: 0;
   color: inherit;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
+++ b/packages/cloud-cognitive/src/components/TagSet/_tag-set.scss
@@ -154,6 +154,7 @@ $block-class-modal: #{$_block-class}-modal;
     padding: 0;
     margin: 0;
     background-color: inherit;
+    border-radius: 0;
     color: inherit;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Contributes to #2557

Reopening on behalf of @qbi11y. v1 version of this PR is #2707.

#### What did you change?
Previously, descenders would get cut off around the edge of tags listed in the overflow due to `border-radius` coming from the Carbon tag. This removes the `border-radius` in the TagSet popover to prevent this from happening.

#### How did you test and verify your work?
Storybook