### PR TITLE
fix: Carbon v11 lodash dependency

### DIFF
--- a/packages/ibm-products/package.json
+++ b/packages/ibm-products/package.json
@@ -78,6 +78,7 @@
     "@carbon/telemetry": "^0.1.0",
     "framer-motion": "^6.5.1",
     "immutability-helper": "^3.1.1",
+    "lodash": "^4.17.21",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
     "react-table": "^7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,6 +1866,7 @@ __metadata:
     jest: ^29.0.1
     jest-config-ibm-cloud-cognitive: ^0.24.5
     jest-environment-jsdom: ^29.0.1
+    lodash: ^4.17.21
     namor: ^1.1.2
     npm-check-updates: ^16.0.6
     npm-run-all: ^4.1.5


### PR DESCRIPTION
DataGrid has an undeclared dependancy on lodash, this PR adds it.