### PR TITLE
feat: Remove react resize detector

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -80,7 +80,6 @@
     "immutability-helper": "^3.1.1",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
-    "react-resize-detector": "^7.1.2",
     "react-table": "^7.8.0",
     "react-window": "^1.8.7"
   },

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
@@ -7,7 +7,7 @@
 
 // Import portions of React that are needed.
 import React, { useState, useRef, useEffect } from 'react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -88,7 +88,7 @@ export let AboutModal = React.forwardRef(
     }, [bodyRef]);
 
     // Detect resize of the ModalBody to recalculate whether scrolling is enabled
-    useResizeDetector({ onResize: handleResize, targetRef: bodyRef });
+    useResizeObserver(bodyRef, { callback: handleResize });
 
     return (
       <ComposedModal

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
@@ -12,7 +12,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Carbon and package components we use.
 import { Button } from '@carbon/react';
@@ -187,33 +187,20 @@ export let ActionBar = React.forwardRef(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [maxVisible, hiddenSizingItems]);
 
-    /* istanbul ignore next */ // not sure how to fake window resize
+    // /* istanbul ignore next */ // not sure how to fake window resize
     const handleResize = () => {
-      // width is the space available for all action bar items horizontally
-      // the action bar items are squares so the height should be one item wide
-      /* istanbul ignore next */ // not sure how to fake window resize
-      checkFullyVisibleItems();
-    };
-
-    /* istanbul ignore next */ // not sure how to fake window resize
-    const handleActionBarItemsResize = () => {
       // when the hidden sizing items change size
-      /* istanbul ignore next */ // not sure how to fake window resize
+      /* istanbul ignore next */
+      // not sure how to fake window resize
       checkFullyVisibleItems();
     };
 
-    useResizeDetector({
-      onResize: handleActionBarItemsResize,
-      targetRef: sizingRef,
-    });
-
-    const { ref: outerRef } = useResizeDetector({
-      onResize: handleResize,
-      targetRef: ref,
-    });
+    // // resize of the items
+    useResizeObserver(sizingRef, { callback: handleResize });
+    useResizeObserver(ref, { callback: handleResize });
 
     return (
-      <div {...rest} className={cx([blockClass, className])} ref={outerRef}>
+      <div {...rest} className={cx([blockClass, className])} ref={ref}>
         {hiddenSizingItems}
 
         <div

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
@@ -56,6 +56,9 @@ export let ActionBar = React.forwardRef(
     const sizingRef = useRef(null);
     const sizes = useRef({});
 
+    const backupRef = useRef();
+    const localRef = ref || backupRef;
+
     // create hidden sizing items
     useEffect(() => {
       // Hidden action bar and items used to calculate sizes
@@ -197,10 +200,10 @@ export let ActionBar = React.forwardRef(
 
     // // resize of the items
     useResizeObserver(sizingRef, { callback: handleResize });
-    useResizeObserver(ref, { callback: handleResize });
+    useResizeObserver(localRef, { callback: handleResize });
 
     return (
-      <div {...rest} className={cx([blockClass, className])} ref={ref}>
+      <div {...rest} className={cx([blockClass, className])} ref={localRef}>
         {hiddenSizingItems}
 
         <div

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -11,7 +11,7 @@ import React, { useState, useEffect, useRef } from 'react';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Carbon and package components we use.
 import {
@@ -268,27 +268,16 @@ export let BreadcrumbWithOverflow = ({
     checkFullyVisibleBreadcrumbItems();
   };
 
-  /* istanbul ignore next */ // not sure how to test resize
-  const handleBreadcrumbItemsResize = () => {
-    /* istanbul ignore next */ // not sure how to test resize
-    checkFullyVisibleBreadcrumbItems();
-  };
-
   let backItem = breadcrumbs[breadcrumbs.length - 1];
   /* istanbul ignore if */ // not sure how to test media queries
   if (backItem.isCurrentPage) {
     backItem = breadcrumbs[breadcrumbs.length - 2];
   }
 
-  useResizeDetector({
-    onResize: handleBreadcrumbItemsResize,
-    targetRef: sizingContainerRef,
-  });
-
-  useResizeDetector({
-    onResize: handleResize,
-    targetRef: breadcrumbItemWithOverflow,
-  });
+  // container resize
+  useResizeObserver(sizingContainerRef, { callback: handleResize });
+  // item resize
+  useResizeObserver(breadcrumbItemWithOverflow, { callback: handleResize });
 
   return (
     <div

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -9,7 +9,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { ButtonSet, Button, usePrefix } from '@carbon/react';
 import { ButtonMenu, ButtonMenuItem } from '../ButtonMenu';
 
@@ -131,21 +131,13 @@ export const ButtonSetWithOverflow = ({
     );
   });
 
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: sizingContainerRefSet,
+  useResizeObserver(sizingContainerRefSet, {
+    callback: checkFullyVisibleItems,
   });
-
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: sizingContainerRefCombo,
+  useResizeObserver(sizingContainerRefCombo, {
+    callback: checkFullyVisibleItems,
   });
-
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: spaceAvailableRef,
-    handleWidth: true,
-  });
+  useResizeObserver(spaceAvailableRef, { callback: checkFullyVisibleItems });
 
   return (
     <div

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Add, OverflowMenuVertical } from '@carbon/react/icons';
 import {
   TableToolbar,
   TableBatchActions,
   TableBatchAction,
 } from '@carbon/react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
 import { pkg, carbon } from '../../../settings';
 import cx from 'classnames';
@@ -155,7 +155,8 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
 };
 
 const DatagridToolbar = (datagridState) => {
-  const { width, ref } = useResizeDetector();
+  const ref = useRef(null);
+  const { width } = useResizeObserver(ref);
   const { DatagridActions, DatagridBatchActions, batchActions, rowSize } =
     datagridState;
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -11,7 +11,7 @@ import { TableBody } from '@carbon/react';
 import { pkg } from '../../../settings';
 import DatagridHead from './DatagridHead';
 import { px } from '@carbon/layout';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 
 const blockClass = `${pkg.prefix}--datagrid`;
 
@@ -52,7 +52,7 @@ const DatagridVirtualBody = (datagridState) => {
     gridRefElement.style.width = gridRefElement?.clientWidth;
   };
 
-  useResizeDetector({ onResize: handleVirtualGridResize, targetRef: gridRef });
+  useResizeObserver(gridRef, { callback: handleVirtualGridResize });
 
   const syncScroll = (e) => {
     const virtualBody = e.target;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -9,7 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { spacing10, baseFontSize } from '@carbon/layout';
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { FlexGrid, Column, Row, Button, Tag } from '@carbon/react';
 import { breakpoints } from '@carbon/layout';
@@ -162,10 +162,10 @@ export let PageHeader = React.forwardRef(
     };
 
     /* istanbul ignore next */
-    const handleResizeActionBarColumn = (width) => {
+    const handleResizeActionBarColumn = ({ width }) => {
       /* don't know how to test resize */
       /* istanbul ignore next */
-      setActionBarColumnWidth(width);
+      setActionBarColumnWidth({ width });
     };
 
     /* istanbul ignore next */
@@ -448,17 +448,11 @@ export let PageHeader = React.forwardRef(
       }
     }, [collapseHeader, metrics.headerOffset, metrics.headerTopValue]);
 
-    useResizeDetector({
-      onResize: handleResizeActionBarColumn,
-      targetRef: sizingContainerRef,
-      handleWidth: true,
+    useResizeObserver(sizingContainerRef, {
+      callback: handleResizeActionBarColumn,
     });
 
-    useResizeDetector({
-      onResize: handleResize,
-      targetRef: headerRef,
-      handleHeight: true,
-    });
+    useResizeObserver(headerRef, { callback: handleResize });
 
     // Determine what form of title to display in the breadcrumb
     let breadcrumbItemForTitle = utilGetBreadcrumbItemForTitle(

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -165,7 +165,7 @@ export let PageHeader = React.forwardRef(
     const handleResizeActionBarColumn = ({ width }) => {
       /* don't know how to test resize */
       /* istanbul ignore next */
-      setActionBarColumnWidth({ width });
+      setActionBarColumnWidth(width);
     };
 
     /* istanbul ignore next */

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -170,7 +170,6 @@ export let SidePanel = React.forwardRef(
 
     /* istanbul ignore next */
     const handleResize = ({ height }) => {
-      console.log(height);
       setPanelHeight(height);
       const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
       const actionsContainer = getActionsContainerElement();

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -12,7 +12,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { moderate02 } from '@carbon/motion';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -169,7 +169,8 @@ export let SidePanel = React.forwardRef(
     }, [labelText, title]);
 
     /* istanbul ignore next */
-    const handleResize = (width, height) => {
+    const handleResize = ({ height }) => {
+      console.log(height);
       setPanelHeight(height);
       const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
       const actionsContainer = getActionsContainerElement();
@@ -686,11 +687,7 @@ export let SidePanel = React.forwardRef(
 
     const contentRef = ref || sidePanelRef;
 
-    useResizeDetector({
-      handleHeight: true,
-      onResize: handleResize,
-      targetRef: contentRef,
-    });
+    useResizeObserver(contentRef, { callback: handleResize });
 
     return (
       <AnimatePresence>

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -14,7 +14,7 @@ import cx from 'classnames';
 import { TagSetOverflow } from './TagSetOverflow';
 import { TagSetModal } from './TagSetModal';
 import { Tag } from '@carbon/react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { prepareProps, isRequiredIf } from '../../global/js/utils/props-helper';
@@ -217,15 +217,9 @@ export let TagSet = React.forwardRef(
       setShowAllModalOpen(false);
     };
 
-    useResizeDetector({
-      onResize: handleSizerTagsResize,
-      targetRef: sizingContainerRef,
-    });
+    useResizeObserver(sizingContainerRef, { callback: handleSizerTagsResize });
 
-    useResizeDetector({
-      onResize: handleResize,
-      targetRef: tagSetRef,
-    });
+    useResizeObserver(tagSetRef, { callback: handleResize });
 
     return (
       <div

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -104,9 +104,7 @@ export const TearsheetShell = React.forwardRef(
     const localRef = useRef();
     const resizer = useRef(null);
     const modalRef = ref || localRef;
-    const { width } = useResizeObserver(resizer, (size) =>
-      console.log('size', size)
-    );
+    const { width } = useResizeObserver(resizer);
 
     const wide = size === 'wide';
 

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -8,7 +8,7 @@
 // Import portions of React that are needed.
 import React, { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -102,8 +102,11 @@ export const TearsheetShell = React.forwardRef(
     }, [portalTargetIn]);
 
     const localRef = useRef();
+    const resizer = useRef(null);
     const modalRef = ref || localRef;
-    const { width, ref: resizer } = useResizeDetector({ handleHeight: false });
+    const { width } = useResizeObserver(resizer, (size) =>
+      console.log('size', size)
+    );
 
     const wide = size === 'wide';
 

--- a/packages/cloud-cognitive/src/global/js/hooks/useResizeObserver.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useResizeObserver.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { useRef, useState, useLayoutEffect } from 'react';
+
+export const useResizeObserver = (
+  ref,
+  options = { callback: null, throttleInterval: 0 }
+) => {
+  const { callback, throttleInterval } = options;
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
+  const throttleTimeout = useRef(null);
+  const entriesToHandle = useRef(null);
+
+  useLayoutEffect(() => {
+    if (!ref?.current) {
+      return;
+    }
+
+    const doCallbacks = () => {
+      if (!ref?.current || !Array.isArray(entriesToHandle?.current)) {
+        return;
+      }
+
+      const entry = entriesToHandle.current[0];
+
+      setWidth(entry.contentRect.width);
+      setHeight(entry.contentRect.height);
+
+      throttleTimeout.current = null;
+
+      callback && callback(entry.contentRect);
+    };
+
+    let observer = new ResizeObserver((entries) => {
+      // always update entriesToHandle
+      entriesToHandle.current = entries;
+
+      if (throttleInterval) {
+        // if a throttleInterval check for running timeout
+        if (throttleTimeout.current === null) {
+          // no live timeout set entries to handle and move on
+
+          // set up throttle
+          throttleTimeout.current = setTimeout(() => {
+            // do callbacks
+            doCallbacks();
+            // reset throttle
+            throttleTimeout.current = null;
+          }, throttleInterval);
+        }
+      } else {
+        // no throttle do callbacks every time
+        doCallbacks();
+      }
+    });
+
+    // observe all refs passed
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+      observer = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, options]);
+
+  return { width, height };
+};

--- a/packages/cloud-cognitive/src/global/js/hooks/useWindowResize.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useWindowResize.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/global/js/hooks/useWindowResize.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useWindowResize.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 import { useRef, useLayoutEffect } from 'react';
 
 const windowExists = typeof window !== `undefined`;

--- a/packages/cloud-cognitive/src/global/js/hooks/useWindowScroll.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useWindowScroll.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2022, 2022
+ * Copyright IBM Corp. 2022, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/cloud-cognitive/src/global/js/hooks/useWindowScroll.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useWindowScroll.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright IBM Corp. 2022, 2022
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 import { useRef, useLayoutEffect } from 'react';
 import { scrollableAncestor } from '../utils/scrollableAncestor';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,7 +1871,6 @@ __metadata:
     npm-run-all: ^4.1.5
     react-dnd: ^15.1.2
     react-dnd-html5-backend: ^15.1.3
-    react-resize-detector: ^7.1.2
     react-table: ^7.8.0
     react-window: ^1.8.7
     rimraf: ^3.0.2
@@ -22499,18 +22498,6 @@ __metadata:
   version: 0.11.0
   resolution: "react-refresh@npm:0.11.0"
   checksum: 112178a05b1e0ffeaf5d9fb4e56b4410a34a73adeb04dbf13abdc50d9ac9df2ada83e81485156cca0b3fa296aa3612751b3d6cd13be4464642a43679b819cbc7
-  languageName: node
-  linkType: hard
-
-"react-resize-detector@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "react-resize-detector@npm:7.1.2"
-  dependencies:
-    lodash: ^4.17.21
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 55f4abad7f7523d16b081b5ab20f75c539a54a08253ce7e9df473d48386f42ceca6c31584ba9fa26e3528b498ef6685ec77fb9a22cffc97df05fb326d0bf1b26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to #2744 

V7 of ReactResizeObserver can result in the error shown in #2744 but the error appears to be a timing issue of some description.

The author fixed a similar looking issue in V8, but it persists in our storybook. In V9 there were more extensive changes that stopped our current usage working.

This PR removes ReactResizeObserver in favor of wrapping ResizeObserver (now standard) in a hook.

#### What did you change?

- Removed react-resize-detector
- Created useResizeObserver hook.
- Checked it functioned as a replacement for all useResizeDetector hook

#### How did you test and verify your work?

- Storybook changing the size of things and adding new elements
- Ran tests

NOTE: Storybook 6 reports the following error which would appear to be related this issue fixed only in Storybook 7. https://github.com/storybookjs/storybook/issues/18716

![image](https://user-images.githubusercontent.com/15086604/233694400-35f14f2e-93da-453a-960d-8e7ced8f12e5.png)

