### PR TITLE
feat: update InlineEditV2

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2340,6 +2340,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--inline-edit-v2 {
+  --c4p--inline-edit-v2--size: var(--cds-spacing-07, 2rem);
   display: flex;
   align-items: center;
   background: transparent;
@@ -2347,6 +2348,15 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 .c4p--inline-edit-v2-readonly {
   cursor: not-allowed;
+}
+.c4p--inline-edit-v2--sm {
+  --c4p--inline-edit-v2--size: var(--cds-spacing-07, 2rem);
+}
+.c4p--inline-edit-v2--md {
+  --c4p--inline-edit-v2--size: var(--cds-spacing-08, 2.5rem);
+}
+.c4p--inline-edit-v2--lg {
+  --c4p--inline-edit-v2--size: var(--cds-spacing-09, 3rem);
 }
 .c4p--inline-edit-v2:hover {
   background: var(--cds-field-01, #f4f4f4);
@@ -2398,16 +2408,16 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--inline-edit-v2__toolbar {
-  --toolbar-width: var(--cds-spacing-07, 2rem);
-  --toolbar-width-focussed: var(--cds-spacing-10, 4rem);
+  --toolbar-width: var(--c4p--inline-edit-v2--size);
+  --toolbar-width-focussed: calc(2 * var(--c4p--inline-edit-v2--size));
   display: inline-flex;
   overflow: hidden;
   width: var(--toolbar-width);
 }
 
 .c4p--inline-edit-v2--invalid .c4p--inline-edit-v2__toolbar {
-  --toolbar-width: var(--cds-spacing-10, 4rem);
-  --toolbar-width-focussed: var(--cds-spacing-12, 6rem);
+  --toolbar-width: calc(2 * var(--c4p--inline-edit-v2--size));
+  --toolbar-width-focussed: calc(3 * var(--c4p--inline-edit-v2--size));
 }
 
 @keyframes slide-in {

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2351,11 +2351,15 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--inline-edit-v2:hover {
   background: var(--cds-field-01, #f4f4f4);
 }
-.c4p--inline-edit-v2:hover .c4p--inline-edit-v2__btn-edit {
+.c4p--inline-edit-v2:hover .c4p--inline-edit-v2__btn-edit,
+.c4p--inline-edit-v2 .c4p--inline-edit-v2__btn-edit.c4p--inline-edit-v2__btn-edit--always-visible {
   visibility: visible;
 }
 .c4p--inline-edit-v2__btn-edit {
   visibility: hidden;
+}
+.c4p--inline-edit-v2--invalid {
+  outline: 2px solid var(--cds-support-01, #da1e28);
 }
 .c4p--inline-edit-v2--focused {
   background: var(--cds-field-01, #f4f4f4);
@@ -2368,6 +2372,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   display: none;
 }
 .c4p--inline-edit-v2__warning-icon {
+  width: var(--cds-spacing-05, 1rem);
   margin: var(--cds-spacing-03, 0.5rem);
   color: var(--cds-support-01, #da1e28);
 }
@@ -2387,11 +2392,6 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
   outline: none;
 }
 
-.c4p--inline-edit-v2-readonly .c4p--inline-edit-v2__text-input.bx--text-input,
-.c4p--inline-edit-v2-readonly .bx--btn.bx--btn--icon-only.bx--tooltip__trigger {
-  cursor: not-allowed;
-}
-
 .c4p--inline-edit-v2__text-input.bx--text-input:focus,
 .c4p--inline-edit-v2__text-input.bx--text-input:active {
   outline: none;
@@ -2406,7 +2406,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--inline-edit-v2--invalid .c4p--inline-edit-v2__toolbar {
-  --toolbar-width: var(--cds-spacing-07, 2rem);
+  --toolbar-width: var(--cds-spacing-10, 4rem);
   --toolbar-width-focussed: var(--cds-spacing-12, 6rem);
 }
 

--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -2378,12 +2378,19 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--inline-edit-v2__text-input {
   flex: 1;
 }
+.c4p--inline-edit-v2--inherit-type .c4p--inline-edit-v2__text-input {
+  /* match font of container */
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
 .c4p--inline-edit-v2__text-input-label {
   display: none;
 }
 .c4p--inline-edit-v2__warning-icon {
   width: var(--cds-spacing-05, 1rem);
-  margin: var(--cds-spacing-03, 0.5rem);
+  margin: auto var(--cds-spacing-03, 0.5rem) auto auto;
   color: var(--cds-support-01, #da1e28);
 }
 .c4p--inline-edit-v2__warning-text {
@@ -2416,8 +2423,10 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--inline-edit-v2--invalid .c4p--inline-edit-v2__toolbar {
-  --toolbar-width: calc(2 * var(--c4p--inline-edit-v2--size));
-  --toolbar-width-focussed: calc(3 * var(--c4p--inline-edit-v2--size));
+  --toolbar-width: calc(var(--c4p--inline-edit-v2--size) + var(--cds-spacing-07, 2rem));
+  --toolbar-width-focussed: calc(
+    2 * var(--c4p--inline-edit-v2--size) + var(--cds-spacing-07, 2rem)
+  );
 }
 
 @keyframes slide-in {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -262,7 +262,7 @@ InlineEditV2.propTypes = {
   /**
    * Provide the text that will be read by a screen reader when visiting this control
    */
-  labelText: PropTypes.string,
+  labelText: PropTypes.string.isRequired,
   /**
    * handler that is called when the cancel button is pressed or when the user removes focus from the input and there is no new value
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -26,10 +26,12 @@ export let InlineEditV2 = forwardRef(
   (
     {
       cancelLabel,
+      editAlwaysVisible,
       editLabel,
       id,
       invalid,
-      invalidLabel,
+      invalidLabel: deprecated_invalidLabel,
+      invalidText,
       labelText,
       onCancel,
       onChange,
@@ -139,7 +141,7 @@ export let InlineEditV2 = forwardRef(
           className={cx(blockClass, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
-            // [`${blockClass}-readonly`]: readOnly,
+            // [`${blockClass}--readonly`]: readOnly,
           })}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -162,11 +164,11 @@ export let InlineEditV2 = forwardRef(
             onKeyDown={onKeyHandler}
           />
           <div className={`${blockClass}__toolbar`}>
+            {invalid && (
+              <WarningFilled16 className={`${blockClass}__warning-icon`} />
+            )}
             {focused ? (
               <>
-                {invalid && (
-                  <WarningFilled16 className={`${blockClass}__warning-icon`} />
-                )}
                 <Button
                   hasIconOnly
                   renderIcon={Close24}
@@ -194,7 +196,10 @@ export let InlineEditV2 = forwardRef(
               </>
             ) : (
               <Button
-                className={`${blockClass}__btn ${blockClass}__btn-edit`}
+                className={cx(`${blockClass}__btn`, `${blockClass}__btn-edit`, {
+                  [`${blockClass}__btn-edit--always-visible`]:
+                    editAlwaysVisible,
+                })}
                 hasIconOnly
                 // renderIcon={readOnly ? EditOff24 : Edit24}
                 renderIcon={Edit24}
@@ -209,8 +214,10 @@ export let InlineEditV2 = forwardRef(
             )}
           </div>
         </div>
-        {focused && invalid && (
-          <p className={`${blockClass}__warning-text`}>{invalidLabel}</p>
+        {invalid && (
+          <p className={`${blockClass}__warning-text`}>
+            {invalidText ?? deprecated_invalidLabel}
+          </p>
         )}
       </div>
     );
@@ -219,11 +226,23 @@ export let InlineEditV2 = forwardRef(
 
 InlineEditV2.displayName = componentName;
 
+export const deprecatedProps = {
+  /**
+   * **Deprecated**
+   * invalidLabel was misnamed, using invalidText to match Carbon
+   */
+  invalidText: PropTypes.string,
+};
+
 InlineEditV2.propTypes = {
   /**
    * label for cancel button
    */
   cancelLabel: PropTypes.string.isRequired,
+  /**
+   * By default the edit icon is shown on hover only.
+   */
+  editAlwaysVisible: PropTypes.bool,
   /**
    * label for edit button
    */
@@ -239,11 +258,11 @@ InlineEditV2.propTypes = {
   /**
    * text that is displayed if the input is invalid
    */
-  invalidLabel: PropTypes.string,
+  invalidText: PropTypes.string,
   /**
    * Provide the text that will be read by a screen reader when visiting this control
    */
-  labelText: PropTypes.string.isRequired,
+  labelText: PropTypes.string,
   /**
    * handler that is called when the cancel button is pressed or when the user removes focus from the input and there is no new value
    */
@@ -272,6 +291,8 @@ InlineEditV2.propTypes = {
    * current value of the input
    */
   value: PropTypes.string.isRequired,
+
+  ...deprecatedProps,
 };
 
 InlineEditV2.defaultProps = {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -33,6 +33,7 @@ export let InlineEditV2 = forwardRef(
       editAlwaysVisible,
       editLabel,
       id,
+      inheritTypography,
       invalid,
       invalidLabel: deprecated_invalidLabel,
       invalidText,
@@ -146,6 +147,7 @@ export let InlineEditV2 = forwardRef(
           className={cx(blockClass, `${blockClass}--${size}`, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
+            [`${blockClass}--inherit-type`]: inheritTypography,
             // [`${blockClass}--readonly`]: readOnly,
           })}
           onFocus={onFocusHandler}
@@ -256,6 +258,14 @@ InlineEditV2.propTypes = {
    * Specify a custom id for the input
    */
   id: PropTypes.string.isRequired,
+  /**
+   * inheritTypography - causes the text entry field to inherit typography settings
+   * assigned to the container. This is useful when editing titles for instance.
+   *
+   * NOTE: The size property limits the vertical size of the input element.
+   * Inherited font's should be selected to fit within the size selected.
+   */
+  inheritTypography: PropTypes.bool,
   /**
    * determines if the input is invalid
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -22,6 +22,10 @@ import { getDevtoolsProps } from '../../global/js/utils/devtools';
 const componentName = 'InlineEditV2';
 const blockClass = `${pkg.prefix}--inline-edit-v2`;
 
+const defaults = {
+  size: 'sm',
+};
+
 export let InlineEditV2 = forwardRef(
   (
     {
@@ -38,6 +42,7 @@ export let InlineEditV2 = forwardRef(
       onSave,
       // readOnly,
       // readOnlyLabel,
+      size = defaults.size,
       saveLabel,
       value,
       ...rest
@@ -138,7 +143,7 @@ export let InlineEditV2 = forwardRef(
     return (
       <div {...rest} ref={ref} {...getDevtoolsProps(componentName)}>
         <div
-          className={cx(blockClass, {
+          className={cx(blockClass, `${blockClass}--${size}`, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
             // [`${blockClass}--readonly`]: readOnly,
@@ -154,7 +159,7 @@ export let InlineEditV2 = forwardRef(
             className={cx(
               `${blockClass}__text-input`,
               `${carbon.prefix}--text-input`,
-              `${carbon.prefix}--text-input--sm`
+              `${carbon.prefix}--text-input--${size}`
             )}
             type="text"
             value={value}
@@ -172,7 +177,7 @@ export let InlineEditV2 = forwardRef(
                 <Button
                   hasIconOnly
                   renderIcon={Close24}
-                  size="sm"
+                  size={size}
                   iconDescription={cancelLabel}
                   onClick={onCancelHandler}
                   kind="ghost"
@@ -184,7 +189,7 @@ export let InlineEditV2 = forwardRef(
                 <Button
                   hasIconOnly
                   renderIcon={Checkmark24}
-                  size="sm"
+                  size={size}
                   iconDescription={saveLabel}
                   onClick={onSaveHandler}
                   kind="ghost"
@@ -203,7 +208,7 @@ export let InlineEditV2 = forwardRef(
                 hasIconOnly
                 // renderIcon={readOnly ? EditOff24 : Edit24}
                 renderIcon={Edit24}
-                size="sm"
+                size={size}
                 // iconDescription={readOnly ? readOnlyLabel : editLabel}
                 iconDescription={editLabel}
                 onClick={onFocusHandler}
@@ -287,6 +292,10 @@ InlineEditV2.propTypes = {
    * label for save button
    */
   saveLabel: PropTypes.string.isRequired,
+  /**
+   * vertical size of control
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /**
    * current value of the input
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
@@ -36,7 +36,7 @@ const defaultProps = {
   editLabel: 'Edit',
   id: 'story-id',
   invalid: false,
-  invalidLabel: 'This field is required',
+  invalidText: 'This field is required',
   labelText: 'Label text',
   onCancel: () => {},
   onChange: () => {},

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -64,13 +64,21 @@
       flex: 1;
     }
 
+    &--inherit-type .#{$block-class}__text-input {
+      /* match font of container */
+      font-size: inherit;
+      font-weight: inherit;
+      letter-spacing: inherit;
+      line-height: inherit;
+    }
+
     &__text-input-label {
       display: none;
     }
 
     &__warning-icon {
       width: $spacing-05;
-      margin: $spacing-03;
+      margin: auto $spacing-03 auto auto;
       color: $support-01;
     }
 
@@ -112,8 +120,11 @@
   }
 
   .#{$block-class}--invalid .#{$block-class}__toolbar {
-    --toolbar-width: calc(2 * var(--#{$block-class}--size));
-    --toolbar-width-focussed: calc(3 * var(--#{$block-class}--size));
+    // width of invalid icon is always $spacing-07 ($spacing-05 + 2 * $spacing-03 margin)
+    --toolbar-width: calc(var(--#{$block-class}--size) + #{$spacing-07});
+    --toolbar-width-focussed: calc(
+      2 * var(--#{$block-class}--size) + #{$spacing-07}
+    );
   }
 
   @keyframes slide-in {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -28,12 +28,17 @@
       background: $field-01;
     }
 
-    &:hover .#{$block-class}__btn-edit {
+    &:hover .#{$block-class}__btn-edit,
+    .#{$block-class}__btn-edit.#{$block-class}__btn-edit--always-visible {
       visibility: visible;
     }
 
     &__btn-edit {
       visibility: hidden;
+    }
+
+    &--invalid {
+      outline: 2px solid $support-01;
     }
 
     &--focused {
@@ -50,6 +55,7 @@
     }
 
     &__warning-icon {
+      width: $spacing-05;
       margin: $spacing-03;
       color: $support-01;
     }
@@ -70,11 +76,11 @@
     outline: none;
   }
 
-  .#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-input},
-  .#{$block-class}-readonly
-    .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
-    cursor: not-allowed;
-  }
+  // .#{$block-class}--readonly .#{$block-class}__text-input.#{$carbon-input},
+  // .#{$block-class}--readonly
+  //   .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
+  //   cursor: not-allowed;
+  // }
 
   .#{$block-class}__text-input.#{$carbon-input}:focus,
   .#{$block-class}__text-input.#{$carbon-input}:active {
@@ -92,7 +98,7 @@
   }
 
   .#{$block-class}--invalid .#{$block-class}__toolbar {
-    --toolbar-width: #{$spacing-07};
+    --toolbar-width: #{$spacing-10};
     --toolbar-width-focussed: #{$spacing-12};
   }
 

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -15,6 +15,8 @@
   $carbon-input: #{$carbon-prefix}--text-input;
 
   .#{$block-class} {
+    --#{$block-class}--size: #{$spacing-07};
+
     display: flex;
     align-items: center;
     background: transparent;
@@ -22,6 +24,18 @@
 
     &-readonly {
       cursor: not-allowed;
+    }
+
+    &--sm {
+      --#{$block-class}--size: #{$spacing-07};
+    }
+
+    &--md {
+      --#{$block-class}--size: #{$spacing-08};
+    }
+
+    &--lg {
+      --#{$block-class}--size: #{$spacing-09};
     }
 
     &:hover {
@@ -88,8 +102,8 @@
   }
 
   .#{$block-class}__toolbar {
-    --toolbar-width: #{$spacing-07};
-    --toolbar-width-focussed: #{$spacing-10};
+    --toolbar-width: var(--#{$block-class}--size);
+    --toolbar-width-focussed: calc(2 * var(--#{$block-class}--size));
 
     // animation div
     display: inline-flex;
@@ -98,8 +112,8 @@
   }
 
   .#{$block-class}--invalid .#{$block-class}__toolbar {
-    --toolbar-width: #{$spacing-10};
-    --toolbar-width-focussed: #{$spacing-12};
+    --toolbar-width: calc(2 * var(--#{$block-class}--size));
+    --toolbar-width-focussed: calc(3 * var(--#{$block-class}--size));
   }
 
   @keyframes slide-in {


### PR DESCRIPTION
Contributes to #2871

There are a number of differences between V1 and V2 Inline edit outlined in the issue.  This addresses some of them.

#### What did you change?

- Invalid state shows even without focus
- rename invalidLabel to invalidText inline with Carbon TextInput
- added option to make edit button always visible.
- update snapshots
- added size to v2
- added option to allow InlineEditV2 to inherit type (allows use in PageHeader title).

#### How did you test and verify your work?

Storybook.