### PR TITLE
Use v2 inline edit in page header

### DIFF
--- a/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/cloud-cognitive/src/__tests__/__snapshots__/styles.test.js.snap
@@ -6818,7 +6818,7 @@ button.c4p--add-select__global-filter-toggle--open {
   white-space: nowrap;
 }
 .c4p--page-header .c4p--page-header__title-row {
-  margin-top: 0;
+  margin-top: 0.125rem; /* spacing needed in case of editable title, otherwise top of focus indicator hidden */
   margin-bottom: 0;
   transform: translateY(0.125rem);
 }
@@ -6877,9 +6877,6 @@ button.c4p--add-select__global-filter-toggle--open {
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.c4p--page-header .c4p--page-header__title .c4p--inline-edit__value {
-  transform: translateY(-2px);
 }
 .c4p--page-header .c4p--page-header__title--editable {
   display: flex;

--- a/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
+++ b/packages/cloud-cognitive/src/components/InlineEditV2/InlineEditV2.js
@@ -23,12 +23,16 @@ const componentName = 'InlineEditV2';
 const blockClass = `${pkg.prefix}--inline-edit-v2`;
 
 const defaults = {
+  buttonTooltipAlignment: 'center',
+  buttonTooltipPosition: 'top',
   size: 'sm',
 };
 
 export let InlineEditV2 = forwardRef(
   (
     {
+      buttonTooltipAlignment,
+      buttonTooltipPosition,
       cancelLabel,
       editAlwaysVisible,
       editLabel,
@@ -187,6 +191,8 @@ export let InlineEditV2 = forwardRef(
                   tabIndex={0}
                   key="cancel"
                   className={`${blockClass}__btn ${blockClass}__btn-cancel`}
+                  tooltipAlignment={buttonTooltipAlignment}
+                  tooltipPosition={buttonTooltipPosition}
                 >
                   <Close size={16} />
                 </IconButton>
@@ -200,6 +206,8 @@ export let InlineEditV2 = forwardRef(
                   key="save"
                   className={`${blockClass}__btn ${blockClass}__btn-save`}
                   disabled={!canSave}
+                  tooltipAlignment={buttonTooltipAlignment}
+                  tooltipPosition={buttonTooltipPosition}
                 >
                   <Checkmark size={16} />
                 </IconButton>
@@ -216,6 +224,8 @@ export let InlineEditV2 = forwardRef(
                 kind="ghost"
                 tabIndex={0}
                 key="edit"
+                tooltipAlignment={buttonTooltipAlignment}
+                tooltipPosition={buttonTooltipPosition}
               >
                 <Edit size={16} />
               </IconButton>
@@ -246,9 +256,34 @@ export const deprecatedProps = {
 
 InlineEditV2.propTypes = {
   /**
-   * label for cancel button
+   * buttonTooltipAlignment from the standard tooltip. Default center.
+   *
+   * Can be passed either as one of tooltip options or as an object specifying cancel, edit and save separately
    */
-  cancelLabel: PropTypes.string.isRequired,
+  buttonTooltipAlignment: PropTypes.oneOfType([
+    PropTypes.oneOf(['start', 'center', 'end']),
+    PropTypes.shape({
+      cancel: PropTypes.oneOf(['start', 'center', 'end']),
+      edit: PropTypes.oneOf(['start', 'center', 'end']),
+      save: PropTypes.oneOf(['start', 'center', 'end']),
+    }),
+  ]),
+  /**
+   * buttonTooltipPosition from the standard tooltip
+   *
+   * Can be passed either as one of tooltip options or as an object specifying cancel, edit and save separately
+   */
+  buttonTooltipPosition: PropTypes.oneOfType([
+    PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+    PropTypes.shape({
+      cancel: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+      edit: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+      save: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+    }),
+  ]),
+  /**
+   * label for cancel button
+   */ cancelLabel: PropTypes.string.isRequired,
   /**
    * By default the edit icon is shown on hover only.
    */
@@ -316,10 +351,4 @@ InlineEditV2.propTypes = {
   value: PropTypes.string.isRequired,
 
   ...deprecatedProps,
-};
-
-InlineEditV2.defaultProps = {
-  invalid: false,
-  invalidLabel: '',
-  // readOnly: false,
 };

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -1082,12 +1082,14 @@ PageHeader.propTypes = {
       loading: PropTypes.bool,
 
       // inline edit version properties
-      editableLabel: PropTypes.string, // .isRequired.if(inlineEditRequired),
-      id: PropTypes.string, // .isRequired.if(inlineEditRequired),
+      editableLabel: PropTypes.string, // .isRequired.if(InlineEditRequired),
+      id: PropTypes.string, // .isRequired.if(InlineEditRequired),
+      onCancel: PropTypes.func,
       onChange: PropTypes.func,
       onSave: PropTypes.func,
-      cancelDescription: PropTypes.string, //.isRequired.if(inlineEditRequired),
-      saveDescription: PropTypes.string, //.isRequired.if(inlineEditRequired),
+      cancelDescription: PropTypes.string, //.isRequired.if(InlineEditRequired),
+      editDescription: PropTypes.string, // .isRequired.if(InlineEditRequired),
+      saveDescription: PropTypes.string, //.isRequired.if(InlineEditRequired),
       // Update docgen if changed
     }),
     PropTypes.string,

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -569,7 +569,7 @@ const Template = ({ children, title, ...props }) => {
         actionTitleSave(titleText);
       }
     : null;
-  const handleTitleChange = title?.onSave
+  const handleTitleChange = title?.onChange
     ? (val) => {
         actionTitleChange(val);
         setTitleText(val);

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.stories.js
@@ -379,6 +379,9 @@ const title = {
     onSave: () => {
       // gets replaced in template
     },
+    onCancel: () => {
+      // gets replaced in template
+    },
     cancelDescription: 'Cancel',
     saveDescription: 'Save',
     text: 'An editable title',
@@ -553,19 +556,31 @@ const demoDummyPageContent = (
 
 const actionTitleChange = action('title onChange');
 const actionTitleSave = action('title onSave');
+const actionTitleCancel = action('title change cancelled');
 // Template.
 // eslint-disable-next-line react/prop-types
 const Template = ({ children, title, ...props }) => {
   const carbonPrefix = usePrefix();
   // eslint-disable-next-line react/prop-types
   const [titleText, setTitleText] = useState(title?.text ?? title);
+
   const handleTitleSave = title?.onSave
+    ? () => {
+        actionTitleSave(titleText);
+      }
+    : null;
+  const handleTitleChange = title?.onSave
     ? (val) => {
-        actionTitleSave(val);
+        actionTitleChange(val);
         setTitleText(val);
       }
     : null;
-  const handleTitleChange = title?.onSave ? actionTitleChange : null;
+  const handleTitleCancel = title?.onCancel
+    ? (val) => {
+        actionTitleCancel(val);
+        setTitleText(val);
+      }
+    : null;
 
   // const [theTitle, setTheTitle] = useState({});
 
@@ -606,6 +621,7 @@ const Template = ({ children, title, ...props }) => {
                 text: titleText,
                 onChange: handleTitleChange,
                 onSave: handleTitleSave,
+                onCancel: handleTitleCancel,
               }
             : title
         }

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeaderTitle.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeaderTitle.js
@@ -48,18 +48,18 @@ export const PageHeaderTitle = ({ blockClass, hasBreadcrumbRow, title }) => {
           <SkeletonText className={`${blockClass}__title-skeleton`} />
         ) : isEditable ? (
           <InlineEdit
-            v1
-            hideLabel
+            buttonTooltipDirection="bottom"
+            v2
             value={text}
-            {...{
-              editDescription,
-              onChange,
-              onSave,
-              labelText: editableLabel,
-              revertDescription,
-              saveDescription,
-            }}
-            buttonTooltipPosition="bottom"
+            cancelLabel={revertDescription}
+            editLabel={editDescription}
+            saveLabel={saveDescription}
+            labelText={editableLabel}
+            onChange={onChange}
+            // buttonTooltipPosition="bottom"
+            onSave={onSave}
+            size="md"
+            inheritTypography
             {...rest}
           />
         ) : (
@@ -87,7 +87,7 @@ export const PageHeaderTitle = ({ blockClass, hasBreadcrumbRow, title }) => {
   );
 };
 
-export const inlineEditRequired = ({ onSave }) => !!onSave;
+export const InlineEditRequired = ({ onSave }) => !!onSave;
 
 PageHeaderTitle.propTypes = {
   // passed from page header
@@ -124,13 +124,13 @@ PageHeaderTitle.propTypes = {
       loading: PropTypes.bool,
 
       // inline edit version properties
-      editDescription: PropTypes.string.isRequired.if(inlineEditRequired),
-      editableLabel: PropTypes.string.isRequired.if(inlineEditRequired),
-      id: PropTypes.string.isRequired.if(inlineEditRequired),
+      editDescription: PropTypes.string.isRequired.if(InlineEditRequired),
+      editableLabel: PropTypes.string.isRequired.if(InlineEditRequired),
+      id: PropTypes.string.isRequired.if(InlineEditRequired),
       onChange: PropTypes.func,
       onSave: PropTypes.func,
-      revertDescription: PropTypes.string.isRequired.if(inlineEditRequired),
-      saveDescription: PropTypes.string.isRequired.if(inlineEditRequired),
+      revertDescription: PropTypes.string.isRequired.if(InlineEditRequired),
+      saveDescription: PropTypes.string.isRequired.if(InlineEditRequired),
       // Update docgen if changed
     }),
     PropTypes.string,

--- a/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
+++ b/packages/cloud-cognitive/src/components/PageHeader/_page-header.scss
@@ -357,7 +357,7 @@ $right-section-alt-width: 100% - $left-section-alt-width;
   }
 
   .#{$block-class}__title-row {
-    margin-top: 0;
+    margin-top: $spacing-01; /* spacing needed in case of editable title, otherwise top of focus indicator hidden */
     margin-bottom: 0;
     transform: translateY(
       $spacing-01
@@ -434,12 +434,6 @@ $right-section-alt-width: 100% - $left-section-alt-width;
     overflow-x: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .#{$block-class}__title .#{$pkg-prefix}--inline-edit__value {
-    // The heading text sits 2px pixels lower in the inline edit which is aligned center
-    // stylelint-disable-next-line carbon/layout-token-use
-    transform: translateY(-2px);
   }
 
   .#{$block-class}__title--editable {


### PR DESCRIPTION
Contributes to #2866 

#### What did you change?

Changes PageHeader use of InlineEdit to V2 to allow the removal of V1.

#### How did you test and verify your work?

storybook and tests