### PR TITLE
fix: Carbon v11 about modal example

### DIFF
--- a/examples/carbon-for-ibm-products/AboutModal/src/Example/Example.jsx
+++ b/examples/carbon-for-ibm-products/AboutModal/src/Example/Example.jsx
@@ -44,17 +44,17 @@ export const Example = () => {
               <>
                 <img
                   alt="Grafana"
-                  className="c4p-about-modal__stories--tech-logo"
+                  className="about-modal__tech-logo"
                   src={grafanaLogo}
                 />
                 <img
                   alt="Ansible"
-                  className="c4p-about-modal__stories--tech-logo"
+                  className="about-modal__tech-logo"
                   src={ansibleLogo}
                 />
                 <img
                   alt="JavaScript"
-                  className="c4p-about-modal__stories--tech-logo"
+                  className="about-modal__tech-logo"
                   src={jsLogo}
                 />
               </>

--- a/examples/carbon-for-ibm-products/AboutModal/src/Example/_example.scss
+++ b/examples/carbon-for-ibm-products/AboutModal/src/Example/_example.scss
@@ -1,6 +1,6 @@
-@use '@carbon/react/scss/spacing' as *;
+@use "@carbon/react/scss/spacing" as *;
 
-.about-modal-stories--tech-logo {
+.about-modal__tech-logo {
   width: 2.25rem;
   height: 2.25rem;
   margin-right: $spacing-05;


### PR DESCRIPTION
Contributes to #2604 

#### What did you change?

Example styling seen here https://stackblitz.com/github/carbon-design-system/ibm-cloud-cognitive/tree/carbon-v11/examples/carbon-for-ibm-products/AboutModal?file=src%2FExample%2FExample.jsx

shows the SVG icons with no constraint on size. This fixes the size of the icons.

#### How did you test and verify your work?

Applied changes to stackblitz example and checked they worked.
