### PR TITLE
feat(Datagrid): add keyboard support for clickable rows (v2)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/useOnRowClick.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useOnRowClick.js
@@ -23,10 +23,18 @@ const useOnRowClick = (hooks) => {
         }
       };
 
+      const onKeyDown = (event) => {
+        const { key } = event;
+        if (key === 'Enter') {
+          onClick();
+        }
+      };
+
       return [
         props,
-        { onClick },
+        { onClick, onKeyDown },
         {
+          tabIndex: 0,
           style: {
             cursor: 'pointer',
           },


### PR DESCRIPTION
Contributes to #2910 

Adds keyboard support to the `useOnRowClick` hook.

#### What did you change?
`useOnRowClick.js`
#### How did you test and verify your work?
Storybook