### PR TITLE
fix: give empty state illustration position

### DIFF
--- a/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
+++ b/packages/ibm-products/src/__tests__/__snapshots__/styles.test.js.snap
@@ -3211,6 +3211,7 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 }
 
 .c4p--empty-state {
+  display: flex;
   color: var(--cds-text-primary, #161616);
 }
 .c4p--empty-state .c4p--empty-state__header {
@@ -3253,6 +3254,22 @@ exports[`CSS export checks doesn't change the exported CSS for released componen
 .c4p--empty-state__illustration.c4p--empty-state__illustration--sm {
   min-width: 4rem;
   max-width: 4rem;
+}
+
+.c4p--empty-state-position--top {
+  flex-direction: column;
+}
+
+.c4p--empty-state-position--right {
+  flex-direction: row-reverse;
+}
+
+.c4p--empty-state-position--bottom {
+  flex-direction: column-reverse;
+}
+
+.c4p--empty-state-position--left {
+  flex-direction: row;
 }
 
 .c4p--empty-state .c4p--empty-state__action-button {

--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.js
@@ -25,6 +25,7 @@ const componentName = 'EmptyState';
 
 // Default values for props
 export const defaults = {
+  position: 'top',
   size: 'lg',
 };
 
@@ -37,6 +38,7 @@ export let EmptyState = React.forwardRef(
       className,
       illustration,
       illustrationDescription,
+      illustrationPosition = defaults.position,
       link,
       size = defaults.size,
       subtitle,
@@ -47,30 +49,28 @@ export let EmptyState = React.forwardRef(
     },
     ref
   ) => {
-    const renderIllustration = () => {
-      return (
-        <img
-          src={illustration}
-          alt={illustrationDescription}
-          className={cx([
-            `${blockClass}__illustration`,
-            `${blockClass}__illustration--${size}`,
-          ])}
-        />
-      );
-    };
-
     return (
       <div
         {
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(blockClass, className, {
+          [`${blockClass}-position--${illustrationPosition}`]: !!illustration,
+        })}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
-        {illustration && renderIllustration()}
+        {illustration && (
+          <img
+            src={illustration}
+            alt={illustrationDescription}
+            className={cx([
+              `${blockClass}__illustration`,
+              `${blockClass}__illustration--${size}`,
+            ])}
+          />
+        )}
         <EmptyStateContent
           action={action}
           link={link}
@@ -115,6 +115,11 @@ EmptyState.propTypes = {
   illustrationDescription: PropTypes.string.isRequired.if(
     ({ illustration }) => illustration
   ),
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state link object

--- a/packages/ibm-products/src/components/EmptyStates/EmptyState.test.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyState.test.js
@@ -123,9 +123,9 @@ describe(name, () => {
 
   it('applies className to the containing node', () => {
     render(<EmptyState {...defaultProps} className={className} />);
-    expect(screen.getByText(/Empty state title/).parentElement).toHaveClass(
-      className
-    );
+    expect(
+      screen.getByText(/Empty state title/).parentElement.parentElement
+    ).toHaveClass(className);
   });
 
   it('renders the small size Empty state', () => {

--- a/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.js
+++ b/packages/ibm-products/src/components/EmptyStates/EmptyStateContent.js
@@ -22,7 +22,7 @@ const componentName = 'EmptyStateContent';
 
 export const EmptyStateContent = ({ action, link, size, subtitle, title }) => {
   return (
-    <>
+    <div className={`${blockClass}__content`}>
       <h3
         className={cx(`${blockClass}__header`, {
           [`${blockClass}__header--small`]: size === 'sm',
@@ -56,7 +56,7 @@ export const EmptyStateContent = ({ action, link, size, subtitle, title }) => {
           {link.text}
         </Link>
       )}
-    </>
+    </div>
   );
 };
 

--- a/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/ErrorEmptyState/ErrorEmptyState.js
@@ -31,6 +31,7 @@ export let ErrorEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let ErrorEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -91,6 +96,11 @@ ErrorEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/NoDataEmptyState/NoDataEmptyState.js
@@ -31,6 +31,7 @@ export let NoDataEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let NoDataEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -91,6 +96,11 @@ NoDataEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/NoTagsEmptyState/NoTagsEmptyState.js
@@ -31,6 +31,7 @@ export let NoTagsEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let NoTagsEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -91,6 +96,11 @@ NoTagsEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/NotFoundEmptyState/NotFoundEmptyState.js
@@ -31,6 +31,7 @@ export let NotFoundEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let NotFoundEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -94,6 +99,11 @@ NotFoundEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/NotificationsEmptyState/NotificationsEmptyState.js
@@ -31,6 +31,7 @@ export let NotificationsEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let NotificationsEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -94,6 +99,11 @@ NotificationsEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
+++ b/packages/ibm-products/src/components/EmptyStates/UnauthorizedEmptyState/UnauthorizedEmptyState.js
@@ -31,6 +31,7 @@ export let UnauthorizedEmptyState = React.forwardRef(
 
       action,
       className,
+      illustrationPosition = defaults.position,
       illustrationTheme,
       link,
       size = defaults.size,
@@ -48,7 +49,11 @@ export let UnauthorizedEmptyState = React.forwardRef(
           // Pass through any other property values as HTML attributes.
           ...rest
         }
-        className={cx(blockClass, className)}
+        className={cx(
+          blockClass,
+          className,
+          `${blockClass}-position--${illustrationPosition}`
+        )}
         ref={ref}
         {...getDevtoolsProps(componentName)}
       >
@@ -94,6 +99,11 @@ UnauthorizedEmptyState.propTypes = {
    * Provide an optional class to be applied to the containing node.
    */
   className: PropTypes.string,
+
+  /**
+   * Designates the position of the illustration relative to the content
+   */
+  illustrationPosition: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * Empty state illustration theme variations.

--- a/packages/ibm-products/src/components/EmptyStates/_empty-state.scss
+++ b/packages/ibm-products/src/components/EmptyStates/_empty-state.scss
@@ -14,6 +14,7 @@
 $block-class: #{c4p-settings.$pkg-prefix}--empty-state;
 
 .#{$block-class} {
+  display: flex;
   color: $text-primary;
 
   .#{$block-class}__header {
@@ -43,20 +44,39 @@ $block-class: #{c4p-settings.$pkg-prefix}--empty-state;
 .#{$block-class}__illustration {
   height: auto;
   margin-bottom: $spacing-05;
+
   &.#{$block-class}__illustration--lg {
     min-width: $spacing-11;
     max-width: $spacing-11;
   }
+
   &.#{$block-class}__illustration--sm {
     min-width: $spacing-10;
     max-width: $spacing-10;
   }
 }
 
+.#{$block-class}-position--top {
+  flex-direction: column;
+}
+
+.#{$block-class}-position--right {
+  flex-direction: row-reverse;
+}
+
+.#{$block-class}-position--bottom {
+  flex-direction: column-reverse;
+}
+
+.#{$block-class}-position--left {
+  flex-direction: row;
+}
+
 .#{$block-class} .#{$block-class}__action-button {
   display: block;
   margin-bottom: $spacing-05;
 }
+
 .#{$block-class} .#{$block-class}__link {
   display: block;
 }


### PR DESCRIPTION
Contributes to #2963 

adds an `illustrationPosition` option to empty state. on a separate note, there's a lot of redundancy in the empty state components. this should be looked at to reduce some code bloat.
