### PR TITLE
feat: expose scss config file

### DIFF
--- a/packages/ibm-products/src/config.scss
+++ b/packages/ibm-products/src/config.scss
@@ -1,0 +1,1 @@
+@forward './global/styles/project-settings';


### PR DESCRIPTION
This feels wrong

`@use "@carbon/ibm-products/scss/index" as config;` to be able to do `config.$pkg-prefix'

It forwards way more than is needed.

Might I suggest a `config.scss` file as per Carbon thus allowing...

With
@use "@carbon/ibm-products/scss/config"

enabling

config.$pkg-prefix
config.$carbon-prefix

