### PR TITLE
fix(Datagrid): `shouldHideMenuItem` works with less than 3 row actions

### DIFF
--- a/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
+++ b/packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
@@ -44,7 +44,20 @@ const useActionsColumn = (hooks) => {
                       style={{ display: 'flex' }}
                     >
                       {rowActions.map((action, index) => {
-                        const { id, itemText, onClick, icon, ...rest } = action;
+                        const {
+                          id,
+                          itemText,
+                          onClick,
+                          icon,
+                          shouldHideMenuItem,
+                          ...rest
+                        } = action;
+                        const hidden =
+                          typeof shouldHideMenuItem === 'function' &&
+                          shouldHideMenuItem(row);
+                        if (hidden) {
+                          return null;
+                        }
                         const selectedRowId = selectedFlatRows?.filter((item) =>
                           item.id === row.id ? item.id : null
                         );


### PR DESCRIPTION
Contributes to #2966 

Add support for `shouldHideMenuItem` to row actions with less than three items.

#### What did you change?
```
packages/cloud-cognitive/src/components/Datagrid/useActionsColumn.js
```
#### How did you test and verify your work?
Storybook