### PR TITLE
feat: update InlineEditV2

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3349,7 +3349,6 @@ c4p--card__icon:active {
 
 .c4p--inline-edit {
   --c4p--inline-edit--size: 2.5rem;
-  --c4p--inline-edit--icon-size: 1rem;
   --c4p--inline-edit--background-color: var(--cds-layer-01, #f4f4f4);
   --c4p--inline-edit--toolbar-width: calc(2 * var(--c4p--inline-edit--size));
   position: relative;
@@ -3371,11 +3370,13 @@ c4p--card__icon:active {
 }
 .c4p--inline-edit.c4p--inline-edit--sm {
   --c4p--inline-edit--size: 2rem;
-  --c4p--inline-edit--icon-size: 1rem;
+}
+.c4p--inline-edit.c4p--inline-edit--md {
+  --c4p--inline-edit--size: 2.5rem;
 }
 .c4p--inline-edit.c4p--inline-edit--lg {
+  /* April 2023 max text input size */
   --c4p--inline-edit--size: 3rem;
-  --c4p--inline-edit--icon-size: 1rem;
 }
 .c4p--inline-edit.c4p--inline-edit--invalid {
   /* stylelint-disable-next-line carbon/theme-token-use */

--- a/packages/cloud-cognitive/src/components/InlineEditV1/_inline-edit-v1.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV1/_inline-edit-v1.scss
@@ -37,7 +37,6 @@ $block-class: #{c4p-settings.$pkg-prefix}--inline-edit;
 
 @include block-wrap($block-class) {
   --#{$block-class}--size: #{$spacing-08};
-  --#{$block-class}--icon-size: #{$spacing-05};
   --#{$block-class}--background-color: #{$layer-01};
   --#{$block-class}--toolbar-width: calc(2 * var(--#{$block-class}--size));
 
@@ -67,12 +66,15 @@ $block-class: #{c4p-settings.$pkg-prefix}--inline-edit;
 
   &.#{$block-class}--sm {
     --#{$block-class}--size: #{$spacing-07};
-    --#{$block-class}--icon-size: #{$spacing-05};
+  }
+
+  &.#{$block-class}--md {
+    --#{$block-class}--size: #{$spacing-08};
   }
 
   &.#{$block-class}--lg {
+    /* April 2023 max text input size */
     --#{$block-class}--size: #{$spacing-09};
-    --#{$block-class}--icon-size: #{$spacing-05};
   }
 
   &.#{$block-class}--invalid {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -33,6 +33,7 @@ export let InlineEditV2 = forwardRef(
       editAlwaysVisible,
       editLabel,
       id,
+      inheritTypography,
       invalid,
       invalidLabel: deprecated_invalidLabel,
       invalidText,
@@ -146,6 +147,7 @@ export let InlineEditV2 = forwardRef(
           className={cx(blockClass, `${blockClass}--${size}`, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
+            [`${blockClass}--inherit-type`]: inheritTypography,
             // [`${blockClass}--readonly`]: readOnly,
           })}
           onFocus={onFocusHandler}
@@ -260,6 +262,14 @@ InlineEditV2.propTypes = {
    * Specify a custom id for the input
    */
   id: PropTypes.string.isRequired,
+  /**
+   * inheritTypography - causes the text entry field to inherit typography settings
+   * assigned to the container. This is useful when editing titles for instance.
+   *
+   * NOTE: The size property limits the vertical size of the input element.
+   * Inherited font's should be selected to fit within the size selected.
+   */
+  inheritTypography: PropTypes.bool,
   /**
    * determines if the input is invalid
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -22,6 +22,10 @@ import { getDevtoolsProps } from '../../global/js/utils/devtools';
 const componentName = 'InlineEditV2';
 const blockClass = `${pkg.prefix}--inline-edit-v2`;
 
+const defaults = {
+  size: 'sm',
+};
+
 export let InlineEditV2 = forwardRef(
   (
     {
@@ -39,6 +43,7 @@ export let InlineEditV2 = forwardRef(
       // readOnly,
       // readOnlyLabel,
       saveLabel,
+      size = defaults.size,
       value,
       ...rest
     },
@@ -138,7 +143,7 @@ export let InlineEditV2 = forwardRef(
     return (
       <div {...rest} ref={ref} {...getDevtoolsProps(componentName)}>
         <div
-          className={cx(blockClass, {
+          className={cx(blockClass, `${blockClass}--${size}`, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
             // [`${blockClass}--readonly`]: readOnly,
@@ -154,7 +159,7 @@ export let InlineEditV2 = forwardRef(
             className={cx(
               `${blockClass}__text-input`,
               `${carbon.prefix}--text-input`,
-              `${carbon.prefix}--text-input--sm`
+              `${carbon.prefix}--text-input--${size}`
             )}
             type="text"
             value={value}
@@ -173,7 +178,7 @@ export let InlineEditV2 = forwardRef(
             {focused ? (
               <>
                 <IconButton
-                  size="sm"
+                  size={size}
                   label={cancelLabel}
                   onClick={onCancelHandler}
                   kind="ghost"
@@ -185,7 +190,7 @@ export let InlineEditV2 = forwardRef(
                 </IconButton>
 
                 <IconButton
-                  size="sm"
+                  size={size}
                   label={saveLabel}
                   onClick={onSaveHandler}
                   kind="ghost"
@@ -203,7 +208,7 @@ export let InlineEditV2 = forwardRef(
                   [`${blockClass}__btn-edit--always-visible`]:
                     editAlwaysVisible,
                 })}
-                size="sm"
+                size={size}
                 label={editLabel}
                 onClick={onFocusHandler}
                 kind="ghost"
@@ -291,6 +296,10 @@ InlineEditV2.propTypes = {
    * label for save button
    */
   saveLabel: PropTypes.string.isRequired,
+  /**
+   * vertical size of control
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /**
    * current value of the input
    */

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -26,10 +26,12 @@ export let InlineEditV2 = forwardRef(
   (
     {
       cancelLabel,
+      editAlwaysVisible,
       editLabel,
       id,
       invalid,
-      invalidLabel,
+      invalidLabel: deprecated_invalidLabel,
+      invalidText,
       labelText,
       onCancel,
       onChange,
@@ -139,7 +141,7 @@ export let InlineEditV2 = forwardRef(
           className={cx(blockClass, {
             [`${blockClass}--focused`]: focused,
             [`${blockClass}--invalid`]: invalid,
-            // [`${blockClass}-readonly`]: readOnly,
+            // [`${blockClass}--readonly`]: readOnly,
           })}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -162,14 +164,14 @@ export let InlineEditV2 = forwardRef(
             onKeyDown={onKeyHandler}
           />
           <div className={`${blockClass}__toolbar`}>
+            {invalid && (
+              <WarningFilled
+                size={16}
+                className={`${blockClass}__warning-icon`}
+              />
+            )}
             {focused ? (
               <>
-                {invalid && (
-                  <WarningFilled
-                    size={16}
-                    className={`${blockClass}__warning-icon`}
-                  />
-                )}
                 <IconButton
                   size="sm"
                   label={cancelLabel}
@@ -197,7 +199,10 @@ export let InlineEditV2 = forwardRef(
               </>
             ) : (
               <IconButton
-                className={`${blockClass}__btn ${blockClass}__btn-edit`}
+                className={cx(`${blockClass}__btn`, `${blockClass}__btn-edit`, {
+                  [`${blockClass}__btn-edit--always-visible`]:
+                    editAlwaysVisible,
+                })}
                 size="sm"
                 label={editLabel}
                 onClick={onFocusHandler}
@@ -210,8 +215,10 @@ export let InlineEditV2 = forwardRef(
             )}
           </div>
         </div>
-        {focused && invalid && (
-          <p className={`${blockClass}__warning-text`}>{invalidLabel}</p>
+        {invalid && (
+          <p className={`${blockClass}__warning-text`}>
+            {invalidText ?? deprecated_invalidLabel}
+          </p>
         )}
       </div>
     );
@@ -222,11 +229,24 @@ InlineEditV2 = pkg.checkComponentEnabled(InlineEditV2, componentName);
 
 InlineEditV2.displayName = componentName;
 
+export const deprecatedProps = {
+  /**
+   * **Deprecated**
+   * invalidLabel was misnamed, using invalidText to match Carbon
+   */
+  invalidText: PropTypes.string,
+};
+
 InlineEditV2.propTypes = {
   /**
    * label for cancel button
    */
   cancelLabel: PropTypes.string.isRequired,
+  /**
+   * By default the edit icon is shown on hover only.
+   */
+  editAlwaysVisible: PropTypes.bool,
+  /**
   /**
    * label for edit button
    */
@@ -242,7 +262,7 @@ InlineEditV2.propTypes = {
   /**
    * text that is displayed if the input is invalid
    */
-  invalidLabel: PropTypes.string,
+  invalidText: PropTypes.string,
   /**
    * Provide the text that will be read by a screen reader when visiting this control
    */
@@ -275,6 +295,8 @@ InlineEditV2.propTypes = {
    * current value of the input
    */
   value: PropTypes.string.isRequired,
+
+  ...deprecatedProps,
 };
 
 InlineEditV2.defaultProps = {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.stories.js
@@ -36,7 +36,7 @@ const defaultProps = {
   editLabel: 'Edit',
   id: 'story-id',
   invalid: false,
-  invalidLabel: 'This field is required',
+  invalidText: 'This field is required',
   labelText: 'Label text',
   onCancel: () => {},
   onChange: () => {},

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -16,10 +16,25 @@ $block-class: #{$pkg-prefix}--inline-edit-v2;
 $carbon-input: #{$carbon-prefix}--text-input;
 
 .#{$block-class} {
+  --#{$block-class}--size: #{$spacing-07};
+
   display: flex;
   align-items: center;
   background: transparent;
   cursor: pointer;
+}
+
+.#{$block-class}--sm {
+  --#{$block-class}--size: #{$spacing-07};
+}
+
+.#{$block-class}--md {
+  --#{$block-class}--size: #{$spacing-08};
+}
+
+.#{$block-class}--lg {
+  /* April 2023 max text input size */
+  --#{$block-class}--size: #{$spacing-09};
 }
 
 .#{$block-class}--readonly {
@@ -89,8 +104,8 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}__toolbar {
-  --toolbar-width: #{$spacing-07};
-  --toolbar-width-focussed: #{$spacing-10};
+  --toolbar-width: var(--#{$block-class}--size);
+  --toolbar-width-focussed: calc(2 * var(--#{$block-class}--size));
 
   // animation div
   display: inline-flex;
@@ -99,8 +114,8 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}--invalid .#{$block-class}__toolbar {
-  --toolbar-width: #{$spacing-10};
-  --toolbar-width-focussed: #{$spacing-12};
+  --toolbar-width: calc(2 * var(--#{$block-class}--size));
+  --toolbar-width-focussed: calc(3 * var(--#{$block-class}--size));
 }
 
 @keyframes slide-in {

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -22,7 +22,7 @@ $carbon-input: #{$carbon-prefix}--text-input;
   cursor: pointer;
 }
 
-.#{$block-class}-readonly {
+.#{$block-class}--readonly {
   cursor: not-allowed;
 }
 
@@ -30,12 +30,17 @@ $carbon-input: #{$carbon-prefix}--text-input;
   background: $field-01;
 }
 
-.#{$block-class}:hover .#{$block-class}__btn-edit {
+.#{$block-class}:hover .#{$block-class}__btn-edit,
+.#{$block-class}__btn-edit.#{$block-class}__btn-edit--always-visible {
   visibility: visible;
 }
 
 .#{$block-class}__btn-edit {
   visibility: hidden;
+}
+
+.#{$block-class}--invalid {
+  outline: 2px solid $support-error;
 }
 
 .#{$block-class}--focused {
@@ -52,6 +57,7 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}__warning-icon {
+  width: $spacing-05;
   margin: $spacing-03;
   color: $support-error;
 }
@@ -71,11 +77,11 @@ $carbon-input: #{$carbon-prefix}--text-input;
   outline: none;
 }
 
-.#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-input},
-.#{$block-class}-readonly
-  .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
-  cursor: not-allowed;
-}
+// .#{$block-class}-readonly .#{$block-class}__text-input.#{$carbon-input},
+// .#{$block-class}-readonly
+//   .#{$carbon-prefix}--btn.#{$carbon-prefix}--btn--icon-only.#{$carbon-prefix}--tooltip__trigger {
+//   cursor: not-allowed;
+// }
 
 .#{$block-class}__text-input.#{$carbon-input}:focus,
 .#{$block-class}__text-input.#{$carbon-input}:active {
@@ -93,7 +99,7 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}--invalid .#{$block-class}__toolbar {
-  --toolbar-width: #{$spacing-07};
+  --toolbar-width: #{$spacing-10};
   --toolbar-width-focussed: #{$spacing-12};
 }
 

--- a/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/_inline-edit-v2.scss
@@ -67,13 +67,21 @@ $carbon-input: #{$carbon-prefix}--text-input;
   flex: 1;
 }
 
+.#{$block-class}--inherit-type .#{$block-class}__text-input {
+  /* match font of container */
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
+
 .#{$block-class}__text-input-label {
   display: none;
 }
 
 .#{$block-class}__warning-icon {
   width: $spacing-05;
-  margin: $spacing-03;
+  margin: auto $spacing-03;
   color: $support-error;
 }
 
@@ -114,8 +122,11 @@ $carbon-input: #{$carbon-prefix}--text-input;
 }
 
 .#{$block-class}--invalid .#{$block-class}__toolbar {
-  --toolbar-width: calc(2 * var(--#{$block-class}--size));
-  --toolbar-width-focussed: calc(3 * var(--#{$block-class}--size));
+  // width of invalid icon is always $spacing-07 ($spacing-05 + 2 * $spacing-03 margin)
+  --toolbar-width: calc(var(--#{$block-class}--size) + #{$spacing-07});
+  --toolbar-width-focussed: calc(
+    2 * var(--#{$block-class}--size) + #{$spacing-07}
+  );
 }
 
 @keyframes slide-in {


### PR DESCRIPTION
Contributes to #2871

There are a number of differences between V1 and V2 Inline edit outlined in the issue.  This addresses some of them.

#### What did you change?

- Invalid state shows even without focus
- rename invalidLabel to invalidText inline with Carbon TextInput
- added option to make edit button always visible.
- update snapshots
- added size to v2
- added option to allow InlineEditV2 to inherit type (allows use in PageHeader title).

#### How did you test and verify your work?

Storybook.