### PR TITLE
feat: Remove react resize detector

### DIFF
--- a/packages/cloud-cognitive/package.json
+++ b/packages/cloud-cognitive/package.json
@@ -77,7 +77,6 @@
     "immutability-helper": "^3.1.1",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
-    "react-resize-detector": "^8.0.3",
     "react-table": "^7.8.0",
     "react-window": "^1.8.8"
   },

--- a/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
+++ b/packages/cloud-cognitive/src/components/AboutModal/AboutModal.js
@@ -7,7 +7,7 @@
 
 // Import portions of React that are needed.
 import React, { useState, useRef, useEffect } from 'react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -82,7 +82,7 @@ export let AboutModal = React.forwardRef(
     }, [bodyRef]);
 
     // Detect resize of the ModalBody to recalculate whether scrolling is enabled
-    useResizeDetector({ onResize: handleResize, targetRef: bodyRef });
+    useResizeObserver(bodyRef, { callback: handleResize });
 
     return (
       <ComposedModal

--- a/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
+++ b/packages/cloud-cognitive/src/components/ActionBar/ActionBar.js
@@ -12,7 +12,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { pkg } from '../../settings';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Carbon and package components we use.
 import { Button } from 'carbon-components-react';
@@ -55,6 +55,8 @@ export let ActionBar = React.forwardRef(
     const refDisplayedItems = useRef(null);
     const sizingRef = useRef(null);
     const sizes = useRef({});
+    const backupRef = useRef();
+    const localRef = ref || backupRef;
 
     // create hidden sizing items
     useEffect(() => {
@@ -189,31 +191,16 @@ export let ActionBar = React.forwardRef(
 
     /* istanbul ignore next */ // not sure how to fake window resize
     const handleResize = () => {
-      // width is the space available for all action bar items horizontally
-      // the action bar items are squares so the height should be one item wide
-      /* istanbul ignore next */ // not sure how to fake window resize
-      checkFullyVisibleItems();
-    };
-
-    /* istanbul ignore next */ // not sure how to fake window resize
-    const handleActionBarItemsResize = () => {
       // when the hidden sizing items change size
       /* istanbul ignore next */ // not sure how to fake window resize
       checkFullyVisibleItems();
     };
 
-    useResizeDetector({
-      onResize: handleActionBarItemsResize,
-      targetRef: sizingRef,
-    });
-
-    const { ref: outerRef } = useResizeDetector({
-      onResize: handleResize,
-      targetRef: ref,
-    });
+    useResizeObserver(sizingRef, { callback: handleResize });
+    useResizeObserver(localRef, { callback: handleResize });
 
     return (
-      <div {...rest} className={cx([blockClass, className])} ref={outerRef}>
+      <div {...rest} className={cx([blockClass, className])} ref={localRef}>
         {hiddenSizingItems}
 
         <div

--- a/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/BreadcrumbWithOverflow/BreadcrumbWithOverflow.js
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Link, TooltipIcon } from 'carbon-components-react';
 import { pkg, carbon } from '../../settings';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { ArrowLeft16 } from '@carbon/icons-react';
 
 // Carbon and package components we use.
@@ -261,27 +261,16 @@ export let BreadcrumbWithOverflow = ({
     checkFullyVisibleBreadcrumbItems();
   };
 
-  /* istanbul ignore next */ // not sure how to test resize
-  const handleBreadcrumbItemsResize = () => {
-    /* istanbul ignore next */ // not sure how to test resize
-    checkFullyVisibleBreadcrumbItems();
-  };
-
   let backItem = breadcrumbs[breadcrumbs.length - 1];
   /* istanbul ignore if */ // not sure how to test media queries
   if (backItem.isCurrentPage) {
     backItem = breadcrumbs[breadcrumbs.length - 2];
   }
 
-  useResizeDetector({
-    onResize: handleBreadcrumbItemsResize,
-    targetRef: sizingContainerRef,
-  });
-
-  useResizeDetector({
-    onResize: handleResize,
-    targetRef: breadcrumbItemWithOverflow,
-  });
+  // container resize
+  useResizeObserver(sizingContainerRef, { callback: handleResize });
+  // item resize
+  useResizeObserver(breadcrumbItemWithOverflow, { callback: handleResize });
 
   return (
     <div

--- a/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
+++ b/packages/cloud-cognitive/src/components/ButtonSetWithOverflow/ButtonSetWithOverflow.js
@@ -9,7 +9,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { ButtonSet, Button } from 'carbon-components-react';
 import { ButtonMenu, ButtonMenuItem } from '../ButtonMenu';
 
@@ -125,21 +125,15 @@ export const ButtonSetWithOverflow = ({
     );
   });
 
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: sizingContainerRefSet,
+  useResizeObserver(sizingContainerRefSet, {
+    callback: checkFullyVisibleItems,
   });
 
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: sizingContainerRefCombo,
+  useResizeObserver(sizingContainerRefCombo, {
+    callback: checkFullyVisibleItems,
   });
 
-  useResizeDetector({
-    onResize: checkFullyVisibleItems,
-    targetRef: spaceAvailableRef,
-    handleWidth: true,
-  });
+  useResizeObserver(spaceAvailableRef, { callback: checkFullyVisibleItems });
 
   return (
     <div

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridToolbar.js
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Add16, OverflowMenuVertical16 } from '@carbon/icons-react';
 import {
   DataTable,
   TableBatchActions,
   TableBatchAction,
 } from 'carbon-components-react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 import { ButtonMenu, ButtonMenuItem } from '../../ButtonMenu';
 import { pkg, carbon } from '../../../settings';
 import cx from 'classnames';
@@ -156,7 +156,8 @@ const DatagridBatchActionsToolbar = (datagridState, width, ref) => {
 };
 
 const DatagridToolbar = (datagridState) => {
-  const { width, ref } = useResizeDetector();
+  const ref = useRef(null);
+  const { width } = useResizeObserver(ref);
   const { DatagridActions, DatagridBatchActions, batchActions, rowSize } =
     datagridState;
 

--- a/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/Datagrid/DatagridVirtualBody.js
@@ -9,7 +9,7 @@ import React, { useEffect } from 'react';
 import { VariableSizeList } from 'react-window';
 import { DataTable } from 'carbon-components-react';
 import { px } from '@carbon/layout';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../../global/js/hooks/useResizeObserver';
 import { pkg } from '../../../settings';
 import DatagridHead from './DatagridHead';
 
@@ -54,7 +54,7 @@ const DatagridVirtualBody = (datagridState) => {
     gridRefElement.style.width = gridRefElement?.clientWidth;
   };
 
-  useResizeDetector({ onResize: handleVirtualGridResize, targetRef: gridRef });
+  useResizeObserver(gridRef, { callback: handleVirtualGridResize });
 
   const syncScroll = (e) => {
     const virtualBody = e.target;

--- a/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
+++ b/packages/cloud-cognitive/src/components/PageHeader/PageHeader.js
@@ -9,7 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { layout05, baseFontSize } from '@carbon/layout';
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { Grid, Column, Row, Button, Tag } from 'carbon-components-react';
 import { breakpoints } from '@carbon/layout';
@@ -162,7 +162,7 @@ export let PageHeader = React.forwardRef(
     };
 
     /* istanbul ignore next */
-    const handleResizeActionBarColumn = (width) => {
+    const handleResizeActionBarColumn = ({ width }) => {
       /* don't know how to test resize */
       /* istanbul ignore next */
       setActionBarColumnWidth(width);
@@ -447,17 +447,11 @@ export let PageHeader = React.forwardRef(
       }
     }, [collapseHeader, metrics.headerOffset, metrics.headerTopValue]);
 
-    useResizeDetector({
-      onResize: handleResizeActionBarColumn,
-      targetRef: sizingContainerRef,
-      handleWidth: true,
+    useResizeObserver(sizingContainerRef, {
+      callback: handleResizeActionBarColumn,
     });
 
-    useResizeDetector({
-      onResize: handleResize,
-      targetRef: headerRef,
-      handleHeight: true,
-    });
+    useResizeObserver(headerRef, { callback: handleResize });
 
     // Determine what form of title to display in the breadcrumb
     let breadcrumbItemForTitle = utilGetBreadcrumbItemForTitle(

--- a/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
+++ b/packages/cloud-cognitive/src/components/SidePanel/SidePanel.js
@@ -12,7 +12,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 // Other standard imports.
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 import { moderate02 } from '@carbon/motion';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
@@ -169,7 +169,7 @@ export let SidePanel = React.forwardRef(
     }, [labelText, title]);
 
     /* istanbul ignore next */
-    const handleResize = (width, height) => {
+    const handleResize = ({ height }) => {
       setPanelHeight(height);
       const sidePanelOuter = document.querySelector(`#${blockClass}-outer`);
       const actionsContainer = getActionsContainerElement();
@@ -686,11 +686,7 @@ export let SidePanel = React.forwardRef(
 
     const contentRef = ref || sidePanelRef;
 
-    useResizeDetector({
-      handleHeight: true,
-      onResize: handleResize,
-      targetRef: contentRef,
-    });
+    useResizeObserver(contentRef, { callback: handleResize });
 
     return (
       <AnimatePresence>

--- a/packages/cloud-cognitive/src/components/TagSet/TagSet.js
+++ b/packages/cloud-cognitive/src/components/TagSet/TagSet.js
@@ -14,7 +14,7 @@ import cx from 'classnames';
 import { TagSetOverflow } from './TagSetOverflow';
 import { TagSetModal } from './TagSetModal';
 import { Tag } from 'carbon-components-react';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 import { getDevtoolsProps } from '../../global/js/utils/devtools';
 import { prepareProps, isRequiredIf } from '../../global/js/utils/props-helper';
@@ -221,15 +221,9 @@ export let TagSet = React.forwardRef(
       setShowAllModalOpen(false);
     };
 
-    useResizeDetector({
-      onResize: handleSizerTagsResize,
-      targetRef: sizingContainerRef,
-    });
+    useResizeObserver(sizingContainerRef, { callback: handleSizerTagsResize });
 
-    useResizeDetector({
-      onResize: handleResize,
-      targetRef: tagSetRef,
-    });
+    useResizeObserver(tagSetRef, { callback: handleResize });
 
     return (
       <div

--- a/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
+++ b/packages/cloud-cognitive/src/components/Tearsheet/TearsheetShell.js
@@ -8,7 +8,7 @@
 // Import portions of React that are needed.
 import React, { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { useResizeDetector } from 'react-resize-detector';
+import { useResizeObserver } from '../../global/js/hooks/useResizeObserver';
 
 // Other standard imports.
 import PropTypes from 'prop-types';
@@ -98,8 +98,9 @@ export const TearsheetShell = React.forwardRef(
     }, [portalTargetIn]);
 
     const localRef = useRef();
+    const resizer = useRef(null);
     const modalRef = ref || localRef;
-    const { width, ref: resizer } = useResizeDetector({ handleHeight: false });
+    const { width } = useResizeObserver(resizer);
 
     // Keep track of the stack depth and our position in it (1-based, 0=closed)
     const [depth, setDepth] = useState(0);

--- a/packages/cloud-cognitive/src/global/js/hooks/useResizeObserver.js
+++ b/packages/cloud-cognitive/src/global/js/hooks/useResizeObserver.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright IBM Corp. 2023, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { useRef, useState, useLayoutEffect } from 'react';
+
+export const useResizeObserver = (
+  ref,
+  options = { callback: null, throttleInterval: 0 }
+) => {
+  const { callback, throttleInterval } = options;
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
+  const throttleTimeout = useRef(null);
+  const entriesToHandle = useRef(null);
+
+  useLayoutEffect(() => {
+    if (!ref?.current) {
+      return;
+    }
+
+    const doCallbacks = () => {
+      if (!ref?.current || !Array.isArray(entriesToHandle?.current)) {
+        return;
+      }
+
+      const entry = entriesToHandle.current[0];
+
+      setWidth(entry.contentRect.width);
+      setHeight(entry.contentRect.height);
+
+      throttleTimeout.current = null;
+
+      callback && callback(entry.contentRect);
+    };
+
+    let observer = new ResizeObserver((entries) => {
+      // always update entriesToHandle
+      entriesToHandle.current = entries;
+
+      if (throttleInterval) {
+        // if a throttleInterval check for running timeout
+        if (throttleTimeout.current === null) {
+          // no live timeout set entries to handle and move on
+
+          // set up throttle
+          throttleTimeout.current = setTimeout(() => {
+            // do callbacks
+            doCallbacks();
+            // reset throttle
+            throttleTimeout.current = null;
+          }, throttleInterval);
+        }
+      } else {
+        // no throttle do callbacks every time
+        doCallbacks();
+      }
+    });
+
+    // observe all refs passed
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+      observer = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, options]);
+
+  return { width, height };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,7 +1850,6 @@ __metadata:
     npm-run-all: ^4.1.5
     react-dnd: ^15.1.2
     react-dnd-html5-backend: ^15.1.3
-    react-resize-detector: ^8.0.3
     react-table: ^7.8.0
     react-window: ^1.8.8
     rimraf: ~3 || > 4.1
@@ -22831,18 +22830,6 @@ __metadata:
   version: 0.11.0
   resolution: "react-refresh@npm:0.11.0"
   checksum: 112178a05b1e0ffeaf5d9fb4e56b4410a34a73adeb04dbf13abdc50d9ac9df2ada83e81485156cca0b3fa296aa3612751b3d6cd13be4464642a43679b819cbc7
-  languageName: node
-  linkType: hard
-
-"react-resize-detector@npm:^8.0.3":
-  version: 8.0.3
-  resolution: "react-resize-detector@npm:8.0.3"
-  dependencies:
-    lodash: ^4.17.21
-  peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 21d34004c925ee97708501d4484ee1e81411eaaa84772d58ed6be08665a81725508645223be14347ae6dad321386830c72619f8de7046708f0b3b9d900b225aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Contributes to [#2744](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2744)

V7 of ReactResizeObserver can result in the error shown in [#2744](https://github.com/carbon-design-system/ibm-cloud-cognitive/issues/2744) but the error appears to be a timing issue of some description.

The author fixed a similar looking issue in V8, but it persists in our storybook. In V9 there were more extensive changes that stopped our current usage working.

This PR removes ReactResizeObserver in favor of wrapping ResizeObserver (now standard) in a hook.

#### What did you change?
- Removed react-resize-detector
- Created useResizeObserver hook.
- Checked it functioned as a replacement for all useResizeDetector hook *How did you test and verify your work?*
- Storybook changing the size of things and adding new elements
- Ran tests

#### How did you test and verify your work?
- Storybook changing the size of things and adding new elements
- Ran tests

