### PR TITLE
fix(build): use v2 ci check script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn
 
       - name: Continuous integration check (includes build)
-        run: yarn ci-check
+        run: yarn ci-check:v2
 
       # Dry run - `yarn lerna version --no-git-tag-version --no-push`
       - name: Publish

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ci-check:build": "run-s -s 'build:*' 'run-all --no-sort --ignore @carbon/ibm-cloud-cognitive-cdai --ignore @carbon/ibm-security ci-check'",
     "ci-check:lint": "run-p -s audit lint",
     "ci-check:tests": "run-p -s 'ci-check:test:*'",
+    "ci-check:v2": "run-s -s ci-check:build ci-check:lint ci-check:test:c4p storybook:build",
     "ci-check:test:cdai": "yarn test:cdai --ci",
     "ci-check:test:c4p": "yarn test:c4p --ci",
     "ci-check:test:security": "yarn test:security --ci",


### PR DESCRIPTION
This should fix the ci-check on the new main branch, ie will skip over cdai/security tests/build
