### PR TITLE
docs(Datagrid): docs update part 2 (v2)

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
@@ -794,6 +794,449 @@ width will be set to the default column width (150px) or the value passed to the
   ...
 ```
 
+## Actions column
+
+This will add row actions (if more than two actions are provided an OverflowMenu
+component will be used) to the cells on the column marked with `isAction: true`.
+Each action button callback will include the actionId and the row object.
+
+1. Include `useActionsColumn` hook
+2. Add `isAction = true` to the column object in which you which to add the
+   overflow menu actions
+3. Add `rowActions = []` array to the props
+
+- `rowActions[].id` for callback to identify the action is called
+- `rowActions[].onClick(actionId: string, row: Row, event: ClickEvent)` callback
+  on menuitem clicked.
+  [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+- `rowActions[].shouldHideMenuItem(row: Row)` callback to hide this menuitem.
+  [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+- `rowActions[].shouldDisableMenuItem(row: Row)` callback to disable this
+  menuitem.
+  [Row properties](https://react-table.tanstack.com/docs/api/useTable#row-properties)
+  - This will override `rowActions[].disabled` (from Carbon) because
+    `shouldDisableMenuItem` is more specific to the row.
+- each action object can take all the props from `OverflowMenuItem` props, see
+  [carbon docs](https://react.carbondesignsystem.com/?path=/docs/components-overflowmenu--default#overflowmenu)
+
+```jsx
+const columns = [
+  // other columns
+  {
+    Header: '',
+    accessor: 'actions',
+    isAction: true,
+  },
+];
+const onActionClick = (actionId, row, event) => {};
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    rowActions: [
+      {
+        id: 'edit',
+        itemText: 'Edit',
+        onClick: onActionClick,
+      },
+      {
+        id: 'hidden',
+        itemText: 'Hidden item',
+        onClick: onActionClick,
+        shouldHideMenuItem: () => true,
+      },
+      {
+        id: 'delete',
+        itemText: 'Delete',
+        hasDivider: true,
+        isDelete: true,
+        onClick: onActionClick,
+      },
+    ],
+  },
+  useActionsColumn
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Customizing columns
+
+Customizing columns allows user to reorder and hide certain columns of the
+datagrid. Consuming component can use the provided callback to save/update
+according to their persistent strategy.
+
+1. Include `useCustomizeColumns` and `useColumnOrder` hooks (required)
+
+- `useColumnOrder` comes from `react-table` but is exported by
+  `@carbon/ibm-products` to be used alongside `useCustomizeColumns`.
+
+2. Implement `options.DatagridActions` component
+
+- this component will have props: `datagridState`
+- render `datagridState.CustomizeColumnsButton` component wherever makes sense.
+
+3. Options available to set:
+
+- `options.initialState.hiddenColumns: Array<ColumnId: String>`
+  - Array of column ids that will be hidden after initial render
+  - [react-table doc](https://react-table.tanstack.com/docs/api/useTable#table-options)
+  - `options.initialState.columnOrder: Array<ColumnId: String>`
+    - Order of the columns. Any column ids not in this array will be ordered by
+      their position in the `options.columns`
+    - [react-table doc](https://react-table.tanstack.com/docs/api/useColumnOrder#table-options)
+  - `options.customizeColumnsProps.onSaveColumnPrefs`
+    - type:
+      `Function(Columns: Array<{ColumnId: String, isVisible: Boolean}>) => void`
+    - Callback function when 'Save' button clicked on the narrow tearsheet. It
+      allows consumer to preserve the updated column preference. This output can
+      also be used to compute the `hiddenColumns` and `columnOrder`
+- Reset to default (optional)
+  - There is a reset to default button on the modal. It will use the
+    `options.columns` as the default. If there are columns should be hidden by
+    default, denote them with property: `isVisible: false` (undefined will be
+    treated as `true`)
+
+```jsx
+const columns = React.useMemo(() => defaultHeader, []);
+const [data] = useState(makeData(10));
+const DatagridActions = (datagridState) => (
+  <TableToolbarContent>
+    <TableToolbarSearch ... />
+    <Button ... />
+    <datagridState.CustomizeColumnsButton />
+  </TableToolbarContent>
+)
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    initialState: {
+      hiddenColumns: ['age'],
+      columnOrder: [],
+    },
+    customizeColumnsProps: {
+      onSaveColumnPrefs: (newColDefs) => {
+        console.log(newColDefs);
+      },
+    },
+    DatagridActions,
+  },
+  useCustomizeColumns,
+  useColumnOrder,
+);
+
+return (
+  <Datagrid datagridState={datagridState} />
+);
+```
+
+## Disabling select rows
+
+Disabling select rows allows you to choose which rows will be disabled in the
+table.
+
+1. Include the `useDisableSelectRows` hook in the `endPlugins` property of
+   `useDatagrid`.
+2. Add the `shouldDisableSelectRow` to the `useDatagrid` hook, this will be a
+   function that returns the row indexes that will be disabled.
+
+```jsx
+const [data] = useState(makeData(10));
+const columns = React.useMemo(() => getColumns(data), []);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    DatagridActions,
+    DatagridBatchActions,
+    endPlugins: [useDisableSelectRows],
+    shouldDisableSelectRow: (row) => row.id % 2 === 0,
+    disableSelectAll: true,
+  },
+  useSelectRows
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Infinite scroll
+
+Infinite scroll is supported via the `useInfiniteScroll` hook. This hook will
+allow you to fetch more data to display to the user after a certain scroll
+threshold. The `useInfiniteScroll` hook can also be used to support virtualized
+data, this is required when working with large amounts of data, only rendering
+the rows that need to be visible in the component at a point in time.
+
+Infinite scroll:
+
+1. Include `useInfiniteScroll` hook
+2. Add `fetchMoreData` property to `useDatagrid`, this will be a function that
+   is called when the scroll threshold is met. Optionally change the height of
+   the grid with the `virtualHeight` property.
+
+```jsx
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    isFetching,
+    fetchMoreData: fetchData,
+    virtualHeight: 540,
+    emptyStateTitle: 'Empty state title',
+    emptyStateDescription: 'Description explaining why the table is empty',
+  },
+  useInfiniteScroll
+);
+```
+
+Virtualized data:
+
+1. Include `useInfiniteScroll` hook
+2. The Datagrid will know to use virtualized data just by providing the
+   `useInfiniteScroll` hook
+
+```jsx
+const [data] = useState(makeData(10000));
+const columns = React.useMemo(() => getColumns(data), []);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+  },
+  useInfiniteScroll
+);
+```
+
+## Nested rows
+
+Nested rows allow disclosing content in data tables progressively by displaying
+primary data first (parent row) and enabling users to navigate secondary
+information levels (child rows).
+
+1. Include the `useNestedRows` hook
+2. Make sure that any row you want to have nested rows in your data has a
+   `subRows` property with an array of objects for each nested row. The row
+   expander will be included by default as long as the `useNestedRows` hook is
+   provided and it is detected that a row has `subRows` within it.
+
+```jsx
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+  },
+  useNestedRows
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Row click
+
+Datagrid supports adding a click event on an entire row with the use of the
+`useOnRowClick` hook.
+
+1. Include the `useOnRowClick` hook
+2. Add the `onRowClick` property, this is a callback function that will be
+   called when a row is clicked. It will give back the row and the click event.
+
+```jsx
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    onRowClick: (row, event) => {
+      ...
+    },
+  },
+  useOnRowClick
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Detect row hover
+
+There may be cases when you want to detect if a user is hovering on a particular
+row. In this case, use the `useRowIsMouseOver` hook.
+
+1. Include the `useRowIsMouseOver` hook
+2. When hover is detected on a row, a property called `isMouseOver` is changed
+   from `false` to `true` within that row.
+
+## Select items across all pages
+
+By default, selecting all items with paginated rows will result in just the
+current page rows being selected. Incorporating the `useSelectAllWithToggle`
+hook will provide the option to select all rows across all pages.
+
+1. Include `useSelectAllWithToggle` and `useSelectRows` hook
+2. Add the `selectAllToggle` property to the `useDatagrid` hook
+
+- optionally pass in labels to ensure proper translation
+- optionally pass in `onSelectAllRows`, function that will be called via the
+  select all rows checkbox onChange
+
+```jsx
+const [data] = useState(makeData(100));
+const columns = React.useMemo(() => getColumns(data), []);
+const [areAllSelected, setAreAllSelected] = useState(false);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    initialState: {
+      pageSize: 10,
+      pageSizes: [5, 10, 25, 50],
+    },
+    selectAllToggle: {
+      labels: {
+        allRows: 'Select all',
+        allPageRows: 'Select all on page',
+      },
+      onSelectAllRows: setAreAllSelected,
+    },
+    DatagridPagination,
+    DatagridActions,
+    DatagridBatchActions,
+  },
+  useSelectRows,
+  useSelectAllWithToggle
+);
+
+return (
+  <>
+    <Datagrid datagridState={datagridState} />
+    <p>{`Are all entries selected across all pages? - ${areAllSelected}`}</p>
+  </>
+);
+```
+
+## Selecting rows
+
+When building a Datagrid that requires selectable rows, use the `useSelectRows`
+hook.
+
+1. Include `useSelectRows` hook
+2. Add `onRowSelect` to the `useDatagrid` hook, this is a callback function
+   called when on a row's selection checkbox onChange, and sends back the row
+   object and the event
+
+```jsx
+const [data] = useState(makeData(10));
+const columns = React.useMemo(() => getColumns(data), []);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    onRowSelect: (row, event) => console.log(row, event),
+  },
+  useSelectRows
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+The select all checkbox can be optionally hidden by settings the `hideSelectAll`
+property to `true` in the `useDatagrid` hook.
+
+```jsx
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    onRowSelect: (row, event) => console.log(row, event),
+    hideSelectAll: true,
+  },
+  useSelectRows
+);
+```
+
+Datagrid also provides the option to use radio selection in cases where only one
+row should be selected at a time. Additionally, you can have preselected
+row/rows, see example below.
+
+```jsx
+const [data] = useState(makeData(10));
+const columns = React.useMemo(() => getColumns(data), []);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+    radio: true,
+    onRadioSelect: (row) => console.log(`Row clicked: ${row.id}`),
+    initialState: {
+      selectedRowIds: {
+        3: true,
+      },
+    },
+  },
+  useSelectRows
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Sortable columns
+
+To add sortable columns to your Datagrid, simply add the `useSortableColumns`
+hook. This will allow each column header to be clickable and sort each column in
+either ascending or descending order.
+
+1. Include `useSortableColumns` hook
+
+```jsx
+const [data] = useState(makeData(10));
+const columns = React.useMemo(() => getColumns(data), []);
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+  },
+  useSortableColumns
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
+## Sticky column
+
+Sticky columns can be useful when you have many columns that create a horizontal
+scroll and you have important data in the first or last column that you always
+want to be visible.
+
+1. Include the `useStickyColumn` hook
+2. Sticky columns can _only_ be applied to the first and the last columns in the
+   Datagrid. To have the first column stick, add `sticky: 'left'` to the first
+   column definition. To have the last column stick, add `sticky: 'right'` to
+   the last column definition.
+
+```jsx
+const columns = [
+  {
+    Header: 'First column',
+    accessor: 'first_column',
+    sticky: 'left',
+  },
+  {
+    ...
+  },
+  {
+    ...
+  }
+];
+const datagridState = useDatagrid(
+  {
+    columns,
+    data,
+  },
+  useStickyColumn
+);
+
+return <Datagrid datagridState={datagridState} />;
+```
+
 ## Code sample
 
 <CodesandboxLink exampleDirectory="Datagrid" />

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
@@ -327,6 +327,7 @@ export const SelectableRow = () => {
       toolbarBatchActions: getBatchActions(),
       emptyStateTitle,
       emptyStateDescription,
+      onRowSelect: (row, event) => console.log(row, event),
     },
     useSelectRows,
     useStickyColumn

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
@@ -1,11 +1,10 @@
-/*
- * Licensed Materials - Property of IBM
- * 5724-Q36
- * (c) Copyright IBM Corp. 2020, 2021
- * US Government Users Restricted Rights - Use, duplication or disclosure
- * restricted by GSA ADP Schedule Contract with IBM Corp.
+/**
+ * Copyright IBM Corp. 2020, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
-// @flow
+
 import React, { useEffect, useState, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
@@ -86,6 +85,7 @@ const SelectAllWithToggle = ({
         renderIcon={(props) => <CaretDown size={16} {...props} />}
         size="sm"
         ariaLabel={allRowsLabel}
+        menuOptionsClass={`${blockClass}__select-all-toggle-overflow`}
       >
         <OverflowMenuItem
           itemText={allPageRowsLabel}

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useSelectAllToggle.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useSelectAllToggle.scss
@@ -8,6 +8,7 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use './variables';
+@use '../../../global/styles/project-settings' as c4p-settings;
 
 .#{variables.$block-class}__grid-container {
   th.#{variables.$block-class}__select-all-toggle-on,
@@ -31,6 +32,6 @@ th.#{variables.$block-class}__select-all-toggle-on.button {
   margin-left: $spacing-01;
 }
 
-.#{$block-class}__select-all-toggle-overflow.#{$carbon-prefix}--overflow-menu-options--sm.#{$carbon-prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+.#{variables.$block-class}__select-all-toggle-overflow.#{c4p-settings.$carbon-prefix}--overflow-menu-options--sm.#{c4p-settings.$carbon-prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
   width: $spacing-13;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/styles/_useSelectAllToggle.scss
+++ b/packages/cloud-cognitive/src/components/Datagrid/styles/_useSelectAllToggle.scss
@@ -1,10 +1,9 @@
-/*
-* Licensed Materials - Property of IBM
-* 5724-Q36
-* (c) Copyright IBM Corp. 2021
-* US Government Users Restricted Rights - Use, duplication or disclosure
-* restricted by GSA ADP Schedule Contract with IBM Corp.
-*/
+//
+// Copyright IBM Corp. 2021, 2023
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
@@ -30,4 +29,8 @@ th.#{variables.$block-class}__select-all-toggle-on {
 
 th.#{variables.$block-class}__select-all-toggle-on.button {
   margin-left: $spacing-01;
+}
+
+.#{$block-class}__select-all-toggle-overflow.#{$carbon-prefix}--overflow-menu-options--sm.#{$carbon-prefix}--overflow-menu-options[data-floating-menu-direction='bottom']::after {
+  width: $spacing-13;
 }

--- a/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
@@ -62,6 +62,7 @@ const SelectRow = (datagridState) => {
     radio,
     toggleAllRowsSelected,
     onRadioSelect,
+    onRowSelect,
     columns,
     withStickyColumn,
   } = datagridState;
@@ -94,6 +95,7 @@ const SelectRow = (datagridState) => {
           }
         }
         onChange(e);
+        onRowSelect?.(row, e);
       }}
       id={`${tableId}-${row.index}`}
       name={`${tableId}-${row.index}-name`}


### PR DESCRIPTION
Contributes to #2917 

Adds documentation for the remaining hooks listed in #2917. I additionally, made some small fixes as I was reviewing `useSelectRows` and `useSelectAllToggle`.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/Datagrid.mdx
packages/cloud-cognitive/src/components/Datagrid/Datagrid.stories.js
packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridSelectAllWithToggle.js
packages/cloud-cognitive/src/components/Datagrid/styles/_useSelectAllToggle.scss
packages/cloud-cognitive/src/components/Datagrid/useSelectRows.js
```
#### How did you test and verify your work?
Storybook